### PR TITLE
fix(#7): prevent stale standing-priority cache resurrection

### DIFF
--- a/tools/priority/__tests__/standing-priority-resolution.test.mjs
+++ b/tools/priority/__tests__/standing-priority-resolution.test.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  isStandingPriorityCacheCandidate,
+  resolveStandingPriorityFromSources
+} from '../sync-standing-priority.mjs';
+
+test('isStandingPriorityCacheCandidate requires OPEN state and standing-priority label', () => {
+  assert.equal(
+    isStandingPriorityCacheCandidate({
+      number: 42,
+      state: 'OPEN',
+      labels: ['bug', 'standing-priority']
+    }),
+    true
+  );
+
+  assert.equal(
+    isStandingPriorityCacheCandidate({
+      number: 42,
+      state: 'CLOSED',
+      labels: ['standing-priority']
+    }),
+    false
+  );
+
+  assert.equal(
+    isStandingPriorityCacheCandidate({
+      number: 42,
+      state: 'OPEN',
+      labels: ['bug']
+    }),
+    false
+  );
+});
+
+test('resolveStandingPriorityFromSources uses cache only when lookups are unavailable and cache is valid', () => {
+  const number = resolveStandingPriorityFromSources({
+    ghOutcome: { status: 'unavailable', error: 'gh missing' },
+    restOutcome: { status: 'error', error: 'network timeout' },
+    cache: {
+      number: 99,
+      state: 'OPEN',
+      labels: ['standing-priority']
+    }
+  });
+  assert.equal(number, 99);
+});
+
+test('resolveStandingPriorityFromSources rejects stale cache when gh reports empty standing set', () => {
+  assert.throws(
+    () =>
+      resolveStandingPriorityFromSources({
+        ghOutcome: { status: 'empty' },
+        restOutcome: { status: 'error', error: 'network timeout' },
+        cache: {
+          number: 1,
+          state: 'OPEN',
+          labels: ['standing-priority']
+        }
+      }),
+    (err) => err?.code === 'NO_STANDING_PRIORITY'
+  );
+});
+
+test('resolveStandingPriorityFromSources rejects stale cache when rest reports empty standing set', () => {
+  assert.throws(
+    () =>
+      resolveStandingPriorityFromSources({
+        ghOutcome: { status: 'error', error: 'gh unavailable' },
+        restOutcome: { status: 'empty' },
+        cache: {
+          number: 1,
+          state: 'OPEN',
+          labels: ['standing-priority']
+        }
+      }),
+    (err) => err?.code === 'NO_STANDING_PRIORITY'
+  );
+});
+
+test('resolveStandingPriorityFromSources fails when only invalid cache remains', () => {
+  assert.throws(
+    () =>
+      resolveStandingPriorityFromSources({
+        ghOutcome: { status: 'unavailable', error: 'gh missing' },
+        restOutcome: { status: 'error', error: 'network timeout' },
+        cache: {
+          number: 1,
+          state: 'CLOSED',
+          labels: ['standing-priority']
+        }
+      }),
+    /Unable to resolve standing-priority issue number/
+  );
+});
+

--- a/tools/priority/sync-standing-priority.mjs
+++ b/tools/priority/sync-standing-priority.mjs
@@ -494,7 +494,7 @@ async function fetchStandingPriorityNumberViaRest(repoRoot, slug) {
   const resolvedSlug = slug ?? resolveRepositorySlug(repoRoot);
   if (!resolvedSlug) {
     console.warn('[priority] Unable to resolve repository slug for REST fallback');
-    return null;
+    return { status: 'error', error: 'repository slug unavailable' };
   }
 
   const token = resolveGitHubToken();
@@ -511,21 +511,77 @@ async function fetchStandingPriorityNumberViaRest(repoRoot, slug) {
 
   try {
     const data = await requestGitHubJson(url.toString(), token);
-      if (Array.isArray(data)) {
-        if (data.length > 1) {
-          const ids = data.map((item) => item?.number).filter(Boolean);
-          console.warn(`[priority] Multiple open items carry the standing-priority label (candidates: ${ids.join(', ')}) – selecting the most recently updated entry.`);
-        }
-        const first = data.find((item) => item?.number != null);
-        if (first) return Number(first.number);
-      } else if (data?.number != null) {
-        return Number(data.number);
+    if (Array.isArray(data)) {
+      if (data.length > 1) {
+        const ids = data.map((item) => item?.number).filter(Boolean);
+        console.warn(
+          `[priority] Multiple open items carry the standing-priority label (candidates: ${ids.join(', ')}) – selecting the most recently updated entry.`
+        );
       }
+      const first = data.find((item) => item?.number != null);
+      if (first) return { status: 'found', number: Number(first.number) };
+      return { status: 'empty' };
+    }
+    if (data?.number != null) {
+      return { status: 'found', number: Number(data.number) };
+    }
+    return { status: 'empty' };
   } catch (err) {
     console.warn(`[priority] REST fallback failed: ${err.message}`);
+    return { status: 'error', error: err.message };
+  }
+}
+
+function createNoStandingPriorityError(message) {
+  const err = new Error(message || "No open issue with label 'standing-priority' found.");
+  err.code = 'NO_STANDING_PRIORITY';
+  return err;
+}
+
+function isNoStandingOutcome(outcome) {
+  return outcome?.status === 'empty';
+}
+
+function isUnavailableOutcome(outcome) {
+  return !outcome || outcome.status === 'error' || outcome.status === 'unavailable';
+}
+
+export function isStandingPriorityCacheCandidate(cache) {
+  if (!cache || cache.number == null) return false;
+  const labels = normalizeList(cache.labels || []);
+  const state = String(cache.state || '').trim().toUpperCase();
+  return state === 'OPEN' && labels.includes('standing-priority');
+}
+
+export function resolveStandingPriorityFromSources({ ghOutcome, restOutcome, cache }) {
+  if (isNoStandingOutcome(ghOutcome) || isNoStandingOutcome(restOutcome)) {
+    throw createNoStandingPriorityError();
   }
 
-  return null;
+  if (isStandingPriorityCacheCandidate(cache)) {
+    return Number(cache.number);
+  }
+
+  const reasons = [];
+  if (!isUnavailableOutcome(ghOutcome)) {
+    reasons.push(`gh status=${ghOutcome.status}`);
+  } else if (ghOutcome?.error) {
+    reasons.push(`gh: ${ghOutcome.error}`);
+  }
+  if (!isUnavailableOutcome(restOutcome)) {
+    reasons.push(`rest status=${restOutcome.status}`);
+  } else if (restOutcome?.error) {
+    reasons.push(`rest: ${restOutcome.error}`);
+  }
+  if (cache?.number != null) {
+    reasons.push('cache invalid (must be OPEN and include standing-priority label)');
+  }
+
+  throw new Error(
+    `Unable to resolve standing-priority issue number${
+      reasons.length > 0 ? ` (${reasons.join('; ')})` : ''
+    }`
+  );
 }
 
 async function fetchIssueViaRest(repoRoot, number, slug) {
@@ -563,36 +619,37 @@ async function resolveStandingPriorityNumber(repoRoot, slug) {
     } catch {}
   }
 
-  let ghMissing = false;
-  let ghErrorMessage = null;
+  let ghOutcome = { status: 'error', error: 'unknown' };
   try {
     const query = ensureCommand(
       sh('gh', ['issue', 'list', '--label', 'standing-priority', '--state', 'open', '--limit', '1', '--json', 'number']),
       'gh'
     );
-    if (query.status === 0 && query.stdout.trim()) {
-      const parsed = JSON.parse(query.stdout);
+    if (query.status === 0) {
+      const parsed = query.stdout.trim() ? JSON.parse(query.stdout) : [];
       const first = Array.isArray(parsed) ? parsed[0] : parsed;
       if (first?.number) return Number(first.number);
-    }
-    if (query.status !== 0) {
-      ghErrorMessage = query.stderr?.trim() || `gh exited with status ${query.status}`;
+      ghOutcome = { status: 'empty' };
+    } else {
+      ghOutcome = {
+        status: 'error',
+        error: query.stderr?.trim() || `gh exited with status ${query.status}`
+      };
     }
   } catch (err) {
     if (err?.code === 'ENOENT') {
       console.warn('[priority] gh CLI not found; falling back to cached standing-priority issue number');
-      ghMissing = true;
+      ghOutcome = { status: 'unavailable', error: err.message || 'gh CLI unavailable' };
+    } else {
+      ghOutcome = { status: 'error', error: err?.message || 'gh issue list failed' };
     }
-    ghErrorMessage = err?.message || ghErrorMessage;
   }
 
-  const restNumber = await fetchStandingPriorityNumberViaRest(repoRoot, slug);
-  if (restNumber != null) return restNumber;
+  const restOutcome = await fetchStandingPriorityNumberViaRest(repoRoot, slug);
+  if (restOutcome?.status === 'found') return restOutcome.number;
 
   const cache = readJson(path.join(repoRoot, '.agent_priority_cache.json'));
-  if (cache?.number != null) return Number(cache.number);
-  const reason = ghMissing ? 'gh CLI unavailable' : ghErrorMessage;
-  throw new Error(`Unable to resolve standing-priority issue number${reason ? ` (${reason})` : ''}`);
+  return resolveStandingPriorityFromSources({ ghOutcome, restOutcome, cache });
 }
 
 function normalizeIssueResult(result) {
@@ -695,7 +752,50 @@ export async function main() {
   const resultsDir = path.join(repoRoot, 'tests', 'results', '_agent', 'issue');
   fs.mkdirSync(resultsDir, { recursive: true });
 
-  const number = await resolveStandingPriorityNumber(repoRoot, slug);
+  let number;
+  try {
+    number = await resolveStandingPriorityNumber(repoRoot, slug);
+  } catch (err) {
+    if (err?.code === 'NO_STANDING_PRIORITY') {
+      const clearedAt = new Date().toISOString();
+      const clearedRouter = {
+        schema: 'agent/priority-router@v1',
+        issue: null,
+        updatedAt: clearedAt,
+        actions: []
+      };
+      writeJson(path.join(resultsDir, 'router.json'), clearedRouter);
+
+      const clearedCache = {
+        ...cache,
+        number: null,
+        title: null,
+        url: null,
+        state: 'NONE',
+        labels: [],
+        assignees: [],
+        milestone: null,
+        commentCount: null,
+        lastSeenUpdatedAt: null,
+        issueDigest: null,
+        bodyDigest: null,
+        cachedAtUtc: clearedAt,
+        lastFetchSource: 'none',
+        lastFetchError: err.message
+      };
+      if (shouldWriteCache(cache, clearedCache)) {
+        writeJson(cachePath, clearedCache);
+      }
+
+      stepSummaryAppend([
+        '### Standing Priority Snapshot',
+        "- Issue: none found (`standing-priority` label on open issues)",
+        `- Status: ${err.message}`,
+        '- Top actions: n/a'
+      ]);
+    }
+    throw err;
+  }
   console.log(`[priority] Standing issue: #${number}`);
 
   let issue;


### PR DESCRIPTION
## Summary\n- make standing-priority resolution treat an explicit empty live result (gh/REST) as authoritative\n- stop falling back to stale cache when no open standing-priority issue exists\n- allow cache fallback only when cache itself is still valid (state=OPEN and includes standing-priority)\n- on no-standing-priority condition, clear router/cache pointers and emit explicit summary context\n- add regression tests for stale-cache and empty-live-result paths\n\n## Why\nIssue #7 tracks a stale-resolution bug where priority:sync could keep selecting a closed/unlabeled issue via cache fallback.\n\n## Validation\n- 
ode --test tools/priority/__tests__/standing-priority-resolution.test.mjs tools/priority/__tests__/sync-standing-priority.test.mjs tools/priority/__tests__/cache-update.test.mjs (11/11 pass)\n- 
ode tools/npm/run-script.mjs priority:sync still resolves active standing issue #7 on this repo\n\n## Notes\n- Running full priority:test still includes an unrelated pre-existing token-dependent failure in check-policy-apply when local token env is missing in that test path.