### PR TITLE
feat(#1): add NI windows container compare wiring

### DIFF
--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -70,6 +70,21 @@ Notes:
 - Dedicated shim entry points follow the versioned pattern documented in
   [`docs/LabVIEWCliShimPattern.md`](./LabVIEWCliShimPattern.md) (current version: 1.0).
 
+## NI Windows container helper
+
+`tools/Run-NIWindowsContainerCompare.ps1` supports local Docker Desktop compare runs against NI's Windows image.
+
+| Variable | Purpose |
+| -------- | ------- |
+| `LV_BASE_VI`, `LV_HEAD_VI` | Base/head VI paths used by `compare:docker:ni:windows` npm helper |
+
+Notes:
+
+- Default image: `nationalinstruments/labview:2026q1-windows`.
+- Override image explicitly with `tools/Run-NIWindowsContainerCompare.ps1 -Image <tag>`.
+- Docker daemon must run in `windows` mode; `compare:docker:ni:windows:probe` fails fast when mode/image checks fail.
+- Output defaults to `tests/results/ni-windows-container/compare-report.html` with deterministic capture logs.
+
 ## Tooling helpers
 
 | Variable | Purpose |

--- a/docs/USAGE_GUIDE.md
+++ b/docs/USAGE_GUIDE.md
@@ -79,6 +79,54 @@ pwsh -File scripts/Render-CompareReport.ps1 `
   -OutputPath compare-report.html
 ```
 
+## NI Windows container compare (local)
+
+Use the local helper when you want deterministic compare execution against NI's Windows image without changing the
+composite action default path.
+
+Preflight Docker mode/image:
+
+```powershell
+node tools/npm/run-script.mjs compare:docker:ni:windows:probe
+```
+
+Expected probe prerequisites:
+
+- Docker Desktop daemon mode is `windows`.
+- Image is present locally (default: `nationalinstruments/labview:2026q1-windows`).
+
+Run compare (base/head provided by environment):
+
+```powershell
+$env:LV_BASE_VI = (Resolve-Path .\VI1.vi).Path
+$env:LV_HEAD_VI = (Resolve-Path .\VI2.vi).Path
+node tools/npm/run-script.mjs compare:docker:ni:windows
+```
+
+Direct invocation with optional overrides:
+
+```powershell
+pwsh -File tools/Run-NIWindowsContainerCompare.ps1 `
+  -BaseVi .\VI1.vi `
+  -HeadVi .\VI2.vi `
+  -Image nationalinstruments/labview:2026q1-windows `
+  -ReportType html `
+  -TimeoutSeconds 600
+```
+
+The helper writes deterministic artifacts beside the report:
+
+- `ni-windows-container-capture.json`
+- `ni-windows-container-stdout.txt`
+- `ni-windows-container-stderr.txt`
+
+Exit semantics:
+
+- `0`: no differences (or probe success).
+- `1`: differences detected (or CLI-level compare error; inspect capture `status/message`).
+- `2`: preflight/configuration error (mode/image/path).
+- `124`: timeout.
+
 ## Workflow branching
 
 Basic success/failure handling:

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "ci:watch": "pwsh -NoLogo -NoProfile -File tools/Follow-OrchestratedRun.ps1 -Watch",
     "ci:watch:rest": "tsc -p tsconfig.cli.json && node dist/tools/watchers/orchestrated-watch.js",
     "cli:validate": "tsc -p tsconfig.cli.json && node dist/tools/cli/validate-cli.js",
+    "compare:docker:ni:windows": "pwsh -NoLogo -NoProfile -File tools/Run-NIWindowsContainerCompare.ps1 -BaseVi $env:LV_BASE_VI -HeadVi $env:LV_HEAD_VI",
+    "compare:docker:ni:windows:probe": "pwsh -NoLogo -NoProfile -File tools/Run-NIWindowsContainerCompare.ps1 -Probe",
     "derive:env": "node dist/src/env/derive-env.js --json",
     "dev:watcher:autotrim": "pwsh -NoLogo -NoProfile -File tools/Dev-WatcherManager.ps1 -AutoTrim",
     "dev:watcher:ensure": "pwsh -NoLogo -NoProfile -File tools/Dev-WatcherManager.ps1 -Ensure",

--- a/tests/LabVIEWCli.Provider.Tests.ps1
+++ b/tests/LabVIEWCli.Provider.Tests.ps1
@@ -56,4 +56,51 @@ Describe 'LabVIEW CLI provider' -Tag 'Unit' {
     $index = [Array]::IndexOf($args, '-LabVIEWPath')
     $args[$index + 1] | Should -Be (Resolve-Path -LiteralPath $labviewPath).Path
   }
+
+  It 'maps headless and logToConsole booleans for CreateComparisonReport' {
+    $args = InModuleScope $script:providerModule.Name {
+      Get-LabVIEWCliArgs -Operation 'CreateComparisonReport' -Params @{
+        vi1 = 'C:\repo\Base.vi'
+        vi2 = 'C:\repo\Head.vi'
+        headless = $true
+        logToConsole = $false
+      }
+    }
+
+    $args | Should -Contain '-Headless'
+    $headlessIndex = [Array]::IndexOf($args, '-Headless')
+    $args[$headlessIndex + 1] | Should -Be 'true'
+
+    $args | Should -Contain '-LogToConsole'
+    $logIndex = [Array]::IndexOf($args, '-LogToConsole')
+    $args[$logIndex + 1] | Should -Be 'false'
+  }
+
+  It 'normalizes string boolean tokens for CreateComparisonReport' {
+    $args = InModuleScope $script:providerModule.Name {
+      Get-LabVIEWCliArgs -Operation 'CreateComparisonReport' -Params @{
+        vi1 = 'C:\repo\Base.vi'
+        vi2 = 'C:\repo\Head.vi'
+        headless = '1'
+        logToConsole = 'false'
+      }
+    }
+
+    $headlessIndex = [Array]::IndexOf($args, '-Headless')
+    $args[$headlessIndex + 1] | Should -Be 'true'
+    $logIndex = [Array]::IndexOf($args, '-LogToConsole')
+    $args[$logIndex + 1] | Should -Be 'false'
+  }
+
+  It 'fails on unsupported boolean tokens for CreateComparisonReport' {
+    {
+      InModuleScope $script:providerModule.Name {
+        Get-LabVIEWCliArgs -Operation 'CreateComparisonReport' -Params @{
+          vi1 = 'C:\repo\Base.vi'
+          vi2 = 'C:\repo\Head.vi'
+          headless = 'maybe'
+        }
+      }
+    } | Should -Throw "*headless*"
+  }
 }

--- a/tools/providers/labviewcli/Provider.psm1
+++ b/tools/providers/labviewcli/Provider.psm1
@@ -13,6 +13,36 @@ function Convert-ToBoolString {
   return $script:boolFalse
 }
 
+function Convert-ToCliBoolString {
+  param(
+    [Parameter(Mandatory)][object]$Value,
+    [Parameter(Mandatory)][string]$ParameterName
+  )
+
+  if ($Value -is [bool]) {
+    return (Convert-ToBoolString -Value $Value)
+  }
+  if ($Value -is [byte] -or $Value -is [int16] -or $Value -is [int] -or $Value -is [int64]) {
+    switch ([int64]$Value) {
+      0 { return $script:boolFalse }
+      1 { return $script:boolTrue }
+      default { throw ("Parameter '{0}' only accepts boolean, 0, or 1 values." -f $ParameterName) }
+    }
+  }
+  if ($Value -is [string]) {
+    $normalized = $Value.Trim().ToLowerInvariant()
+    switch ($normalized) {
+      'true' { return $script:boolTrue }
+      'false' { return $script:boolFalse }
+      '1' { return $script:boolTrue }
+      '0' { return $script:boolFalse }
+      default { throw ("Parameter '{0}' string value '{1}' is not a supported boolean token." -f $ParameterName, $Value) }
+    }
+  }
+
+  throw ("Parameter '{0}' value type '{1}' is not supported for boolean conversion." -f $ParameterName, $Value.GetType().FullName)
+}
+
 function Resolve-LabVIEWCliBinaryPath {
   return Resolve-LabVIEWCliPath
 }
@@ -130,6 +160,12 @@ function Get-LabVIEWCliArgs {
       $resolvedLvPath = Resolve-LabVIEWPathFromParams -Params $Params
       if ($resolvedLvPath) {
         $args += @('-LabVIEWPath', $resolvedLvPath)
+      }
+      if ($Params.ContainsKey('headless')) {
+        $args += @('-Headless', (Convert-ToCliBoolString -Value $Params.headless -ParameterName 'headless'))
+      }
+      if ($Params.ContainsKey('logToConsole')) {
+        $args += @('-LogToConsole', (Convert-ToCliBoolString -Value $Params.logToConsole -ParameterName 'logToConsole'))
       }
       return $args
     }

--- a/tools/providers/spec/operations.json
+++ b/tools/providers/spec/operations.json
@@ -87,6 +87,24 @@
           "description": "Destination path for the comparison report."
         },
         {
+          "id": "labviewPath",
+          "type": "path",
+          "required": false,
+          "description": "Optional LabVIEW.exe path supplied to LabVIEW CLI."
+        },
+        {
+          "id": "headless",
+          "type": "bool",
+          "required": false,
+          "description": "When true, requests headless execution for compatible CLI versions."
+        },
+        {
+          "id": "logToConsole",
+          "type": "bool",
+          "required": false,
+          "description": "When true, enables LabVIEW CLI console logging."
+        },
+        {
           "id": "flags",
           "type": "array",
           "required": false,


### PR DESCRIPTION
## Summary
- add npm entrypoints for NI Windows container compare + probe
- extend `CreateComparisonReport` operation schema with `labviewPath`, `headless`, and `logToConsole`
- map new compare parameters in the LabVIEW CLI provider with strict boolean normalization
- expand provider unit tests for new argument mapping/validation
- document local NI Windows container usage and environment expectations

## Validation
- `pwsh -NoLogo -NoProfile -File Invoke-PesterTests.ps1 -TestsPath tests/LabVIEWCli.Provider.Tests.ps1`
- `node tools/npm/run-script.mjs hooks:pre-commit`
- `node tools/npm/run-script.mjs hooks:multi`
- `node tools/npm/run-script.mjs hooks:schema`
- `node tools/npm/run-script.mjs compare:docker:ni:windows:probe`
- `node tools/npm/run-script.mjs compare:docker:ni:windows` (deterministic non-zero with capture diagnostics on this host)

Refs #1