### PR TITLE
feat(#33): hybrid strict/smoke policy gate contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ the same summary table to a GitHub issue for stakeholders.
   so reviewers can scan cosmetic changes on mobile without downloading artifacts first.
 - Comment-size safety guards cap preview/image payload and apply markdown truncation when needed; the summarizer writes
   this state to totals (`previewImages`, `markdownTruncated`) and emits an explicit truncation note in the PR comment.
+- `tools/Test-PRVIHistorySmoke.ps1` now emits explicit hybrid gate policy metadata (`schema: vi-history-policy-gate@v1`):
+  strict (`requireDiff=true`) violations are hard failures, while smoke (`requireDiff=false`) violations are recorded as
+  non-blocking warnings for diagnostics.
 - To rehearse the fork flow locally, run `pwsh -File tools/Test-ForkSimulation.ps1` in three passes: `-DryRun` shows the
   steps, the default run opens a draft PR and validates the automatic compare job, and `-KeepBranch` preserves the
   scratch branch while the staging/history dispatches finish so you can inspect the artifacts.

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -149,6 +149,10 @@ Quick reference for building, testing, and releasing the LVCompare composite act
         The same helper emits a `### Mobile Preview` section in the PR comment/summary markdown when previews are
         available, and writes extracted files to `tests/results/pr-vi-history/<target>/previews/` with index contract
         `pr-vi-history-image-index@v1`.
+        The on-demand smoke harness (`tools/Test-PRVIHistorySmoke.ps1`) enforces hybrid gate policy:
+        - strict targets (`requireDiff=true`) are hard-fail
+        - smoke targets (`requireDiff=false`) are non-blocking warnings
+        - summary output includes `Policy` (`vi-history-policy-gate@v1`) with separated strict failures and smoke warnings
         Extractor toggles:
         - `PR_VI_HISTORY_EXTRACT_REPORT_IMAGES`
         - `VI_HISTORY_EXTRACT_REPORT_IMAGES`

--- a/fixtures/vi-history/README.md
+++ b/fixtures/vi-history/README.md
@@ -50,3 +50,18 @@ Extend the `steps` list when new scenarios are required; tests ensure every refe
   }
 }
 ```
+
+## Policy Gate Semantics
+
+`tools/Test-PRVIHistorySmoke.ps1` evaluates each expected target with a hybrid
+policy contract:
+
+- `strict` (`requireDiff: true`):
+  - missing rows, zero comparisons, or missing required diffs are **hard
+    failures** (blocking).
+- `smoke` (`requireDiff: false`):
+  - the same conditions are emitted as **warnings** (non-blocking) so
+    diagnostics stay visible without failing the run.
+
+The smoke summary JSON now includes `Policy` (`vi-history-policy-gate@v1`) with
+separate strict failure and smoke warning buckets.

--- a/tests/Resolve-VIHistoryPolicyDecision.Tests.ps1
+++ b/tests/Resolve-VIHistoryPolicyDecision.Tests.ps1
@@ -1,0 +1,58 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Describe 'Resolve-VIHistoryPolicyDecision' -Tag 'Unit' {
+    BeforeAll {
+        $repoRoot = Split-Path -Parent $PSScriptRoot
+        . (Join-Path $repoRoot 'tools' 'Resolve-VIHistoryPolicyDecision.ps1')
+    }
+
+    It 'returns strict pass when required diffs are present' {
+        $result = Resolve-VIHistoryPolicyDecision -TargetPath 'fixtures/vi-attr/Head.vi' -RequireDiff:$true -MinDiffs 1 -Comparisons 2 -Diffs 2 -Status 'diff'
+        $result.policyClass | Should -Be 'strict'
+        $result.outcome | Should -Be 'pass'
+        $result.gateOutcome | Should -Be 'pass'
+        $result.hardFail | Should -BeFalse
+    }
+
+    It 'returns strict failure when summary row is missing' {
+        $result = Resolve-VIHistoryPolicyDecision -TargetPath 'fixtures/vi-attr/Head.vi' -RequireDiff:$true -MinDiffs 1 -Missing
+        $result.outcome | Should -Be 'fail'
+        $result.hardFail | Should -BeTrue
+        $result.reasonCode | Should -Be 'missing-summary-row'
+    }
+
+    It 'returns strict failure when diffs are below threshold' {
+        $result = Resolve-VIHistoryPolicyDecision -TargetPath 'fixtures/vi-attr/Head.vi' -RequireDiff:$true -MinDiffs 2 -Comparisons 2 -Diffs 1 -Status 'diff'
+        $result.outcome | Should -Be 'fail'
+        $result.reasonCode | Should -Be 'insufficient-diffs'
+    }
+
+    It 'returns strict failure when status is not diff' {
+        $result = Resolve-VIHistoryPolicyDecision -TargetPath 'fixtures/vi-attr/Head.vi' -RequireDiff:$true -MinDiffs 1 -Comparisons 2 -Diffs 2 -Status 'match'
+        $result.outcome | Should -Be 'fail'
+        $result.reasonCode | Should -Be 'strict-status-mismatch'
+    }
+
+    It 'returns smoke warning when summary row is missing' {
+        $result = Resolve-VIHistoryPolicyDecision -TargetPath 'fixtures/vi-attr/Base.vi' -RequireDiff:$false -MinDiffs 0 -Missing
+        $result.policyClass | Should -Be 'smoke'
+        $result.outcome | Should -Be 'warn'
+        $result.warning | Should -BeTrue
+        $result.gateOutcome | Should -Be 'pass'
+    }
+
+    It 'returns smoke warning for zero comparisons' {
+        $result = Resolve-VIHistoryPolicyDecision -TargetPath 'fixtures/vi-attr/Base.vi' -RequireDiff:$false -MinDiffs 0 -Comparisons 0 -Diffs 0 -Status 'match'
+        $result.outcome | Should -Be 'warn'
+        $result.reasonCode | Should -Be 'zero-comparisons'
+    }
+
+    It 'returns smoke pass for non-diff metadata outcomes' {
+        $result = Resolve-VIHistoryPolicyDecision -TargetPath 'fixtures/vi-attr/Base.vi' -RequireDiff:$false -MinDiffs 0 -Comparisons 1 -Diffs 0 -Status 'match'
+        $result.outcome | Should -Be 'pass'
+        $result.gateOutcome | Should -Be 'pass'
+        $result.warning | Should -BeFalse
+    }
+}
+

--- a/tools/Resolve-VIHistoryPolicyDecision.ps1
+++ b/tools/Resolve-VIHistoryPolicyDecision.ps1
@@ -1,0 +1,81 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Resolve-VIHistoryPolicyDecision {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$TargetPath,
+
+        [Parameter(Mandatory)]
+        [bool]$RequireDiff,
+
+        [int]$MinDiffs = 0,
+
+        [AllowNull()]
+        [int]$Comparisons,
+
+        [AllowNull()]
+        [int]$Diffs,
+
+        [AllowNull()]
+        [string]$Status,
+
+        [switch]$Missing
+    )
+
+    $policyClass = if ($RequireDiff) { 'strict' } else { 'smoke' }
+    $requiredDiffs = [Math]::Max(0, [int]$MinDiffs)
+    $normalStatus = if ([string]::IsNullOrWhiteSpace($Status)) { 'unknown' } else { $Status.Trim().ToLowerInvariant() }
+
+    $outcome = 'pass'
+    $reasonCode = 'ok'
+    $reasonMessage = 'policy checks passed'
+
+    if ($Missing) {
+        $reasonCode = 'missing-summary-row'
+        $reasonMessage = ("No summary row was produced for target '{0}'." -f $TargetPath)
+        if ($RequireDiff) {
+            $outcome = 'fail'
+        } else {
+            $outcome = 'warn'
+        }
+    } elseif ($null -eq $Comparisons -or $Comparisons -lt 1) {
+        $reasonCode = 'zero-comparisons'
+        $reasonMessage = ("Target '{0}' reported zero comparisons." -f $TargetPath)
+        if ($RequireDiff) {
+            $outcome = 'fail'
+        } else {
+            $outcome = 'warn'
+        }
+    } elseif ($RequireDiff -and ($null -eq $Diffs -or $Diffs -lt $requiredDiffs)) {
+        $outcome = 'fail'
+        $reasonCode = 'insufficient-diffs'
+        $reasonMessage = ("Target '{0}' expected at least {1} diff(s) but reported {2}." -f $TargetPath, $requiredDiffs, [int]$Diffs)
+    } elseif ($RequireDiff -and $normalStatus -notmatch 'diff') {
+        $outcome = 'fail'
+        $reasonCode = 'strict-status-mismatch'
+        $reasonMessage = ("Target '{0}' expected diff status but saw '{1}'." -f $TargetPath, $normalStatus)
+    } elseif ((-not $RequireDiff) -and $requiredDiffs -gt 0 -and ($null -eq $Diffs -or $Diffs -lt $requiredDiffs)) {
+        $outcome = 'warn'
+        $reasonCode = 'insufficient-diffs'
+        $reasonMessage = ("Target '{0}' expected at least {1} diff(s) but reported {2}." -f $TargetPath, $requiredDiffs, [int]$Diffs)
+    }
+
+    [pscustomobject]@{
+        policyClass     = $policyClass
+        outcome         = $outcome
+        gateOutcome     = if ($outcome -eq 'fail') { 'fail' } else { 'pass' }
+        hardFail        = ($outcome -eq 'fail')
+        warning         = ($outcome -eq 'warn')
+        reasonCode      = $reasonCode
+        reasonMessage   = $reasonMessage
+        requireDiff     = $RequireDiff
+        minDiffs        = $requiredDiffs
+        comparisons     = if ($null -eq $Comparisons) { 0 } else { [int]$Comparisons }
+        diffs           = if ($null -eq $Diffs) { 0 } else { [int]$Diffs }
+        status          = $normalStatus
+        targetPath      = $TargetPath
+    }
+}
+

--- a/tools/Test-PRVIHistorySmoke.ps1
+++ b/tools/Test-PRVIHistorySmoke.ps1
@@ -51,6 +51,12 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
+$policyHelperPath = Join-Path $PSScriptRoot 'Resolve-VIHistoryPolicyDecision.ps1'
+if (-not (Test-Path -LiteralPath $policyHelperPath -PathType Leaf)) {
+    throw "Policy helper not found: $policyHelperPath"
+}
+. $policyHelperPath
+
 if ($WorkflowTimeoutMinutes -lt 1) {
     throw 'WorkflowTimeoutMinutes must be greater than zero.'
 }
@@ -765,6 +771,21 @@ $scratchContext = [ordered]@{
     NetDiffAnchored = $false
     TargetExpectations = @()
     TargetValidation = @()
+    Policy = [ordered]@{
+        schema = 'vi-history-policy-gate@v1'
+        strict = [ordered]@{
+            total = 0
+            pass = 0
+            fail = 0
+            failures = @()
+        }
+        smoke = [ordered]@{
+            total = 0
+            pass = 0
+            warn = 0
+            warnings = @()
+        }
+    }
     MaxPairsRequested = $MaxPairs
     MaxPairsEffective = $effectiveMaxPairs
     WorkflowTimeoutMinutes = $WorkflowTimeoutMinutes
@@ -987,38 +1008,65 @@ try {
     }
 
     $targetValidations = New-Object System.Collections.Generic.List[pscustomobject]
+    $targetValidationByPath = @{}
+    $strictFailures = New-Object System.Collections.Generic.List[pscustomobject]
+    $smokeWarnings = New-Object System.Collections.Generic.List[pscustomobject]
     $totalComparisons = 0
     $totalDiffs = 0
     foreach ($expectedTarget in $expectedTargets) {
         $row = $commentRows | Where-Object { $_.path -eq $expectedTarget.repoPath } | Select-Object -First 1
-        if (-not $row) {
-            throw ("History comment is missing summary row for target '{0}'." -f $expectedTarget.repoPath)
-        }
-
-        if ($row.comparisons -lt 1) {
-            throw ("Target '{0}' reported zero comparisons in history comment." -f $expectedTarget.repoPath)
-        }
-
+        $comparisons = if ($row) { [int]$row.comparisons } else { 0 }
+        $diffs = if ($row) { [int]$row.diffs } else { 0 }
+        $status = if ($row) { [string]$row.status } else { 'missing' }
         $requiredDiffs = [Math]::Max(0, [int]$expectedTarget.minDiffs)
-        if ([bool]$expectedTarget.requireDiff -and $row.diffs -lt $requiredDiffs) {
-            throw ("Target '{0}' expected at least {1} diff(s) but comment reported {2}." -f $expectedTarget.repoPath, $requiredDiffs, $row.diffs)
+
+        $commentDecision = Resolve-VIHistoryPolicyDecision `
+            -TargetPath ([string]$expectedTarget.repoPath) `
+            -RequireDiff ([bool]$expectedTarget.requireDiff) `
+            -MinDiffs $requiredDiffs `
+            -Comparisons $comparisons `
+            -Diffs $diffs `
+            -Status $status `
+            -Missing:(-not [bool]$row)
+
+        if ($commentDecision.hardFail) {
+            $strictFailures.Add([pscustomobject]@{
+                source      = 'comment'
+                targetPath  = [string]$expectedTarget.repoPath
+                reasonCode  = [string]$commentDecision.reasonCode
+                reason      = [string]$commentDecision.reasonMessage
+            }) | Out-Null
+            throw ("[strict policy][comment] {0}" -f $commentDecision.reasonMessage)
+        }
+        if ($commentDecision.warning) {
+            $warningRecord = [pscustomobject]@{
+                source      = 'comment'
+                targetPath  = [string]$expectedTarget.repoPath
+                reasonCode  = [string]$commentDecision.reasonCode
+                reason      = [string]$commentDecision.reasonMessage
+            }
+            $smokeWarnings.Add($warningRecord) | Out-Null
+            Write-Warning ("[smoke policy][comment] {0}" -f $commentDecision.reasonMessage)
         }
 
-        if ([bool]$expectedTarget.requireDiff -and $row.status -notlike '*diff*') {
-            throw ("Target '{0}' expected diff status but saw '{1}'." -f $expectedTarget.repoPath, $row.status)
+        $totalComparisons += $comparisons
+        $totalDiffs += $diffs
+        $validationRecord = [pscustomobject]@{
+            repoPath            = [string]$expectedTarget.repoPath
+            comparisons         = $comparisons
+            diffs               = $diffs
+            status              = $status
+            requireDiff         = [bool]$expectedTarget.requireDiff
+            minDiffs            = [int]$expectedTarget.minDiffs
+            classificationHint  = if ($expectedTarget.PSObject.Properties['classificationHint']) { [string]$expectedTarget.classificationHint } else { $null }
+            policyClass         = [string]$commentDecision.policyClass
+            commentPolicyOutcome= [string]$commentDecision.outcome
+            commentPolicyReason = [string]$commentDecision.reasonMessage
+            artifactPolicyOutcome= 'pending'
+            artifactPolicyReason = $null
         }
-
-        $totalComparisons += [int]$row.comparisons
-        $totalDiffs += [int]$row.diffs
-        $targetValidations.Add([pscustomobject]@{
-            repoPath          = [string]$expectedTarget.repoPath
-            comparisons       = [int]$row.comparisons
-            diffs             = [int]$row.diffs
-            status            = [string]$row.status
-            requireDiff       = [bool]$expectedTarget.requireDiff
-            minDiffs          = [int]$expectedTarget.minDiffs
-            classificationHint= if ($expectedTarget.PSObject.Properties['classificationHint']) { [string]$expectedTarget.classificationHint } else { $null }
-        }) | Out-Null
+        $targetValidations.Add($validationRecord) | Out-Null
+        $targetValidationByPath[[string]$expectedTarget.repoPath] = $validationRecord
     }
     $scratchContext.TargetValidation = @($targetValidations)
     $scratchContext.Comparisons = $totalComparisons
@@ -1060,19 +1108,46 @@ try {
 
         foreach ($expectedTarget in $expectedTargets) {
             $summaryTarget = $targetSummaries | Where-Object { $_.repoPath -eq $expectedTarget.repoPath } | Select-Object -First 1
-            if (-not $summaryTarget) {
-                throw ("Summary JSON missing target entry for '{0}'." -f $expectedTarget.repoPath)
-            }
-            $artifactComparisons = if ($summaryTarget.stats) { [int]$summaryTarget.stats.processed } else { 0 }
-            $artifactDiffs = if ($summaryTarget.stats) { [int]$summaryTarget.stats.diffs } else { 0 }
-            if ($artifactComparisons -lt 1) {
-                throw ("Summary JSON reported zero comparisons for target '{0}'." -f $expectedTarget.repoPath)
-            }
+            $artifactComparisons = if ($summaryTarget -and $summaryTarget.stats) { [int]$summaryTarget.stats.processed } else { 0 }
+            $artifactDiffs = if ($summaryTarget -and $summaryTarget.stats) { [int]$summaryTarget.stats.diffs } else { 0 }
             $requiredDiffs = [Math]::Max(0, [int]$expectedTarget.minDiffs)
-            if ([bool]$expectedTarget.requireDiff -and $artifactDiffs -lt $requiredDiffs) {
-                throw ("Summary JSON target '{0}' expected at least {1} diff(s) but saw {2}." -f $expectedTarget.repoPath, $requiredDiffs, $artifactDiffs)
+            $artifactStatus = if ($summaryTarget -and $summaryTarget.PSObject.Properties['status']) { [string]$summaryTarget.status } else { 'missing' }
+            $artifactDecision = Resolve-VIHistoryPolicyDecision `
+                -TargetPath ([string]$expectedTarget.repoPath) `
+                -RequireDiff ([bool]$expectedTarget.requireDiff) `
+                -MinDiffs $requiredDiffs `
+                -Comparisons $artifactComparisons `
+                -Diffs $artifactDiffs `
+                -Status $artifactStatus `
+                -Missing:(-not [bool]$summaryTarget)
+
+            if ($artifactDecision.hardFail) {
+                $strictFailures.Add([pscustomobject]@{
+                    source      = 'artifact'
+                    targetPath  = [string]$expectedTarget.repoPath
+                    reasonCode  = [string]$artifactDecision.reasonCode
+                    reason      = [string]$artifactDecision.reasonMessage
+                }) | Out-Null
+                throw ("[strict policy][artifact] {0}" -f $artifactDecision.reasonMessage)
             }
-            if ($scenarioKey -eq 'sequential' -and $summaryTarget.repoPath -eq 'fixtures/vi-attr/Head.vi') {
+            if ($artifactDecision.warning) {
+                $warningRecord = [pscustomobject]@{
+                    source      = 'artifact'
+                    targetPath  = [string]$expectedTarget.repoPath
+                    reasonCode  = [string]$artifactDecision.reasonCode
+                    reason      = [string]$artifactDecision.reasonMessage
+                }
+                $smokeWarnings.Add($warningRecord) | Out-Null
+                Write-Warning ("[smoke policy][artifact] {0}" -f $artifactDecision.reasonMessage)
+            }
+
+            $targetValidation = $targetValidationByPath[[string]$expectedTarget.repoPath]
+            if ($targetValidation) {
+                $targetValidation.artifactPolicyOutcome = [string]$artifactDecision.outcome
+                $targetValidation.artifactPolicyReason = [string]$artifactDecision.reasonMessage
+            }
+
+            if ($scenarioKey -eq 'sequential' -and $summaryTarget -and $summaryTarget.repoPath -eq 'fixtures/vi-attr/Head.vi') {
                 $expectedSequentialComparisons = [Math]::Max(1, $commitSummaries.Count)
                 if ($effectiveMaxPairs -gt 0) {
                     $expectedSequentialComparisons = [Math]::Max(1, [Math]::Min($expectedSequentialComparisons, $effectiveMaxPairs))
@@ -1114,6 +1189,47 @@ try {
         } catch {
             Write-Warning ("Failed to delete temporary artifact directory {0}: {1}" -f $artifactDir, $_.Exception.Message)
         }
+    }
+
+    $policyStrictTotal = 0
+    $policyStrictPass = 0
+    $policySmokeTotal = 0
+    $policySmokePass = 0
+    $policySmokeWarn = 0
+    foreach ($validation in @($targetValidations)) {
+        if (-not $validation) { continue }
+        $isStrict = [bool]$validation.requireDiff
+        $commentOutcome = if ($validation.PSObject.Properties['commentPolicyOutcome']) { [string]$validation.commentPolicyOutcome } else { 'pass' }
+        $artifactOutcome = if ($validation.PSObject.Properties['artifactPolicyOutcome']) { [string]$validation.artifactPolicyOutcome } else { 'pass' }
+        $hasWarn = @($commentOutcome, $artifactOutcome) -contains 'warn'
+
+        if ($isStrict) {
+            $policyStrictTotal++
+            if ($commentOutcome -ne 'fail' -and $artifactOutcome -ne 'fail') {
+                $policyStrictPass++
+            }
+        } else {
+            $policySmokeTotal++
+            if ($hasWarn) {
+                $policySmokeWarn++
+            } else {
+                $policySmokePass++
+            }
+        }
+    }
+
+    $scratchContext.Policy.strict.total = $policyStrictTotal
+    $scratchContext.Policy.strict.pass = $policyStrictPass
+    $scratchContext.Policy.strict.fail = $strictFailures.Count
+    $scratchContext.Policy.strict.failures = @($strictFailures)
+    $scratchContext.Policy.smoke.total = $policySmokeTotal
+    $scratchContext.Policy.smoke.pass = $policySmokePass
+    $scratchContext.Policy.smoke.warn = $policySmokeWarn
+    $scratchContext.Policy.smoke.warnings = @($smokeWarnings)
+
+    if ($smokeWarnings.Count -gt 0) {
+        Write-Host ("Policy summary: strict pass={0}/{1}, strict fail={2}; smoke pass={3}/{4}, smoke warn={5}" -f `
+                $policyStrictPass, $policyStrictTotal, $strictFailures.Count, $policySmokePass, $policySmokeTotal, $policySmokeWarn)
     }
 
     $scratchContext.Success = $true


### PR DESCRIPTION
## Summary
- add explicit strict-vs-smoke policy decision helper for VI history smoke validation
- make strict targets (`requireDiff=true`) blocking with actionable failure reasons
- keep smoke targets (`requireDiff=false`) non-blocking and surface warnings in summary output
- emit additive `Policy` contract (`vi-history-policy-gate@v1`) in smoke summary JSON
- document hybrid policy in README + developer docs

## Validation
- `Invoke-Pester -Path tests/Resolve-VIHistoryPolicyDecision.Tests.ps1 -Output Detailed`
- `Invoke-Pester -Path tests/MixedSameCommitFixture.Tests.ps1 -Output Detailed`
- `pwsh -File tools/Test-PRVIHistorySmoke.ps1 -Scenario mixed-same-commit -DryRun`
- `pwsh -File tools/PrePush-Checks.ps1 -SkipIconEditorFixtureChecks`

Closes #33