### PR TITLE
feat(#9): harden PR VI history comment payload limits

### DIFF
--- a/.github/workflows/pr-vi-history.yml
+++ b/.github/workflows/pr-vi-history.yml
@@ -213,7 +213,9 @@ jobs:
           pwsh -NoLogo -NoProfile -File (Join-Path $env:GITHUB_WORKSPACE 'tools' 'Summarize-PRVIHistory.ps1') `
             -SummaryPath $summaryPath `
             -MarkdownPath $markdownPath `
-            -OutputJsonPath $expandedPath
+            -OutputJsonPath $expandedPath `
+            -MaxPreviewImages 6 `
+            -MaxMarkdownLength 55000
 
           "markdown_path=$markdownPath" | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append
 
@@ -255,6 +257,12 @@ jobs:
           $markdown = $null
           if ($env:MARKDOWN_ENCODED) {
             $markdown = ($env:MARKDOWN_ENCODED -replace '%0A', "`n")
+            $maxCommentMarkdownLength = 58000
+            if ($markdown.Length -gt $maxCommentMarkdownLength) {
+              $truncationNote = "`n`n> NOTE - Comment body truncated for GitHub size safety."
+              $safeLength = [Math]::Max(0, $maxCommentMarkdownLength - $truncationNote.Length)
+              $markdown = $markdown.Substring(0, $safeLength).TrimEnd() + $truncationNote
+            }
           }
 
           if ($pairCount -le 0) {

--- a/tests/Summarize-PRVIHistory.Tests.ps1
+++ b/tests/Summarize-PRVIHistory.Tests.ps1
@@ -89,6 +89,7 @@ Describe 'Summarize-PRVIHistory.ps1' {
         $result.totals.diffs | Should -Be 2
         $result.totals.comparisons | Should -Be 4
         $result.totals.previewImages | Should -Be 1
+        $result.totals.markdownTruncated | Should -BeFalse
         $result.previews.Count | Should -Be 1
         $result.markdown | Should -Match 'fixtures/Example.vi'
         $result.markdown | Should -Match 'diff'
@@ -101,5 +102,90 @@ Describe 'Summarize-PRVIHistory.ps1' {
 
         $jsonEcho = Get-Content -LiteralPath $jsonOutPath -Raw -Encoding utf8 | ConvertFrom-Json -Depth 4
         $jsonEcho.markdown | Should -Be $result.markdown
+    }
+
+    It 'limits preview entries and truncates oversized markdown safely' {
+        $resultsRoot = Join-Path $TestDrive 'pr-history-limits'
+        $targetA = Join-Path $resultsRoot '01-A'
+        $targetB = Join-Path $resultsRoot '02-B'
+        New-Item -ItemType Directory -Path $targetA -Force | Out-Null
+        New-Item -ItemType Directory -Path $targetB -Force | Out-Null
+
+        $reportA = Join-Path $targetA 'history-report.html'
+        $reportB = Join-Path $targetB 'history-report.html'
+        Set-Content -LiteralPath $reportA -Value '<html></html>' -Encoding utf8
+        Set-Content -LiteralPath $reportB -Value '<html></html>' -Encoding utf8
+
+        $imageAPath = Join-Path $targetA 'previews/history-image-000.png'
+        $imageBPath = Join-Path $targetB 'previews/history-image-000.png'
+        New-Item -ItemType Directory -Path (Split-Path -Parent $imageAPath) -Force | Out-Null
+        New-Item -ItemType Directory -Path (Split-Path -Parent $imageBPath) -Force | Out-Null
+        [System.IO.File]::WriteAllBytes($imageAPath, @(0x01, 0x02))
+        [System.IO.File]::WriteAllBytes($imageBPath, @(0x03, 0x04))
+
+        $indexA = Join-Path $targetA 'vi-history-image-index.json'
+        $indexB = Join-Path $targetB 'vi-history-image-index.json'
+        [ordered]@{
+            schema = 'pr-vi-history-image-index@v1'
+            images = @(
+                [ordered]@{
+                    status   = 'saved'
+                    savedPath= $imageAPath
+                    alt      = 'A'
+                }
+            )
+        } | ConvertTo-Json -Depth 4 | Set-Content -LiteralPath $indexA -Encoding utf8
+        [ordered]@{
+            schema = 'pr-vi-history-image-index@v1'
+            images = @(
+                [ordered]@{
+                    status   = 'saved'
+                    savedPath= $imageBPath
+                    alt      = 'B'
+                }
+            )
+        } | ConvertTo-Json -Depth 4 | Set-Content -LiteralPath $indexB -Encoding utf8
+
+        $longMessage = ('x' * 1200)
+        $summaryPath = Join-Path $TestDrive 'pr-history-limits-summary.json'
+        $longRepoA = ('A' * 360) + '.vi'
+        $longRepoB = ('B' * 360) + '.vi'
+        [ordered]@{
+            schema = 'pr-vi-history-summary@v1'
+            resultsRoot = $resultsRoot
+            targets = @(
+                [ordered]@{
+                    repoPath = $longRepoA
+                    status = 'completed'
+                    changeTypes = @('modified')
+                    message = $longMessage
+                    stats = [ordered]@{ processed = 1; diffs = 1 }
+                    reportHtml = $reportA
+                    reportImages = [ordered]@{
+                        status = 'completed'
+                        indexPath = $indexA
+                    }
+                },
+                [ordered]@{
+                    repoPath = $longRepoB
+                    status = 'completed'
+                    changeTypes = @('modified')
+                    message = $longMessage
+                    stats = [ordered]@{ processed = 1; diffs = 1 }
+                    reportHtml = $reportB
+                    reportImages = [ordered]@{
+                        status = 'completed'
+                        indexPath = $indexB
+                    }
+                }
+            )
+        } | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $summaryPath -Encoding utf8
+
+        $result = & $scriptPath -SummaryPath $summaryPath -MaxPreviewImages 1 -MaxMarkdownLength 500
+        $result.previews.Count | Should -Be 1
+        $result.totals.previewImages | Should -Be 1
+        $result.totals.markdownTruncated | Should -BeTrue
+        $result.markdown.Length | Should -BeLessOrEqual 900
+        $result.markdown | Should -Match 'Summary truncated for comment size safety'
     }
 }

--- a/tools/Summarize-PRVIHistory.ps1
+++ b/tools/Summarize-PRVIHistory.ps1
@@ -26,7 +26,13 @@ param(
 
     [string]$MarkdownPath,
 
-    [string]$OutputJsonPath
+    [string]$OutputJsonPath,
+
+    [ValidateRange(0, 50)]
+    [int]$MaxPreviewImages = 6,
+
+    [ValidateRange(500, 65535)]
+    [int]$MaxMarkdownLength = 55000
 )
 
 Set-StrictMode -Version Latest
@@ -230,6 +236,9 @@ foreach ($target in $targets) {
 
 $markdown = $rows -join [Environment]::NewLine
 $previewEntries = Get-MobilePreviewEntries -Targets $targets -ResultsRoot $resultsRoot -MaxPerTarget 1
+if ($MaxPreviewImages -ge 0 -and $previewEntries.Count -gt $MaxPreviewImages) {
+    $previewEntries = @($previewEntries | Select-Object -First $MaxPreviewImages)
+}
 if ($previewEntries.Count -gt 0) {
     $previewLines = New-Object System.Collections.Generic.List[string]
     $previewLines.Add('') | Out-Null
@@ -241,6 +250,14 @@ if ($previewEntries.Count -gt 0) {
     $markdown = ($markdown, ($previewLines -join [Environment]::NewLine)) -join [Environment]::NewLine
 }
 
+$markdownTruncated = $false
+if ($MaxMarkdownLength -gt 0 -and $markdown.Length -gt $MaxMarkdownLength) {
+    $suffix = [Environment]::NewLine + [Environment]::NewLine + '> NOTE - Summary truncated for comment size safety.'
+    $safeLength = [Math]::Max(0, $MaxMarkdownLength - $suffix.Length)
+    $markdown = $markdown.Substring(0, $safeLength).TrimEnd() + $suffix
+    $markdownTruncated = $true
+}
+
 $result = [pscustomobject]@{
     totals = [pscustomobject]@{
         targets     = $targets.Count
@@ -248,6 +265,7 @@ $result = [pscustomobject]@{
         comparisons = $comparisonTotal
         diffs       = $diffTotal
         previewImages = $previewEntries.Count
+        markdownTruncated = $markdownTruncated
     }
     targets  = $targets
     previews = $previewEntries


### PR DESCRIPTION
## Summary\n- cap mobile preview entries emitted by Summarize-PRVIHistory.ps1\n- add markdown truncation safety in summarizer (MaxMarkdownLength) with explicit truncation flag\n- add workflow-level fallback truncation before posting PR comment\n- extend summary tests to cover preview cap + truncation behavior\n\n## Validation\n- Invoke-Pester -Path tests/Summarize-PRVIHistory.Tests.ps1,tests/Invoke-PRVIHistory.Tests.ps1,tests/Extract-VIHistoryReportImages.Tests.ps1 -Output Detailed\n\nRefs #9