### PR TITLE
feat(#32): add VI history KPI benchmark and delta artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,13 @@ the same summary table to a GitHub issue for stakeholders.
 - `tools/Test-PRVIHistorySmoke.ps1` now emits explicit hybrid gate policy metadata (`schema: vi-history-policy-gate@v1`):
   strict (`requireDiff=true`) violations are hard failures, while smoke (`requireDiff=false`) violations are recorded as
   non-blocking warnings for diagnostics.
+- Smoke runs now emit benchmark artifacts under `tests/results/_agent/smoke/vi-history/benchmarks/`:
+  - `vi-history-benchmark-*.json` (`schema: vi-history-benchmark@v1`)
+  - `vi-history-benchmark-delta-*.json` (`schema: vi-history-benchmark-delta@v1`)
+  - `vi-history-benchmark-delta-*.md` (PR/issue-ready KPI delta comment body)
+- `tools/Test-PRVIHistorySmoke.ps1` can post KPI delta evidence comments automatically:
+  - always to the synthetic PR (before cleanup)
+  - optionally to an issue via `-EvidenceIssueNumber`
 - To rehearse the fork flow locally, run `pwsh -File tools/Test-ForkSimulation.ps1` in three passes: `-DryRun` shows the
   steps, the default run opens a draft PR and validates the automatic compare job, and `-KeepBranch` preserves the
   scratch branch while the staging/history dispatches finish so you can inspect the artifacts.

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -164,6 +164,14 @@ Quick reference for building, testing, and releasing the LVCompare composite act
         - strict targets (`requireDiff=true`) are hard-fail
         - smoke targets (`requireDiff=false`) are non-blocking warnings
         - summary output includes `Policy` (`vi-history-policy-gate@v1`) with separated strict failures and smoke warnings
+        Smoke KPI artifacts are additive and emitted per run:
+        - `tests/results/_agent/smoke/vi-history/benchmarks/vi-history-benchmark-*.json`
+          (`schema: vi-history-benchmark@v1`)
+        - `tests/results/_agent/smoke/vi-history/benchmarks/vi-history-benchmark-delta-*.json`
+          (`schema: vi-history-benchmark-delta@v1`)
+        - `tests/results/_agent/smoke/vi-history/benchmarks/vi-history-benchmark-delta-*.md`
+          (PR/issue evidence comment body)
+        Use `-EvidenceIssueNumber <n>` to mirror KPI delta comments to a tracking issue.
         Extractor toggles:
         - `PR_VI_HISTORY_EXTRACT_REPORT_IMAGES`
         - `VI_HISTORY_EXTRACT_REPORT_IMAGES`

--- a/docs/knowledgebase/VICompare-Refs-Workflow.md
+++ b/docs/knowledgebase/VICompare-Refs-Workflow.md
@@ -111,6 +111,9 @@
   comment safety limits. Totals expose `previewImages` and `markdownTruncated`; per-target metadata surfaces under
   `targets[].reportImages` in `pr-vi-history-summary@v1`.
   For a full end-to-end validation, run the smoke helper (`pwsh -File tools/Test-PRVIHistorySmoke.ps1` or `npm run smoke:vi-history`) to create a scratch PR, dispatch the workflow, and record the results under `tests/results/_agent/smoke/vi-history/`.
+  Benchmark/delta evidence is emitted alongside smoke summaries under
+  `tests/results/_agent/smoke/vi-history/benchmarks/` (`vi-history-benchmark@v1` and
+  `vi-history-benchmark-delta@v1`) with a markdown comment body ready for PR/issue posting.
 
 ## Dispatch inputs (GitHub UI or `gh workflow run`)
 

--- a/tests/Write-VIHistoryBenchmark.Tests.ps1
+++ b/tests/Write-VIHistoryBenchmark.Tests.ps1
@@ -1,0 +1,139 @@
+#Requires -Version 7.0
+
+Set-StrictMode -Version Latest
+
+Describe 'Write-VIHistoryBenchmark.ps1' {
+    BeforeAll {
+        $scriptPath = (Resolve-Path (Join-Path $PSScriptRoot '..' 'tools' 'Write-VIHistoryBenchmark.ps1')).ProviderPath
+    }
+
+    It 'writes benchmark artifacts and reports insufficient baseline when no prior run exists' {
+        $summaryPath = Join-Path $TestDrive 'vi-history-smoke-current.json'
+        $benchmarksDir = Join-Path $TestDrive 'benchmarks'
+        New-Item -ItemType Directory -Path $benchmarksDir -Force | Out-Null
+
+        [ordered]@{
+            Scenario = 'attribute'
+            RunId = 1001
+            PrNumber = 55
+            Success = $true
+            Comparisons = 3
+            Diffs = 2
+            PairClassification = [ordered]@{
+                signal = 1
+                'noise-masscompile' = 1
+                unknown = 1
+            }
+            PairTiming = [ordered]@{
+                comparisonCount = 3
+                totalSeconds = 9.0
+                p50Seconds = 2.0
+                p95Seconds = 5.0
+            }
+            PairTimeline = @(
+                [ordered]@{ previewStatus = 'present' },
+                [ordered]@{ previewStatus = 'missing' },
+                [ordered]@{ previewStatus = 'present' }
+            )
+            CommentTruncated = $false
+            TruncationReason = 'none'
+        } | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $summaryPath -Encoding utf8
+
+        $result = & $scriptPath -SmokeSummaryPath $summaryPath -BenchmarksDir $benchmarksDir -BaselineWindow 5
+
+        $result.baselineCount | Should -Be 0
+        $result.deltaStatus | Should -Be 'insufficient-baseline'
+        Test-Path -LiteralPath $result.benchmarkPath -PathType Leaf | Should -BeTrue
+        Test-Path -LiteralPath $result.deltaPath -PathType Leaf | Should -BeTrue
+        Test-Path -LiteralPath $result.commentPath -PathType Leaf | Should -BeTrue
+
+        $benchmark = Get-Content -LiteralPath $result.benchmarkPath -Raw -Encoding utf8 | ConvertFrom-Json -Depth 10
+        $benchmark.schema | Should -Be 'vi-history-benchmark@v1'
+        $benchmark.metrics.pairCounts.total | Should -Be 3
+        $benchmark.metrics.pairCounts.signal | Should -Be 1
+        $benchmark.metrics.previewCoverage | Should -Be 0.666667
+
+        $delta = Get-Content -LiteralPath $result.deltaPath -Raw -Encoding utf8 | ConvertFrom-Json -Depth 10
+        $delta.schema | Should -Be 'vi-history-benchmark-delta@v1'
+        $delta.status | Should -Be 'insufficient-baseline'
+
+        $comment = Get-Content -LiteralPath $result.commentPath -Raw -Encoding utf8
+        $comment | Should -Match 'Baseline unavailable'
+    }
+
+    It 'computes KPI deltas against prior successful benchmarks for the same scenario' {
+        $summaryPath = Join-Path $TestDrive 'vi-history-smoke-current-ready.json'
+        $benchmarksDir = Join-Path $TestDrive 'benchmarks-ready'
+        New-Item -ItemType Directory -Path $benchmarksDir -Force | Out-Null
+
+        $baselinePath = Join-Path $benchmarksDir 'vi-history-benchmark-20260101010101.json'
+        [ordered]@{
+            schema = 'vi-history-benchmark@v1'
+            generatedAt = (Get-Date).ToString('o')
+            scenario = 'attribute'
+            success = $true
+            metrics = [ordered]@{
+                pairCounts = [ordered]@{
+                    total = 2
+                    signal = 1
+                    noiseMasscompile = 1
+                    noiseCosmetic = 0
+                    unknown = 0
+                    comparisons = 2
+                    diffs = 2
+                }
+                timing = [ordered]@{
+                    totalSeconds = 6
+                    p50Seconds = 2
+                    p95Seconds = 4
+                }
+                previewCoverage = 0.5
+                truncation = [ordered]@{
+                    commentTruncated = $false
+                    reason = 'none'
+                }
+            }
+        } | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $baselinePath -Encoding utf8
+
+        [ordered]@{
+            Scenario = 'attribute'
+            RunId = 1002
+            PrNumber = 56
+            Success = $true
+            Comparisons = 3
+            Diffs = 2
+            PairClassification = [ordered]@{
+                signal = 2
+                'noise-masscompile' = 1
+            }
+            PairTiming = [ordered]@{
+                comparisonCount = 3
+                totalSeconds = 9
+                p50Seconds = 3
+                p95Seconds = 5
+            }
+            PairTimeline = @(
+                [ordered]@{ previewStatus = 'present' },
+                [ordered]@{ previewStatus = 'present' },
+                [ordered]@{ previewStatus = 'missing' }
+            )
+            CommentTruncated = $true
+            TruncationReason = 'max-markdown-length'
+        } | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $summaryPath -Encoding utf8
+
+        $result = & $scriptPath -SmokeSummaryPath $summaryPath -BenchmarksDir $benchmarksDir -BaselineWindow 5
+
+        $result.baselineCount | Should -Be 1
+        $result.deltaStatus | Should -Be 'ready'
+
+        $delta = Get-Content -LiteralPath $result.deltaPath -Raw -Encoding utf8 | ConvertFrom-Json -Depth 10
+        $delta.status | Should -Be 'ready'
+        $delta.delta.pairTotal | Should -Be 1
+        $delta.delta.signalPairs | Should -Be 1
+        $delta.delta.previewCoverage | Should -Be 0.166667
+
+        $comment = Get-Content -LiteralPath $result.commentPath -Raw -Encoding utf8
+        $comment | Should -Match '\| Metric \| Current \| Baseline \| Delta \|'
+        $comment | Should -Match 'Timing P95'
+    }
+}

--- a/tools/Test-PRVIHistorySmoke.ps1
+++ b/tools/Test-PRVIHistorySmoke.ps1
@@ -36,6 +36,12 @@ Optional override for the `history_timeout_minutes` workflow input used by
 .PARAMETER CompareTimeoutSeconds
 Optional override for the `compare_timeout_seconds` workflow input used by
 `pr-vi-history.yml`. Defaults to `900` for smoke evidence runs.
+
+.PARAMETER BenchmarkBaselineWindow
+Rolling baseline window (same scenario) used when computing KPI deltas.
+
+.PARAMETER EvidenceIssueNumber
+Optional issue number where KPI delta markdown should be posted.
 #>
 [CmdletBinding()]
 param(
@@ -46,7 +52,10 @@ param(
     [string]$Scenario = 'attribute',
     [int]$MaxPairs = 6,
     [int]$WorkflowTimeoutMinutes = 25,
-    [int]$CompareTimeoutSeconds = 900
+    [int]$CompareTimeoutSeconds = 900,
+    [ValidateRange(1, 50)]
+    [int]$BenchmarkBaselineWindow = 5,
+    [int]$EvidenceIssueNumber = 0
 )
 
 Set-StrictMode -Version Latest
@@ -63,6 +72,11 @@ if (-not (Test-Path -LiteralPath $pairTimelineHelperPath -PathType Leaf)) {
     throw "Pair timeline helper not found: $pairTimelineHelperPath"
 }
 . $pairTimelineHelperPath
+
+$benchmarkWriterPath = Join-Path $PSScriptRoot 'Write-VIHistoryBenchmark.ps1'
+if (-not (Test-Path -LiteralPath $benchmarkWriterPath -PathType Leaf)) {
+    throw "Benchmark writer helper not found: $benchmarkWriterPath"
+}
 
 if ($WorkflowTimeoutMinutes -lt 1) {
     throw 'WorkflowTimeoutMinutes must be greater than zero.'
@@ -974,6 +988,8 @@ $scratchContext = [ordered]@{
     mobilePreviewValidated = $false
     mobilePreviewImageCount = 0
     mobilePreviewCommentFound = $false
+    CommentTruncated = $false
+    TruncationReason = 'none'
     NetDiffAnchored = $false
     TargetExpectations = @()
     TargetValidation = @()
@@ -1000,10 +1016,19 @@ $scratchContext = [ordered]@{
         p50Seconds = $null
         p95Seconds = $null
     }
+    Benchmark = [ordered]@{
+        benchmarkPath = $null
+        deltaPath = $null
+        commentPath = $null
+        baselineCount = 0
+        deltaStatus = 'pending'
+    }
     MaxPairsRequested = $MaxPairs
     MaxPairsEffective = $effectiveMaxPairs
     WorkflowTimeoutMinutes = $WorkflowTimeoutMinutes
     CompareTimeoutSeconds = $CompareTimeoutSeconds
+    BenchmarkBaselineWindow = $BenchmarkBaselineWindow
+    EvidenceIssueNumber = $EvidenceIssueNumber
     MobilePreviewRequired = $scenarioRequiresMobilePreview
 }
 
@@ -1239,6 +1264,16 @@ try {
     $mobilePreviewImageMatches = [regex]::Matches($historyComment, '<img\s+[^>]*src=["''][^"''>]*history-image-[^"''>]*["''][^>]*>')
     $scratchContext.mobilePreviewCommentFound = $mobilePreviewHeaderMatch.Success
     $scratchContext.mobilePreviewImageCount = $mobilePreviewImageMatches.Count
+    if ($historyComment -match 'Summary truncated for comment size safety') {
+        $scratchContext.CommentTruncated = $true
+        $scratchContext.TruncationReason = 'max-markdown-length'
+    } elseif ($historyComment -match 'Timeline rows truncated for mobile/comment-size safety') {
+        $scratchContext.CommentTruncated = $true
+        $scratchContext.TruncationReason = 'timeline-row-drop'
+    } else {
+        $scratchContext.CommentTruncated = $false
+        $scratchContext.TruncationReason = 'none'
+    }
 
     $commentRows = @(Get-HistorySummaryRowsFromComment -CommentBody $historyComment)
     if ($commentRows.Count -eq 0) {
@@ -1510,6 +1545,51 @@ finally {
         Restore-HistoryTracking -Path $trackedPath
     }
 
+    $scratchContext.SummaryGeneratedAt = (Get-Date).ToString('o')
+    $scratchContext.KeepBranch = [bool]$KeepBranch
+    $scratchContext.BaseBranch = $BaseBranch
+    $scratchContext.MaxPairs = $effectiveMaxPairs
+    $scratchContext.InitialBranch = $initialBranch
+    $scratchContext | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $summaryPath -Encoding utf8
+
+    try {
+        $benchmarkResult = & $benchmarkWriterPath `
+            -SmokeSummaryPath $summaryPath `
+            -BaselineWindow $BenchmarkBaselineWindow
+        if ($benchmarkResult) {
+            $scratchContext.Benchmark.benchmarkPath = if ($benchmarkResult.PSObject.Properties['benchmarkPath']) { [string]$benchmarkResult.benchmarkPath } else { $null }
+            $scratchContext.Benchmark.deltaPath = if ($benchmarkResult.PSObject.Properties['deltaPath']) { [string]$benchmarkResult.deltaPath } else { $null }
+            $scratchContext.Benchmark.commentPath = if ($benchmarkResult.PSObject.Properties['commentPath']) { [string]$benchmarkResult.commentPath } else { $null }
+            $scratchContext.Benchmark.baselineCount = if ($benchmarkResult.PSObject.Properties['baselineCount']) { [int]$benchmarkResult.baselineCount } else { 0 }
+            $scratchContext.Benchmark.deltaStatus = if ($benchmarkResult.PSObject.Properties['deltaStatus']) { [string]$benchmarkResult.deltaStatus } else { 'unknown' }
+
+            $commentMarkdown = if ($benchmarkResult.PSObject.Properties['commentMarkdown']) { [string]$benchmarkResult.commentMarkdown } else { $null }
+            if (-not [string]::IsNullOrWhiteSpace($commentMarkdown)) {
+                if ($scratchContext.PrNumber) {
+                    try {
+                        Invoke-Gh -Arguments @('pr', 'comment', $scratchContext.PrNumber.ToString(), '--repo', $repoInfo.Slug, '--body', $commentMarkdown) | Out-Null
+                        Write-Host ("Posted KPI delta comment to PR #{0}." -f $scratchContext.PrNumber)
+                    } catch {
+                        Write-Warning ("Failed to post KPI delta comment to PR #{0}: {1}" -f $scratchContext.PrNumber, $_.Exception.Message)
+                    }
+                }
+                if ($EvidenceIssueNumber -gt 0) {
+                    try {
+                        Invoke-Gh -Arguments @('issue', 'comment', $EvidenceIssueNumber.ToString(), '--repo', $repoInfo.Slug, '--body', $commentMarkdown) | Out-Null
+                        Write-Host ("Posted KPI delta comment to issue #{0}." -f $EvidenceIssueNumber)
+                    } catch {
+                        Write-Warning ("Failed to post KPI delta comment to issue #{0}: {1}" -f $EvidenceIssueNumber, $_.Exception.Message)
+                    }
+                }
+            }
+        }
+    } catch {
+        Write-Warning ("Failed to generate KPI benchmark/delta artifacts: {0}" -f $_.Exception.Message)
+    }
+
+    $scratchContext | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $summaryPath -Encoding utf8
+    Write-Host "Summary written to $summaryPath"
+
     if (-not $KeepBranch) {
         Write-Host 'Cleaning up scratch PR and branch...'
         try {
@@ -1532,13 +1612,4 @@ finally {
     } else {
         Write-Host 'KeepBranch specified - leaving scratch PR and branch in place.'
     }
-
-    $scratchContext.SummaryGeneratedAt = (Get-Date).ToString('o')
-    $scratchContext.KeepBranch = [bool]$KeepBranch
-    $scratchContext.BaseBranch = $BaseBranch
-    $scratchContext.MaxPairs = $effectiveMaxPairs
-    $scratchContext.InitialBranch = $initialBranch
-
-    $scratchContext | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $summaryPath -Encoding utf8
-    Write-Host "Summary written to $summaryPath"
 }

--- a/tools/Write-VIHistoryBenchmark.ps1
+++ b/tools/Write-VIHistoryBenchmark.ps1
@@ -1,0 +1,365 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+  Builds KPI benchmark + delta artifacts from a VI history smoke summary.
+
+.DESCRIPTION
+  Reads `vi-history-smoke-*.json` output from `tools/Test-PRVIHistorySmoke.ps1`,
+  emits a benchmark artifact (`vi-history-benchmark@v1`), computes deltas
+  against a rolling baseline for the same scenario, and writes a markdown block
+  that can be posted to PR/issue evidence comments.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]$SmokeSummaryPath,
+
+    [string]$BenchmarksDir = 'tests/results/_agent/smoke/vi-history/benchmarks',
+
+    [ValidateRange(1, 50)]
+    [int]$BaselineWindow = 5,
+
+    [string]$BenchmarkPath,
+
+    [string]$DeltaPath,
+
+    [string]$CommentPath,
+
+    [string]$GitHubOutputPath
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Resolve-ExistingFile {
+    param(
+        [string]$Path,
+        [string]$Description
+    )
+    if ([string]::IsNullOrWhiteSpace($Path)) {
+        throw "$Description path not provided."
+    }
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        throw "$Description not found: $Path"
+    }
+    return (Resolve-Path -LiteralPath $Path).Path
+}
+
+function Convert-ToNullableDouble {
+    param([AllowNull()]$Value)
+    if ($null -eq $Value) { return $null }
+    try {
+        $number = [double]$Value
+        if ([double]::IsNaN($number) -or [double]::IsInfinity($number)) {
+            return $null
+        }
+        return $number
+    } catch {
+        return $null
+    }
+}
+
+function Convert-ToNullableInt {
+    param([AllowNull()]$Value)
+    if ($null -eq $Value) { return $null }
+    try {
+        return [int]$Value
+    } catch {
+        return $null
+    }
+}
+
+function Get-MapIntValue {
+    param(
+        [AllowNull()]$Map,
+        [string]$Key
+    )
+
+    if (-not $Map -or [string]::IsNullOrWhiteSpace($Key)) { return 0 }
+
+    if ($Map -is [System.Collections.IDictionary]) {
+        foreach ($entry in $Map.GetEnumerator()) {
+            if ([string]::Equals([string]$entry.Key, $Key, [System.StringComparison]::OrdinalIgnoreCase)) {
+                $value = Convert-ToNullableInt -Value $entry.Value
+                if ($null -ne $value) { return $value }
+                return 0
+            }
+        }
+        return 0
+    }
+
+    foreach ($property in $Map.PSObject.Properties) {
+        if ([string]::Equals([string]$property.Name, $Key, [System.StringComparison]::OrdinalIgnoreCase)) {
+            $value = Convert-ToNullableInt -Value $property.Value
+            if ($null -ne $value) { return $value }
+            return 0
+        }
+    }
+
+    return 0
+}
+
+function Get-Percent {
+    param(
+        [int]$Numerator,
+        [int]$Denominator
+    )
+
+    if ($Denominator -le 0) { return $null }
+    return [Math]::Round(($Numerator / [double]$Denominator), 6)
+}
+
+function Get-AverageNullable {
+    param(
+        [AllowNull()]
+        [double[]]$Values
+    )
+
+    $clean = @()
+    if ($Values) {
+        foreach ($value in $Values) {
+            if ($null -eq $value) { continue }
+            if ([double]::IsNaN([double]$value) -or [double]::IsInfinity([double]$value)) { continue }
+            $clean += [double]$value
+        }
+    }
+    if ($clean.Count -eq 0) { return $null }
+
+    $sum = 0.0
+    foreach ($value in $clean) { $sum += $value }
+    return [Math]::Round(($sum / [double]$clean.Count), 6)
+}
+
+function Format-Delta {
+    param([AllowNull()][double]$Value)
+    if ($null -eq $Value) { return '_n/a_' }
+    if ($Value -gt 0) { return ("+{0}" -f ([Math]::Round($Value, 6))) }
+    return ([Math]::Round($Value, 6)).ToString()
+}
+
+$resolvedSummaryPath = Resolve-ExistingFile -Path $SmokeSummaryPath -Description 'Smoke summary'
+$summary = Get-Content -LiteralPath $resolvedSummaryPath -Raw -ErrorAction Stop | ConvertFrom-Json -Depth 12 -ErrorAction Stop
+
+$summaryDir = Split-Path -Parent $resolvedSummaryPath
+if ([string]::IsNullOrWhiteSpace($BenchmarksDir)) {
+    $BenchmarksDir = Join-Path $summaryDir 'benchmarks'
+}
+if (-not [System.IO.Path]::IsPathRooted($BenchmarksDir)) {
+    $BenchmarksDir = Join-Path $summaryDir $BenchmarksDir
+}
+if (-not (Test-Path -LiteralPath $BenchmarksDir -PathType Container)) {
+    New-Item -ItemType Directory -Path $BenchmarksDir -Force | Out-Null
+}
+$BenchmarksDir = (Resolve-Path -LiteralPath $BenchmarksDir).Path
+
+$timestamp = (Get-Date).ToString('yyyyMMddHHmmss')
+if ([string]::IsNullOrWhiteSpace($BenchmarkPath)) {
+    $BenchmarkPath = Join-Path $BenchmarksDir ("vi-history-benchmark-{0}.json" -f $timestamp)
+}
+if ([string]::IsNullOrWhiteSpace($DeltaPath)) {
+    $DeltaPath = Join-Path $BenchmarksDir ("vi-history-benchmark-delta-{0}.json" -f $timestamp)
+}
+if ([string]::IsNullOrWhiteSpace($CommentPath)) {
+    $CommentPath = Join-Path $BenchmarksDir ("vi-history-benchmark-delta-{0}.md" -f $timestamp)
+}
+
+$pairTimeline = @()
+if ($summary.PSObject.Properties['PairTimeline'] -and $summary.PairTimeline -is [System.Collections.IEnumerable]) {
+    $pairTimeline = @($summary.PairTimeline)
+}
+
+$pairClassification = if ($summary.PSObject.Properties['PairClassification']) { $summary.PairClassification } else { $null }
+$pairTiming = if ($summary.PSObject.Properties['PairTiming']) { $summary.PairTiming } else { $null }
+
+$signalPairs = Get-MapIntValue -Map $pairClassification -Key 'signal'
+$noiseMasscompilePairs = Get-MapIntValue -Map $pairClassification -Key 'noise-masscompile'
+$noiseCosmeticPairs = Get-MapIntValue -Map $pairClassification -Key 'noise-cosmetic'
+$unknownPairs = Get-MapIntValue -Map $pairClassification -Key 'unknown'
+
+$pairTotal = if ($pairTiming -and $pairTiming.PSObject.Properties['comparisonCount']) {
+    [Math]::Max(0, (Convert-ToNullableInt -Value $pairTiming.comparisonCount))
+} else {
+    $pairTimeline.Count
+}
+$diffs = if ($summary.PSObject.Properties['Diffs']) { [Math]::Max(0, (Convert-ToNullableInt -Value $summary.Diffs)) } else { 0 }
+$comparisons = if ($summary.PSObject.Properties['Comparisons']) { [Math]::Max(0, (Convert-ToNullableInt -Value $summary.Comparisons)) } else { $pairTotal }
+
+$previewPresentPairs = 0
+foreach ($pair in $pairTimeline) {
+    if (-not $pair) { continue }
+    if ($pair.PSObject.Properties['previewStatus'] -and [string]$pair.previewStatus -eq 'present') {
+        $previewPresentPairs++
+    }
+}
+$previewCoverage = Get-Percent -Numerator $previewPresentPairs -Denominator $pairTotal
+
+$timingTotalSeconds = if ($pairTiming -and $pairTiming.PSObject.Properties['totalSeconds']) { Convert-ToNullableDouble -Value $pairTiming.totalSeconds } else { $null }
+$timingP50Seconds = if ($pairTiming -and $pairTiming.PSObject.Properties['p50Seconds']) { Convert-ToNullableDouble -Value $pairTiming.p50Seconds } else { $null }
+$timingP95Seconds = if ($pairTiming -and $pairTiming.PSObject.Properties['p95Seconds']) { Convert-ToNullableDouble -Value $pairTiming.p95Seconds } else { $null }
+
+$commentTruncated = if ($summary.PSObject.Properties['CommentTruncated']) { [bool]$summary.CommentTruncated } else { $false }
+$truncationReason = if ($summary.PSObject.Properties['TruncationReason'] -and $summary.TruncationReason) { [string]$summary.TruncationReason } else { 'none' }
+
+$benchmark = [ordered]@{
+    schema           = 'vi-history-benchmark@v1'
+    generatedAt      = (Get-Date).ToString('o')
+    sourceSummaryPath= $resolvedSummaryPath
+    scenario         = if ($summary.PSObject.Properties['Scenario']) { [string]$summary.Scenario } else { 'unknown' }
+    runId            = if ($summary.PSObject.Properties['RunId']) { Convert-ToNullableInt -Value $summary.RunId } else { $null }
+    prNumber         = if ($summary.PSObject.Properties['PrNumber']) { Convert-ToNullableInt -Value $summary.PrNumber } else { $null }
+    success          = if ($summary.PSObject.Properties['Success']) { [bool]$summary.Success } else { $false }
+    metrics          = [ordered]@{
+        pairCounts = [ordered]@{
+            total            = $pairTotal
+            signal           = $signalPairs
+            noiseMasscompile = $noiseMasscompilePairs
+            noiseCosmetic    = $noiseCosmeticPairs
+            unknown          = $unknownPairs
+            comparisons      = $comparisons
+            diffs            = $diffs
+        }
+        timing = [ordered]@{
+            totalSeconds = $timingTotalSeconds
+            p50Seconds   = $timingP50Seconds
+            p95Seconds   = $timingP95Seconds
+        }
+        previewCoverage = $previewCoverage
+        truncation = [ordered]@{
+            commentTruncated = $commentTruncated
+            reason           = $truncationReason
+        }
+    }
+}
+
+$benchmark | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $BenchmarkPath -Encoding utf8
+$resolvedBenchmarkPath = (Resolve-Path -LiteralPath $BenchmarkPath).Path
+
+$allBenchmarkFiles = @(Get-ChildItem -LiteralPath $BenchmarksDir -Filter 'vi-history-benchmark-*.json' -File |
+    Sort-Object LastWriteTimeUtc -Descending)
+
+$baselineBenchmarks = New-Object System.Collections.Generic.List[object]
+foreach ($file in $allBenchmarkFiles) {
+    if ([System.StringComparer]::OrdinalIgnoreCase.Equals($file.FullName, $resolvedBenchmarkPath)) { continue }
+    try {
+        $candidate = Get-Content -LiteralPath $file.FullName -Raw -ErrorAction Stop | ConvertFrom-Json -Depth 12 -ErrorAction Stop
+    } catch {
+        continue
+    }
+    if (-not $candidate) { continue }
+    if (-not $candidate.PSObject.Properties['scenario']) { continue }
+    if (-not [string]::Equals([string]$candidate.scenario, [string]$benchmark.scenario, [System.StringComparison]::OrdinalIgnoreCase)) { continue }
+    if (-not ($candidate.PSObject.Properties['success'] -and [bool]$candidate.success)) { continue }
+    $baselineBenchmarks.Add($candidate) | Out-Null
+    if ($baselineBenchmarks.Count -ge $BaselineWindow) { break }
+}
+
+$baselineCount = $baselineBenchmarks.Count
+$baselinePairTotal = Get-AverageNullable -Values @($baselineBenchmarks | ForEach-Object { Convert-ToNullableDouble -Value $_.metrics.pairCounts.total })
+$baselineSignal = Get-AverageNullable -Values @($baselineBenchmarks | ForEach-Object { Convert-ToNullableDouble -Value $_.metrics.pairCounts.signal })
+$baselineNoiseMasscompile = Get-AverageNullable -Values @($baselineBenchmarks | ForEach-Object { Convert-ToNullableDouble -Value $_.metrics.pairCounts.noiseMasscompile })
+$baselinePreviewCoverage = Get-AverageNullable -Values @($baselineBenchmarks | ForEach-Object { Convert-ToNullableDouble -Value $_.metrics.previewCoverage })
+$baselineP50 = Get-AverageNullable -Values @($baselineBenchmarks | ForEach-Object { Convert-ToNullableDouble -Value $_.metrics.timing.p50Seconds })
+$baselineP95 = Get-AverageNullable -Values @($baselineBenchmarks | ForEach-Object { Convert-ToNullableDouble -Value $_.metrics.timing.p95Seconds })
+$baselineTotalSeconds = Get-AverageNullable -Values @($baselineBenchmarks | ForEach-Object { Convert-ToNullableDouble -Value $_.metrics.timing.totalSeconds })
+$baselineTruncationRate = Get-AverageNullable -Values @($baselineBenchmarks | ForEach-Object {
+        if ($_.metrics.truncation.commentTruncated) { 1.0 } else { 0.0 }
+    })
+
+$currentPairTotal = Convert-ToNullableDouble -Value $benchmark.metrics.pairCounts.total
+$currentSignal = Convert-ToNullableDouble -Value $benchmark.metrics.pairCounts.signal
+$currentNoiseMasscompile = Convert-ToNullableDouble -Value $benchmark.metrics.pairCounts.noiseMasscompile
+$currentPreviewCoverage = Convert-ToNullableDouble -Value $benchmark.metrics.previewCoverage
+$currentP50 = Convert-ToNullableDouble -Value $benchmark.metrics.timing.p50Seconds
+$currentP95 = Convert-ToNullableDouble -Value $benchmark.metrics.timing.p95Seconds
+$currentTotalSeconds = Convert-ToNullableDouble -Value $benchmark.metrics.timing.totalSeconds
+$currentTruncationRate = if ($benchmark.metrics.truncation.commentTruncated) { 1.0 } else { 0.0 }
+
+$delta = [ordered]@{
+    schema       = 'vi-history-benchmark-delta@v1'
+    generatedAt  = (Get-Date).ToString('o')
+    currentPath  = $resolvedBenchmarkPath
+    baselineWindow = $BaselineWindow
+    baselineCount  = $baselineCount
+    status       = if ($baselineCount -gt 0) { 'ready' } else { 'insufficient-baseline' }
+    current      = [ordered]@{
+        pairTotal            = $currentPairTotal
+        signalPairs          = $currentSignal
+        noiseMasscompilePairs= $currentNoiseMasscompile
+        previewCoverage      = $currentPreviewCoverage
+        timingP50Seconds     = $currentP50
+        timingP95Seconds     = $currentP95
+        timingTotalSeconds   = $currentTotalSeconds
+        truncationRate       = $currentTruncationRate
+    }
+    baseline     = [ordered]@{
+        pairTotal            = $baselinePairTotal
+        signalPairs          = $baselineSignal
+        noiseMasscompilePairs= $baselineNoiseMasscompile
+        previewCoverage      = $baselinePreviewCoverage
+        timingP50Seconds     = $baselineP50
+        timingP95Seconds     = $baselineP95
+        timingTotalSeconds   = $baselineTotalSeconds
+        truncationRate       = $baselineTruncationRate
+    }
+    delta        = [ordered]@{
+        pairTotal            = if ($baselineCount -gt 0 -and $null -ne $currentPairTotal -and $null -ne $baselinePairTotal) { [Math]::Round($currentPairTotal - $baselinePairTotal, 6) } else { $null }
+        signalPairs          = if ($baselineCount -gt 0 -and $null -ne $currentSignal -and $null -ne $baselineSignal) { [Math]::Round($currentSignal - $baselineSignal, 6) } else { $null }
+        noiseMasscompilePairs= if ($baselineCount -gt 0 -and $null -ne $currentNoiseMasscompile -and $null -ne $baselineNoiseMasscompile) { [Math]::Round($currentNoiseMasscompile - $baselineNoiseMasscompile, 6) } else { $null }
+        previewCoverage      = if ($baselineCount -gt 0 -and $null -ne $currentPreviewCoverage -and $null -ne $baselinePreviewCoverage) { [Math]::Round($currentPreviewCoverage - $baselinePreviewCoverage, 6) } else { $null }
+        timingP50Seconds     = if ($baselineCount -gt 0 -and $null -ne $currentP50 -and $null -ne $baselineP50) { [Math]::Round($currentP50 - $baselineP50, 6) } else { $null }
+        timingP95Seconds     = if ($baselineCount -gt 0 -and $null -ne $currentP95 -and $null -ne $baselineP95) { [Math]::Round($currentP95 - $baselineP95, 6) } else { $null }
+        timingTotalSeconds   = if ($baselineCount -gt 0 -and $null -ne $currentTotalSeconds -and $null -ne $baselineTotalSeconds) { [Math]::Round($currentTotalSeconds - $baselineTotalSeconds, 6) } else { $null }
+        truncationRate       = if ($baselineCount -gt 0 -and $null -ne $baselineTruncationRate) { [Math]::Round($currentTruncationRate - $baselineTruncationRate, 6) } else { $null }
+    }
+}
+
+$delta | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $DeltaPath -Encoding utf8
+$resolvedDeltaPath = (Resolve-Path -LiteralPath $DeltaPath).Path
+
+$commentLines = New-Object System.Collections.Generic.List[string]
+$commentLines.Add('### VI History KPI Delta') | Out-Null
+$commentLines.Add('') | Out-Null
+if ($baselineCount -gt 0) {
+    $commentLines.Add(('- Scenario: `{0}` | Baseline window: {1} run(s)' -f $benchmark.scenario, $baselineCount)) | Out-Null
+    $commentLines.Add('') | Out-Null
+    $commentLines.Add('| Metric | Current | Baseline | Delta |') | Out-Null
+    $commentLines.Add('| --- | --- | --- | --- |') | Out-Null
+    $commentLines.Add(('| Pair Total | {0} | {1} | {2} |' -f $currentPairTotal, $baselinePairTotal, (Format-Delta -Value $delta.delta.pairTotal))) | Out-Null
+    $commentLines.Add(('| Signal Pairs | {0} | {1} | {2} |' -f $currentSignal, $baselineSignal, (Format-Delta -Value $delta.delta.signalPairs))) | Out-Null
+    $commentLines.Add(('| Noise-Masscompile Pairs | {0} | {1} | {2} |' -f $currentNoiseMasscompile, $baselineNoiseMasscompile, (Format-Delta -Value $delta.delta.noiseMasscompilePairs))) | Out-Null
+    $commentLines.Add(('| Preview Coverage | {0} | {1} | {2} |' -f $currentPreviewCoverage, $baselinePreviewCoverage, (Format-Delta -Value $delta.delta.previewCoverage))) | Out-Null
+    $commentLines.Add(('| Timing P50 (s) | {0} | {1} | {2} |' -f $currentP50, $baselineP50, (Format-Delta -Value $delta.delta.timingP50Seconds))) | Out-Null
+    $commentLines.Add(('| Timing P95 (s) | {0} | {1} | {2} |' -f $currentP95, $baselineP95, (Format-Delta -Value $delta.delta.timingP95Seconds))) | Out-Null
+    $commentLines.Add(('| Timing Total (s) | {0} | {1} | {2} |' -f $currentTotalSeconds, $baselineTotalSeconds, (Format-Delta -Value $delta.delta.timingTotalSeconds))) | Out-Null
+    $commentLines.Add(('| Truncation Rate | {0} | {1} | {2} |' -f $currentTruncationRate, $baselineTruncationRate, (Format-Delta -Value $delta.delta.truncationRate))) | Out-Null
+} else {
+    $commentLines.Add(('- Scenario: `{0}`' -f $benchmark.scenario)) | Out-Null
+    $commentLines.Add('') | Out-Null
+    $commentLines.Add('_Baseline unavailable (need at least one previous successful benchmark for this scenario)._') | Out-Null
+}
+$commentLines.Add('') | Out-Null
+$commentLines.Add(('- Benchmark JSON: `{0}`' -f $resolvedBenchmarkPath)) | Out-Null
+$commentLines.Add(('- Delta JSON: `{0}`' -f $resolvedDeltaPath)) | Out-Null
+$commentMarkdown = $commentLines -join [Environment]::NewLine
+
+$commentMarkdown | Set-Content -LiteralPath $CommentPath -Encoding utf8
+$resolvedCommentPath = (Resolve-Path -LiteralPath $CommentPath).Path
+
+$result = [pscustomobject]@{
+    benchmarkPath = $resolvedBenchmarkPath
+    deltaPath     = $resolvedDeltaPath
+    commentPath   = $resolvedCommentPath
+    baselineCount = $baselineCount
+    deltaStatus   = [string]$delta.status
+    commentMarkdown = $commentMarkdown
+}
+
+if ($GitHubOutputPath) {
+    "benchmark_path=$resolvedBenchmarkPath" | Out-File -FilePath $GitHubOutputPath -Encoding utf8 -Append
+    "delta_path=$resolvedDeltaPath" | Out-File -FilePath $GitHubOutputPath -Encoding utf8 -Append
+    "comment_path=$resolvedCommentPath" | Out-File -FilePath $GitHubOutputPath -Encoding utf8 -Append
+    "baseline_count=$baselineCount" | Out-File -FilePath $GitHubOutputPath -Encoding utf8 -Append
+    "delta_status=$($delta.status)" | Out-File -FilePath $GitHubOutputPath -Encoding utf8 -Append
+}
+
+return $result


### PR DESCRIPTION
## Summary
- add `tools/Write-VIHistoryBenchmark.ps1` to emit per-run KPI benchmark artifacts and rolling baseline deltas
- add `tests/Write-VIHistoryBenchmark.Tests.ps1` coverage for baseline-missing and baseline-ready delta modes
- wire `tools/Test-PRVIHistorySmoke.ps1` to:
  - detect comment truncation markers
  - persist benchmark metadata in smoke summary output
  - generate benchmark + delta artifacts on each run
  - post KPI delta evidence comments to synthetic PRs and optionally issues (`-EvidenceIssueNumber`)
- document benchmark/delta artifact contracts in README + developer docs/knowledge base

## Validation
- `Invoke-Pester -Path tests/Write-VIHistoryBenchmark.Tests.ps1 -Output Detailed`
- `Invoke-Pester -Path tests/Invoke-PRVIHistory.Tests.ps1 -Output Detailed`
- `Invoke-Pester -Path tests/Summarize-PRVIHistory.Tests.ps1 -Output Detailed`
- `pwsh -NoLogo -NoProfile -File tools/Test-PRVIHistorySmoke.ps1 -DryRun -Scenario attribute`
- `pwsh -NoLogo -NoProfile -File tools/PrePush-Checks.ps1` (actionlint passes; local icon-editor fixture freshness path still emits the known warning block)

Closes #32
