### PR TITLE
docs(#9): add mobile preview contract docs + smoke assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,14 @@ the same summary table to a GitHub issue for stakeholders.
   runner (`self-hosted, Windows, X64`) so the same LVCompare install used in CI handles fork PRs.
 - Manual `/vi-stage` and `/vi-history` dispatches accept a `fetch_depth` input (default `20`) when you need to pull a
   deeper history for local tests.
+- `/vi-history` artifacts now include extracted preview assets under
+  `tests/results/pr-vi-history/<target>/previews/history-image-*` plus
+  `tests/results/pr-vi-history/<target>/vi-history-image-index.json`
+  (`schema: pr-vi-history-image-index@v1`) for deterministic image lookup.
+- The history summary/comment renderer adds a `### Mobile Preview` block that inlines a capped set of extracted images
+  so reviewers can scan cosmetic changes on mobile without downloading artifacts first.
+- Comment-size safety guards cap preview/image payload and apply markdown truncation when needed; the summarizer writes
+  this state to totals (`previewImages`, `markdownTruncated`) and emits an explicit truncation note in the PR comment.
 - To rehearse the fork flow locally, run `pwsh -File tools/Test-ForkSimulation.ps1` in three passes: `-DryRun` shows the
   steps, the default run opens a draft PR and validates the automatic compare job, and `-KeepBranch` preserves the
   scratch branch while the staging/history dispatches finish so you can inspect the artifacts.

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -143,6 +143,15 @@ Quick reference for building, testing, and releasing the LVCompare composite act
         `tools/Inspect-HistorySignalStats.ps1` wraps the helper + stub and prints the signal/noise counts directly.
       3. `tools/Summarize-PRVIHistory.ps1` renders the PR table with change types, comparison/diff counts, and
          relative report paths so reviewers can triage without downloading the artifact bundle.
+        The summary contract now includes additive image metadata for report rendering:
+        - target node `reportImages` (`enabled`, `indexPath`, `previewCount`, `previews[]`)
+        - totals `previewImages` and `markdownTruncated` in `pr-vi-history-summary@v1`
+        The same helper emits a `### Mobile Preview` section in the PR comment/summary markdown when previews are
+        available, and writes extracted files to `tests/results/pr-vi-history/<target>/previews/` with index contract
+        `pr-vi-history-image-index@v1`.
+        Extractor toggles:
+        - `PR_VI_HISTORY_EXTRACT_REPORT_IMAGES`
+        - `VI_HISTORY_EXTRACT_REPORT_IMAGES`
     - Override the history depth via the workflow_dispatch input `max_pairs` when you need a longer runway; otherwise
       accept the default for quick attribution. The workflow uploads the results directory as
       `pr-vi-history-<pr-number>.zip` for local inspection.

--- a/docs/knowledgebase/VICompare-Refs-Workflow.md
+++ b/docs/knowledgebase/VICompare-Refs-Workflow.md
@@ -103,6 +103,13 @@
   pwsh -File tools/Invoke-PRVIHistory.ps1 -ManifestPath vi-history-manifest.json -ResultsRoot tests/results/pr-vi-history
   pwsh -File tools/Summarize-PRVIHistory.ps1 -SummaryPath tests/results/pr-vi-history/vi-history-summary.json -MarkdownPath vi-history-summary.md
   ```
+  Mobile preview extraction writes additive artifacts per target:
+  - `tests/results/pr-vi-history/<target>/previews/history-image-*`
+  - `tests/results/pr-vi-history/<target>/vi-history-image-index.json`
+    (`schema: pr-vi-history-image-index@v1`)
+  The rendered summary/comment includes `### Mobile Preview` with inline `<img ...history-image-...>` tags, capped by
+  comment safety limits. Totals expose `previewImages` and `markdownTruncated`; per-target metadata surfaces under
+  `targets[].reportImages` in `pr-vi-history-summary@v1`.
   For a full end-to-end validation, run the smoke helper (`pwsh -File tools/Test-PRVIHistorySmoke.ps1` or `npm run smoke:vi-history`) to create a scratch PR, dispatch the workflow, and record the results under `tests/results/_agent/smoke/vi-history/`.
 
 ## Dispatch inputs (GitHub UI or `gh workflow run`)
@@ -194,6 +201,9 @@ gh workflow run vi-compare-refs.yml `
   rendering is skipped or fails, the Markdown path still points at the fallback report so consumers always have a
   summary to ingest. A compressed `category-counts-json` blob is also published so downstream automation can react to runs
   dominated by cosmetic noise without re-reading the manifests.
+- History summary JSON (`tests/results/pr-vi-history/vi-history-summary.json`) now adds `targets[].reportImages` and
+  totals `previewImages` / `markdownTruncated` so downstream checks can verify image extraction and comment-size
+  truncation deterministically.
 - Per-mode manifests live under `tests/results/ref-compare/history/<mode>/manifest.json`
   (`schema: vi-compare/history@v1`) and enumerate the commit pairs, summaries, and LVCompare outcomes.
 - Per-iteration summaries (`*-summary.json`) live beside the mode manifest

--- a/tools/Test-PRVIHistorySmoke.ps1
+++ b/tools/Test-PRVIHistorySmoke.ps1
@@ -467,6 +467,9 @@ $scratchContext = [ordered]@{
     Comparisons   = $null
     Diffs         = $null
     ArtifactValidated = $false
+    mobilePreviewValidated = $false
+    mobilePreviewImageCount = 0
+    mobilePreviewCommentFound = $false
 }
 
 $commitSummaries = @()
@@ -575,6 +578,10 @@ try {
     if (-not $historyComment) {
         throw 'Expected `/vi-history` comment not found on the draft PR.'
     }
+    $mobilePreviewHeaderMatch = [regex]::Match($historyComment, '(?im)^###\s+Mobile Preview\s*$')
+    $mobilePreviewImageMatches = [regex]::Matches($historyComment, '<img\s+[^>]*src=["''][^"''>]*history-image-[^"''>]*["''][^>]*>')
+    $scratchContext.mobilePreviewCommentFound = $mobilePreviewHeaderMatch.Success
+    $scratchContext.mobilePreviewImageCount = $mobilePreviewImageMatches.Count
 
     $rowPattern = '\|\s*<code>fixtures/vi-attr/Head\.vi</code>\s*\|\s*(?<change>[^|]+)\|\s*(?<comparisons>\d+)\s*\|\s*(?<diffs>\d+)\s*\|\s*(?<status>[^|]+)\|'
     $rowMatch = [regex]::Match($historyComment, $rowPattern)
@@ -600,6 +607,12 @@ try {
         }
         if ($statusValue -notlike '*diff*') {
             throw ("Expected status column to mark diff but saw '{0}'." -f $statusValue)
+        }
+        if (-not $mobilePreviewHeaderMatch.Success) {
+            throw 'Sequential history comment is missing the `### Mobile Preview` section.'
+        }
+        if ($mobilePreviewImageMatches.Count -lt 1) {
+            throw 'Sequential history comment did not include preview image tags (`history-image-*`).'
         }
 
         $artifactDir = Join-Path $summaryDir ("artifact-$timestamp")
@@ -628,6 +641,18 @@ try {
         if ($artifactDiffs -lt 1) {
             throw 'Summary JSON should report at least one diff for sequential history smoke.'
         }
+
+        $imageIndexFiles = Get-ChildItem -LiteralPath $artifactDir -Recurse -Filter 'vi-history-image-index.json' -File
+        if (-not $imageIndexFiles -or $imageIndexFiles.Count -lt 1) {
+            throw 'vi-history-image-index.json not found in downloaded artifact.'
+        }
+        $previewImageFiles = Get-ChildItem -LiteralPath $artifactDir -Recurse -File |
+            Where-Object { $_.Name -like 'history-image-*' -and $_.FullName -match '[\\/]+previews[\\/]' }
+        if (-not $previewImageFiles -or $previewImageFiles.Count -lt 1) {
+            throw 'Preview image files (`previews/history-image-*`) not found in downloaded artifact.'
+        }
+        $scratchContext.mobilePreviewImageCount = [Math]::Max($scratchContext.mobilePreviewImageCount, $previewImageFiles.Count)
+        $scratchContext.mobilePreviewValidated = $true
         $scratchContext.ArtifactValidated = $true
         try {
             Remove-Item -LiteralPath $artifactDir -Recurse -Force


### PR DESCRIPTION
## Summary
- document the VI history mobile preview contracts and artifact locations in README and workflow docs
- document additive summary fields (	argets[].reportImages, previewImages, markdownTruncated) and extractor env toggles
- harden 	ools/Test-PRVIHistorySmoke.ps1 sequential validation to assert mobile preview section, preview image tags, and preview artifacts/index
- emit additive smoke summary fields: mobilePreviewValidated, mobilePreviewImageCount, mobilePreviewCommentFound

## Validation
- pwsh -NoLogo -NoProfile -File Invoke-PesterTests.ps1 -TestsPath tests/Summarize-PRVIHistory.Tests.ps1
- pwsh -NoLogo -NoProfile -File Invoke-PesterTests.ps1 -TestsPath tests/Invoke-PRVIHistory.Tests.ps1
- pwsh -NoLogo -NoProfile -File Invoke-PesterTests.ps1 -TestsPath tests/Extract-VIHistoryReportImages.Tests.ps1
- pwsh -NoLogo -NoProfile -File tools/PrePush-Checks.ps1 -SkipIconEditorFixtureChecks

Refs #9