### PR TITLE
fix(#9): ensure sequential smoke keeps a net VI diff

### DIFF
--- a/tools/Test-PRVIHistorySmoke.ps1
+++ b/tools/Test-PRVIHistorySmoke.ps1
@@ -478,6 +478,7 @@ $scratchContext = [ordered]@{
     mobilePreviewValidated = $false
     mobilePreviewImageCount = 0
     mobilePreviewCommentFound = $false
+    NetDiffAnchored = $false
 }
 
 $commitSummaries = @()
@@ -496,6 +497,25 @@ try {
         }
         'sequential' {
             $commitSummaries = Invoke-SequentialHistoryCommits -TargetVi $targetVi
+            $netDiffPaths = @(Invoke-Git -Arguments @('diff', '--name-only', "origin/$BaseBranch", '--', $targetVi))
+            if ($netDiffPaths.Count -eq 0) {
+                $anchorSourceVi = 'fixtures/vi-attr/Base.vi'
+                Write-Host ("Sequential scenario has no net diff against origin/{0}; applying anchor commit: {1} <= {2}" -f $BaseBranch, $targetVi, $anchorSourceVi)
+                Copy-VIContent -Source $anchorSourceVi -Destination $targetVi
+                $anchorStatus = @(Invoke-Git -Arguments @('status', '--porcelain', '--', $targetVi))
+                if ($anchorStatus.Count -eq 0) {
+                    throw 'Failed to produce net diff anchor change for sequential scenario.'
+                }
+                Invoke-Git -Arguments @('add', '-f', $targetVi) | Out-Null
+                $anchorMessage = 'chore: sequential history net-diff anchor'
+                Invoke-Git -Arguments @('commit', '-m', $anchorMessage) | Out-Null
+                $commitSummaries += [pscustomobject]@{
+                    Title   = 'Net-diff anchor'
+                    Source  = $anchorSourceVi
+                    Message = $anchorMessage
+                }
+                $scratchContext.NetDiffAnchored = $true
+            }
         }
     }
     $scratchContext.CommitCount = $commitSummaries.Count


### PR DESCRIPTION
## Summary
- detect when sequential fixture commits produce no net diff against origin/develop
- add deterministic anchor commit (ixtures/vi-attr/Base.vi -> ixtures/vi-attr/Head.vi) only in that case
- record NetDiffAnchored in smoke summary JSON for traceability

Refs #9