### PR TITLE
fix(#1): default NI container compare to headless and harden reruns

### DIFF
--- a/docs/USAGE_GUIDE.md
+++ b/docs/USAGE_GUIDE.md
@@ -114,6 +114,9 @@ pwsh -File tools/Run-NIWindowsContainerCompare.ps1 `
   -TimeoutSeconds 600
 ```
 
+The helper injects `-Headless` automatically for container runs unless you
+already provide it in `-Flags`.
+
 The helper writes deterministic artifacts beside the report:
 
 - `ni-windows-container-capture.json`

--- a/tests/Run-NIWindowsContainerCompare.Tests.ps1
+++ b/tests/Run-NIWindowsContainerCompare.Tests.ps1
@@ -96,6 +96,36 @@ exit 0
       if ($lines.Count -eq 0) { return @() }
       return @($lines | ForEach-Object { $_ | ConvertFrom-Json })
     }
+
+    $script:GetFlagsFromDockerRunRecord = {
+      param([Parameter(Mandatory)]$Record)
+      $args = @($Record.args)
+      $b64Value = $null
+      for ($i = 0; $i -lt $args.Count; $i++) {
+        if ($args[$i] -eq '--env' -and ($i + 1) -lt $args.Count) {
+          $next = [string]$args[$i + 1]
+          if ($next.StartsWith('COMPARE_FLAGS_B64=')) {
+            $b64Value = $next.Substring('COMPARE_FLAGS_B64='.Length)
+            break
+          }
+        }
+      }
+      if ([string]::IsNullOrWhiteSpace($b64Value)) {
+        return @()
+      }
+      $json = [System.Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($b64Value))
+      if ([string]::IsNullOrWhiteSpace($json)) {
+        return @()
+      }
+      $parsed = $json | ConvertFrom-Json
+      if ($parsed -is [System.Collections.IEnumerable] -and -not ($parsed -is [string])) {
+        return @($parsed | ForEach-Object { [string]$_ })
+      }
+      if ([string]::IsNullOrWhiteSpace([string]$parsed)) {
+        return @()
+      }
+      return @([string]$parsed)
+    }
   }
 
   BeforeEach {
@@ -198,6 +228,75 @@ exit 0
 
     $records = & $script:ReadDockerStubLog -Path $logPath
     (@($records | Where-Object { $_.args[0] -eq 'run' })).Count | Should -Be 1
+  }
+
+  It 'injects -Headless into container compare flags by default' {
+    $work = Join-Path $TestDrive 'compare-headless-default'
+    New-Item -ItemType Directory -Path $work | Out-Null
+    & $script:NewDockerStub -WorkRoot $work | Out-Null
+
+    $logPath = Join-Path $work 'docker-log.ndjson'
+    Set-Item Env:DOCKER_STUB_LOG $logPath
+    Set-Item Env:DOCKER_STUB_OSTYPE 'windows'
+    Set-Item Env:DOCKER_STUB_IMAGE_EXISTS '1'
+    Set-Item Env:DOCKER_STUB_RUN_EXIT_CODE '0'
+
+    $baseVi = Join-Path $work 'Base.vi'
+    $headVi = Join-Path $work 'Head.vi'
+    Set-Content -LiteralPath $baseVi -Value 'base' -Encoding utf8
+    Set-Content -LiteralPath $headVi -Value 'head' -Encoding utf8
+    $reportPath = Join-Path $work 'out\compare-report.html'
+
+    & pwsh -NoLogo -NoProfile -File $script:RunnerScript `
+      -BaseVi $baseVi `
+      -HeadVi $headVi `
+      -ReportPath $reportPath `
+      -Flags @('-noattr') 2>&1 | Out-Null
+    $LASTEXITCODE | Should -Be 0
+
+    $records = & $script:ReadDockerStubLog -Path $logPath
+    $runRecord = @($records | Where-Object { $_.args[0] -eq 'run' } | Select-Object -First 1)
+    $runRecord.Count | Should -Be 1
+    $flags = & $script:GetFlagsFromDockerRunRecord -Record $runRecord[0]
+    $flags | Should -Contain '-noattr'
+    $flags | Should -Contain '-Headless'
+    (@($flags | Where-Object { $_ -eq '-Headless' })).Count | Should -Be 1
+  }
+
+  It 'classifies report overwrite failures as error (not diff)' {
+    $work = Join-Path $TestDrive 'compare-report-overwrite'
+    New-Item -ItemType Directory -Path $work | Out-Null
+    & $script:NewDockerStub -WorkRoot $work | Out-Null
+
+    Set-Item Env:DOCKER_STUB_LOG (Join-Path $work 'docker-log.ndjson')
+    Set-Item Env:DOCKER_STUB_OSTYPE 'windows'
+    Set-Item Env:DOCKER_STUB_IMAGE_EXISTS '1'
+    Set-Item Env:DOCKER_STUB_RUN_EXIT_CODE '1'
+    Set-Item Env:DOCKER_STUB_RUN_STDERR @'
+Operation output:
+Report path already exists: C:\compare\m1\compare-report.html
+
+Use -o to overwrite existing report.
+CreateComparisonReport operation failed.
+'@
+
+    $baseVi = Join-Path $work 'Base.vi'
+    $headVi = Join-Path $work 'Head.vi'
+    Set-Content -LiteralPath $baseVi -Value 'base' -Encoding utf8
+    Set-Content -LiteralPath $headVi -Value 'head' -Encoding utf8
+    $reportPath = Join-Path $work 'out\compare-report.html'
+
+    $output = & pwsh -NoLogo -NoProfile -File $script:RunnerScript `
+      -BaseVi $baseVi `
+      -HeadVi $headVi `
+      -ReportPath $reportPath 2>&1
+    $LASTEXITCODE | Should -Be 1 -Because ($output -join "`n")
+
+    $capturePath = Join-Path (Split-Path -Parent $reportPath) 'ni-windows-container-capture.json'
+    $capture = Get-Content -LiteralPath $capturePath -Raw | ConvertFrom-Json
+    $capture.status | Should -Be 'error'
+    $capture.classification | Should -Be 'run-error'
+    $capture.message | Should -Match 'Report path already exists|overwrite existing report|operation failed'
   }
 
   It 'returns timeout classification with deterministic timeout exit code' {

--- a/tools/Run-NIWindowsContainerCompare.ps1
+++ b/tools/Run-NIWindowsContainerCompare.ps1
@@ -255,6 +255,35 @@ exit $LASTEXITCODE
 '@
 }
 
+function Get-EffectiveCompareFlags {
+  param(
+    [AllowNull()][string[]]$InputFlags
+  )
+
+  $flags = @()
+  if ($InputFlags) {
+    foreach ($flag in $InputFlags) {
+      if (-not [string]::IsNullOrWhiteSpace([string]$flag)) {
+        $flags += [string]$flag
+      }
+    }
+  }
+
+  $hasHeadless = $false
+  foreach ($flag in $flags) {
+    if ($flag.Trim().ToLowerInvariant() -eq '-headless') {
+      $hasHeadless = $true
+      break
+    }
+  }
+  if (-not $hasHeadless) {
+    # Container execution is non-interactive; force headless CLI mode by default.
+    $flags += '-Headless'
+  }
+
+  return @($flags)
+}
+
 function Convert-ToEncodedCommand {
   param(
     [Parameter(Mandatory)][string]$CommandText
@@ -364,6 +393,22 @@ function Test-LabVIEWCliFailure {
   return (
     $combined -match 'Error code\s*:' -or
     $combined -match 'An error occurred while running the LabVIEW CLI'
+  )
+}
+
+function Test-ReportOverwriteFailure {
+  param(
+    [AllowNull()][string]$StdErr,
+    [AllowNull()][string]$StdOut
+  )
+
+  $combined = @($StdErr, $StdOut) -join "`n"
+  if ([string]::IsNullOrWhiteSpace($combined)) {
+    return $false
+  }
+  return (
+    $combined -match 'Report path already exists' -or
+    $combined -match 'Use\s+-o\s+to overwrite existing report'
   )
 }
 
@@ -500,6 +545,9 @@ try {
     if (-not (Test-Path -LiteralPath $reportDirectory -PathType Container)) {
       New-Item -ItemType Directory -Path $reportDirectory -Force | Out-Null
     }
+    if (Test-Path -LiteralPath $resolvedReportPath -PathType Leaf) {
+      Remove-Item -LiteralPath $resolvedReportPath -Force -ErrorAction Stop
+    }
 
     $capturePath = Join-Path $reportDirectory 'ni-windows-container-capture.json'
     $stdoutPath = Join-Path $reportDirectory 'ni-windows-container-stdout.txt'
@@ -511,7 +559,7 @@ try {
     $capture.stdoutPath = $stdoutPath
     $capture.stderrPath = $stderrPath
 
-    $flagsPayload = if ($Flags) { @($Flags) } else { @() }
+    $flagsPayload = Get-EffectiveCompareFlags -InputFlags $Flags
     $flagsJson = $flagsPayload | ConvertTo-Json -Compress
     if ([string]::IsNullOrWhiteSpace($flagsJson)) {
       $flagsJson = '[]'
@@ -586,6 +634,10 @@ try {
             $capture.message = $failure.message
             $capture.labviewCliErrorCode = $failure.labviewCliErrorCode
             $capture.recommendation = $failure.recommendation
+          } elseif (Test-ReportOverwriteFailure -StdErr $stderrContent -StdOut $stdoutContent) {
+            $capture.status = 'error'
+            $capture.classification = 'run-error'
+            $capture.message = Resolve-RunFailureMessage -StdErr $stderrContent -StdOut $stdoutContent -ExitCode $exitCode
           } else {
             $capture.status = 'diff'
             $capture.classification = 'diff'


### PR DESCRIPTION
## Summary\n- default 	ools/Run-NIWindowsContainerCompare.ps1 to include -Headless for NI Windows container runs unless already provided\n- remove stale report output before each run to avoid false diff classification on reruns\n- classify known report-overwrite failures as un-error instead of diff\n- document default headless behavior in container usage docs\n\n## Why\nIssue #1 currently reports deterministic -350000 connection failures in default helper usage. Local Docker validation on this host showed that adding -Headless clears the connection failure and allows CreateComparisonReport to execute.\n\n## Validation\n- Invoke-Pester -Path tests/Run-NIWindowsContainerCompare.Tests.ps1 -CI (6 passed)\n- 
ode tools/npm/run-script.mjs hooks:multi (pass)\n- real local run: pwsh -File tools/Run-NIWindowsContainerCompare.ps1 -BaseVi .\\VI1.vi -HeadVi .\\VI2.vi -Image nationalinstruments/labview:2026q1-windows -ReportType html\n  - capture now reports status=ok|diff with eportExists=true instead of labview-cli-connection/-350000\n- npm entrypoint run: compare:docker:ni:windows with LV_BASE_VI/LV_HEAD_VI set (pass)\n\nCloses #1