### PR TITLE
fix(#87): add harness fixture and repair windows compare failure classification

### DIFF
--- a/fixtures/vi-history/pr-harness.json
+++ b/fixtures/vi-history/pr-harness.json
@@ -1,0 +1,55 @@
+{
+  "schema": "vi-history-pr-harness@v1",
+  "description": "Fixture-driven PR harness scenarios for VI history workflow traffic.",
+  "targetPath": "fixtures/vi-attr/Head.vi",
+  "maxPairs": 6,
+  "scenarios": [
+    {
+      "id": "attribute",
+      "title": "VI Attribute",
+      "mode": "attribute",
+      "source": "fixtures/vi-attr/attr/HeadAttr.vi",
+      "message": "chore: harness vi attribute update",
+      "requireDiff": true
+    },
+    {
+      "id": "fp-cosmetic",
+      "title": "Front Panel Cosmetic",
+      "mode": "attribute",
+      "source": "fixtures/vi-stage/fp-cosmetic/Head.vi",
+      "message": "chore: harness front panel cosmetic update",
+      "requireDiff": true
+    },
+    {
+      "id": "connector-pane",
+      "title": "Connector Pane",
+      "mode": "attribute",
+      "source": "fixtures/vi-stage/connector-pane/Head.vi",
+      "message": "chore: harness connector pane update",
+      "requireDiff": true
+    },
+    {
+      "id": "control-rename",
+      "title": "Control Rename",
+      "mode": "attribute",
+      "source": "fixtures/vi-stage/control-rename/Head.vi",
+      "message": "chore: harness control rename update",
+      "requireDiff": true
+    },
+    {
+      "id": "block-diagram",
+      "title": "Block Diagram Cosmetic",
+      "mode": "attribute",
+      "source": "fixtures/vi-stage/bd-cosmetic/Head.vi",
+      "message": "chore: harness block diagram cosmetic update",
+      "requireDiff": true
+    },
+    {
+      "id": "sequential",
+      "title": "Sequential Multi-Category",
+      "mode": "sequential",
+      "message": "chore: harness sequential history run",
+      "requireDiff": true
+    }
+  ]
+}

--- a/tests/PRVIHistoryHarnessFixture.Tests.ps1
+++ b/tests/PRVIHistoryHarnessFixture.Tests.ps1
@@ -1,0 +1,50 @@
+#Requires -Version 7.0
+
+Set-StrictMode -Version Latest
+
+Describe 'PR VI history harness fixture' {
+    BeforeAll {
+        $repoRoot = (Get-Location).Path
+        $script:FixturePath = Join-Path $repoRoot 'fixtures' 'vi-history' 'pr-harness.json'
+        Test-Path -LiteralPath $script:FixturePath -PathType Leaf | Should -BeTrue
+        $script:Fixture = Get-Content -LiteralPath $script:FixturePath -Raw | ConvertFrom-Json -ErrorAction Stop
+    }
+
+    It 'defines the expected harness schema and deterministic defaults' {
+        $script:Fixture.schema | Should -Be 'vi-history-pr-harness@v1'
+        $script:Fixture.targetPath | Should -Not -BeNullOrEmpty
+        ([int]$script:Fixture.maxPairs -ge 1) | Should -BeTrue
+        $script:Fixture.scenarios | Should -Not -BeNullOrEmpty
+        ($script:Fixture.scenarios.Count -ge 2) | Should -BeTrue
+    }
+
+    It 'contains diff-required scenarios with valid source paths' {
+        $repoRoot = (Get-Location).Path
+        $ids = New-Object System.Collections.Generic.HashSet[string]
+        $requireDiffCount = 0
+
+        foreach ($scenario in $script:Fixture.scenarios) {
+            [string]::IsNullOrWhiteSpace($scenario.id) | Should -BeFalse
+            [string]::IsNullOrWhiteSpace($scenario.mode) | Should -BeFalse
+            $ids.Add([string]$scenario.id) | Should -BeTrue
+
+            if ($scenario.PSObject.Properties['source']) {
+                [string]::IsNullOrWhiteSpace($scenario.source) | Should -BeFalse
+                $resolvedSource = if ([System.IO.Path]::IsPathRooted($scenario.source)) {
+                    $scenario.source
+                } else {
+                    Join-Path $repoRoot $scenario.source
+                }
+                Test-Path -LiteralPath $resolvedSource -PathType Leaf | Should -BeTrue
+            }
+
+            if ([bool]$scenario.requireDiff) {
+                $requireDiffCount += 1
+            }
+        }
+
+        ($requireDiffCount -ge 2) | Should -BeTrue
+        $ids.Contains('attribute') | Should -BeTrue
+        $ids.Contains('sequential') | Should -BeTrue
+    }
+}

--- a/tests/Run-NIWindowsContainerCompare.Tests.ps1
+++ b/tests/Run-NIWindowsContainerCompare.Tests.ps1
@@ -647,4 +647,39 @@ exit 0
       $capture.timedOut | Should -BeFalse
     }
   }
+  It 'handles non-diff non-timeout non-preflight exit codes without missing helper failures' {
+    $work = Join-Path $TestDrive 'compare-nondiff-exit2'
+    New-Item -ItemType Directory -Path $work | Out-Null
+    & $script:NewDockerStub -WorkRoot $work | Out-Null
+
+    Set-Item Env:DOCKER_STUB_LOG (Join-Path $work 'docker-log.ndjson')
+    Set-Item Env:DOCKER_STUB_OSTYPE 'windows'
+    Set-Item Env:DOCKER_STUB_IMAGE_EXISTS '1'
+    Set-Item Env:DOCKER_STUB_CONTEXT 'desktop-windows'
+    Set-Item Env:DOCKER_STUB_RUN_EXIT_CODE '2'
+    Set-Item Env:DOCKER_STUB_RUN_STDERR 'Error message: synthetic non-diff execution failure'
+
+    $baseVi = Join-Path $work 'Base.vi'
+    $headVi = Join-Path $work 'Head.vi'
+    Set-Content -LiteralPath $baseVi -Value 'base' -Encoding utf8
+    Set-Content -LiteralPath $headVi -Value 'head' -Encoding utf8
+    $reportPath = Join-Path $work 'out\compare-report.html'
+
+    $output = & pwsh -NoLogo -NoProfile -File $script:RunnerScript `
+      -BaseVi $baseVi `
+      -HeadVi $headVi `
+      -ReportPath $reportPath `
+      -RuntimeEngineReadyTimeoutSeconds 5 `
+      -RuntimeEngineReadyPollSeconds 1 2>&1
+    $LASTEXITCODE | Should -BeIn @(1, 2) -Because ($output -join "`n")
+    ($output -join "`n") | Should -Not -Match 'Resolve-RunFailureClassification'
+
+    $capturePath = Join-Path (Split-Path -Parent $reportPath) 'ni-windows-container-capture.json'
+    Test-Path -LiteralPath $capturePath | Should -BeTrue
+    $capture = Get-Content -LiteralPath $capturePath -Raw | ConvertFrom-Json
+    [string]::IsNullOrWhiteSpace([string]$capture.resultClass) | Should -BeFalse
+    [string]::IsNullOrWhiteSpace([string]$capture.gateOutcome) | Should -BeFalse
+  }
 }
+
+

--- a/tools/Run-NIWindowsContainerCompare.ps1
+++ b/tools/Run-NIWindowsContainerCompare.ps1
@@ -619,6 +619,44 @@ function Resolve-RunFailureMessage {
   return ("Container compare failed with exit code {0}." -f $ExitCode)
 }
 
+function Resolve-RunFailureClassification {
+  param(
+    [Parameter(Mandatory)][string]$Image,
+    [AllowNull()][string]$StdErr,
+    [AllowNull()][string]$StdOut,
+    [Parameter(Mandatory)][int]$ExitCode
+  )
+
+  $combined = @($StdErr, $StdOut) -join "`n"
+  $message = Resolve-RunFailureMessage -StdErr $StdErr -StdOut $StdOut -ExitCode $ExitCode
+
+  $labviewCliErrorCode = $null
+  if (-not [string]::IsNullOrWhiteSpace($combined)) {
+    $codeMatch = [regex]::Match($combined, 'Error code\s*:\s*(-?\d+)')
+    if ($codeMatch.Success) {
+      $parsedCode = 0
+      if ([int]::TryParse($codeMatch.Groups[1].Value, [ref]$parsedCode)) {
+        $labviewCliErrorCode = $parsedCode
+      }
+    }
+  }
+
+  $isStartupConnectivity = Test-CompareStartupConnectivitySignature -StdOut $StdOut -StdErr $StdErr -Message $message
+  $recommendation = if ($isStartupConnectivity) {
+    'LabVIEW CLI startup/connectivity failure detected. Retry after prelaunch and verify LabVIEWCLI.ini timeout settings.'
+  } else {
+    ('Inspect stdout/stderr artifacts and runtime logs for the failed compare in image {0}.' -f $Image)
+  }
+
+  return [pscustomobject]@{
+    status = 'error'
+    classification = 'run-error'
+    message = $message
+    labviewCliErrorCode = $labviewCliErrorCode
+    recommendation = $recommendation
+  }
+}
+
 function Parse-ContainerMeta {
   param([AllowNull()][string]$StdOut)
 
@@ -1136,3 +1174,4 @@ if ($finalExitCode -ne 0 -and -not [string]::IsNullOrWhiteSpace($capture.message
 }
 
 exit $finalExitCode
+


### PR DESCRIPTION
Implements standing-priority #87 unblockers for deterministic diff-only container history execution.\n\n## What changed\n- Added missing ixtures/vi-history/pr-harness.json required by fast-loop history scenario selection.\n- Added fixture contract test 	ests/PRVIHistoryHarnessFixture.Tests.ps1.\n- Restored missing Resolve-RunFailureClassification helper in Run-NIWindowsContainerCompare.ps1 (prevented runtime cmdlet-not-found failures on non-diff failure paths).\n- Added regression test covering non-diff/non-timeout/non-preflight exit path in Run-NIWindowsContainerCompare.Tests.ps1.\n\n## Validation\n- Invoke-Pester on targeted suites (40 tests, all passing).\n- 	ools/PrePush-Checks.ps1 -SkipIconEditorFixtureChecks (actionlint green).\n\n## Live runtime note\n- Windows-only fast-loop currently hard-stops on host Docker Desktop daemon outage (Docker Desktop is unable to start), which is infrastructure state outside this patch and correctly classified as runtime determinism failure.\n