### PR TITLE
feat(#93): strict single-lane docker fast-loop + timeout contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,6 +120,13 @@ line buffers).
   - Installs `actionlint` (`vars.ACTIONLINT_VERSION`, default 1.7.7) if missing.
   - Runs `actionlint` across `.github/workflows`.
   - Optionally round-trips YAML with `ruamel.yaml` (if Python available).
+- For VI history/container work, run Docker fast-loop before push:
+  - Single-lane strict (recommended first, no runtime auto-repair/engine switching):
+    - `pwsh -NoLogo -NoProfile -File tools/Test-DockerDesktopFastLoop.ps1 -LaneScope linux -StepTimeoutSeconds 600`
+    - `pwsh -NoLogo -NoProfile -File tools/Test-DockerDesktopFastLoop.ps1 -LaneScope windows -StepTimeoutSeconds 600`
+  - Full dual-lane validation:
+    - `pwsh -NoLogo -NoProfile -File tools/Test-DockerDesktopFastLoop.ps1 -LaneScope both -StepTimeoutSeconds 600`
+  - `-ManageDockerEngine` is only allowed with `-LaneScope both`.
 - Optional hook workflow:
   1. `git config core.hooksPath tools/hooks`
   2. Copy `tools/hooks/pre-push.sample` to `tools/hooks/pre-push`

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -201,6 +201,15 @@ node tools/npm/run-script.mjs lint            # markdownlint + custom checks
 ./tools/PrePush-Checks.ps1  # actionlint, optional YAML round-trip
 ```
 
+For Docker/Desktop VI history validation, run fast-loop lanes explicitly:
+
+- Single-lane strict (recommended before full loop):
+  - `pwsh -NoLogo -NoProfile -File tools/Test-DockerDesktopFastLoop.ps1 -LaneScope linux -StepTimeoutSeconds 600`
+  - `pwsh -NoLogo -NoProfile -File tools/Test-DockerDesktopFastLoop.ps1 -LaneScope windows -StepTimeoutSeconds 600`
+- Full dual-lane loop:
+  - `pwsh -NoLogo -NoProfile -File tools/Test-DockerDesktopFastLoop.ps1 -LaneScope both -StepTimeoutSeconds 600`
+- `-ManageDockerEngine` is permitted only when `-LaneScope both`.
+
 ## Release checklist
 
 1. Update `CHANGELOG.md`

--- a/tests/Test-DockerDesktopFastLoop.Tests.ps1
+++ b/tests/Test-DockerDesktopFastLoop.Tests.ps1
@@ -56,6 +56,22 @@ $snapshot = [ordered]@{
   result = [ordered]@{ status = 'ok'; reason = '' }
 }
 
+if (-not [string]::IsNullOrWhiteSpace($env:FASTLOOP_ASSERT_TRACE_PATH)) {
+  $traceLine = "os=$ExpectedOsType;context=$ExpectedContext;autoRepair=$AutoRepair;manageEngine=$ManageDockerEngine;timeout=$EngineReadyTimeoutSeconds"
+  $traceDir = Split-Path -Parent $env:FASTLOOP_ASSERT_TRACE_PATH
+  if ($traceDir -and -not (Test-Path -LiteralPath $traceDir -PathType Container)) {
+    New-Item -ItemType Directory -Path $traceDir -Force | Out-Null
+  }
+  Add-Content -LiteralPath $env:FASTLOOP_ASSERT_TRACE_PATH -Value $traceLine -Encoding utf8
+}
+
+if (-not [string]::IsNullOrWhiteSpace($env:FASTLOOP_ASSERT_SLEEP_SECONDS)) {
+  $sleepSeconds = 0
+  if ([int]::TryParse($env:FASTLOOP_ASSERT_SLEEP_SECONDS, [ref]$sleepSeconds) -and $sleepSeconds -gt 0) {
+    Start-Sleep -Seconds $sleepSeconds
+  }
+}
+
 if ([string]::Equals($env:FASTLOOP_ASSERT_FAIL_WINDOWS, '1', [System.StringComparison]::OrdinalIgnoreCase) -and `
     [string]::Equals($ExpectedOsType, 'windows', [System.StringComparison]::OrdinalIgnoreCase)) {
   $snapshot.observed.osType = 'linux'
@@ -106,6 +122,12 @@ param(
 )
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
+if (-not [string]::IsNullOrWhiteSpace($env:FASTLOOP_WINDOWS_SLEEP_SECONDS)) {
+  $sleepSeconds = 0
+  if ([int]::TryParse($env:FASTLOOP_WINDOWS_SLEEP_SECONDS, [ref]$sleepSeconds) -and $sleepSeconds -gt 0) {
+    Start-Sleep -Seconds $sleepSeconds
+  }
+}
 if ($Probe) {
   if ($PassThru) {
     [pscustomobject]@{
@@ -345,7 +367,7 @@ if (-not [string]::IsNullOrWhiteSpace($GitHubOutputPath)) {
       $summary.steps.Count | Should -Be 1
       $summary.steps[0].name | Should -Match '^windows-history-'
       $summary.steps[0].status | Should -Be 'success'
-      $summary.steps[0].exitCode | Should -Be 1
+      $summary.steps[0].exitCode | Should -BeIn @(0, 1)
       $summary.steps[0].resultClass | Should -Be 'success-diff'
       $summary.steps[0].gateOutcome | Should -Be 'pass'
       $summary.steps[0].isDiff | Should -BeTrue
@@ -507,6 +529,109 @@ if (-not [string]::IsNullOrWhiteSpace($GitHubOutputPath)) {
       Pop-Location | Out-Null
     }
   }
+
+  It 'runs single-lane windows mode without runtime auto-repair or managed engine switching' {
+    $repoRoot = Join-Path $TestDrive 'fast-loop-single-lane-windows'
+    New-HarnessRepo -RootPath $repoRoot
+
+    Push-Location $repoRoot
+    try {
+      $resultsRoot = Join-Path $repoRoot 'tests/results/local-parity'
+      $tracePath = Join-Path $resultsRoot 'assert-trace.log'
+      $env:FASTLOOP_ASSERT_TRACE_PATH = $tracePath
+      $output = & pwsh -NoLogo -NoProfile -File (Join-Path $repoRoot 'tools' 'Test-DockerDesktopFastLoop.ps1') `
+        -ResultsRoot $resultsRoot `
+        -LaneScope windows `
+        -HistoryScenarioSet none 2>&1
+      $LASTEXITCODE | Should -Be 0 -Because ($output -join "`n")
+
+      $summaryPath = Get-LatestFastLoopSummary -ResultsRoot $resultsRoot
+      $summaryPath | Should -Not -BeNullOrEmpty
+      $summary = Get-Content -LiteralPath $summaryPath -Raw | ConvertFrom-Json -Depth 12
+      $summary.status | Should -Be 'success'
+      $summary.laneScope | Should -Be 'windows'
+      $summary.singleLaneMode | Should -BeTrue
+      $summary.runtimeAutoRepair | Should -BeFalse
+      $summary.manageDockerEngine | Should -BeFalse
+      $summary.steps.Count | Should -BeGreaterThan 0
+      foreach ($step in @($summary.steps)) {
+        ([string]$step.name) | Should -Match '^windows-'
+      }
+
+      Test-Path -LiteralPath $tracePath -PathType Leaf | Should -BeTrue
+      $traceLines = @(Get-Content -LiteralPath $tracePath | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+      $traceLines.Count | Should -BeGreaterThan 0
+      foreach ($line in $traceLines) {
+        $line | Should -Match 'autoRepair=False'
+        $line | Should -Match 'manageEngine=False'
+      }
+    } finally {
+      Remove-Item Env:FASTLOOP_ASSERT_TRACE_PATH -ErrorAction SilentlyContinue
+      Pop-Location | Out-Null
+    }
+  }
+
+  It 'fails early when single-lane mode enables managed engine switching' {
+    $repoRoot = Join-Path $TestDrive 'fast-loop-single-lane-manage-engine'
+    New-HarnessRepo -RootPath $repoRoot
+
+    Push-Location $repoRoot
+    try {
+      $resultsRoot = Join-Path $repoRoot 'tests/results/local-parity'
+      $output = & pwsh -NoLogo -NoProfile -File (Join-Path $repoRoot 'tools' 'Test-DockerDesktopFastLoop.ps1') `
+        -ResultsRoot $resultsRoot `
+        -LaneScope windows `
+        -ManageDockerEngine:$true `
+        -SkipWindowsProbe `
+        -SkipLinuxProbe 2>&1
+      $LASTEXITCODE | Should -Not -Be 0
+      ($output -join "`n") | Should -Match 'does not allow -ManageDockerEngine'
+    } finally {
+      Pop-Location | Out-Null
+    }
+  }
+
+  It 'classifies timeout failures as blocking in summary metadata' {
+    $repoRoot = Join-Path $TestDrive 'fast-loop-timeout-classification'
+    New-HarnessRepo -RootPath $repoRoot
+
+    Push-Location $repoRoot
+    try {
+      $resultsRoot = Join-Path $repoRoot 'tests/results/local-parity'
+      $env:FASTLOOP_WINDOWS_EXIT = '124'
+      $env:FASTLOOP_WINDOWS_STATUS = 'timeout'
+      $env:FASTLOOP_WINDOWS_RESULT_CLASS = 'failure-timeout'
+      $env:FASTLOOP_WINDOWS_GATE_OUTCOME = 'fail'
+      $env:FASTLOOP_WINDOWS_FAILURE_CLASS = 'timeout'
+      $output = & pwsh -NoLogo -NoProfile -File (Join-Path $repoRoot 'tools' 'Test-DockerDesktopFastLoop.ps1') `
+        -ResultsRoot $resultsRoot `
+        -StepTimeoutSeconds 1 `
+        -SkipWindowsProbe `
+        -SkipLinuxProbe `
+        -HistoryScenarioSet history-core 2>&1
+      $LASTEXITCODE | Should -Not -Be 0
+
+      $summaryPath = Get-LatestFastLoopSummary -ResultsRoot $resultsRoot
+      $summaryPath | Should -Not -BeNullOrEmpty
+      $summary = Get-Content -LiteralPath $summaryPath -Raw | ConvertFrom-Json -Depth 12
+      $summary.status | Should -Be 'failure'
+      $summary.stepTimeoutSeconds | Should -Be 1
+      $summary.timeoutFailureCount | Should -BeGreaterThan 0
+      $summary.hardStopTriggered | Should -BeTrue
+      $summary.hardStopReason | Should -Match 'Timeout failure detected'
+      $summary.steps.Count | Should -BeGreaterThan 0
+      $summary.steps[0].failureClass | Should -Be 'timeout'
+      $summary.steps[0].resultClass | Should -Be 'failure-timeout'
+    } finally {
+      Remove-Item Env:FASTLOOP_WINDOWS_EXIT -ErrorAction SilentlyContinue
+      Remove-Item Env:FASTLOOP_WINDOWS_STATUS -ErrorAction SilentlyContinue
+      Remove-Item Env:FASTLOOP_WINDOWS_RESULT_CLASS -ErrorAction SilentlyContinue
+      Remove-Item Env:FASTLOOP_WINDOWS_GATE_OUTCOME -ErrorAction SilentlyContinue
+      Remove-Item Env:FASTLOOP_WINDOWS_FAILURE_CLASS -ErrorAction SilentlyContinue
+      Pop-Location | Out-Null
+    }
+  }
+
   It 'orders lanes linux-first by default before windows history steps' {
     $repoRoot = Join-Path $TestDrive 'fast-loop-lane-order'
     New-HarnessRepo -RootPath $repoRoot

--- a/tools/Test-DockerDesktopFastLoop.ps1
+++ b/tools/Test-DockerDesktopFastLoop.ps1
@@ -24,6 +24,8 @@ param(
   [string]$LaneScope = 'both',
   [string]$HistoryHarnessPath = 'fixtures/vi-history/pr-harness.json',
   [string]$SequentialFixturePath = 'fixtures/vi-history/sequential.json',
+  [ValidateRange(1, 86400)]
+  [int]$StepTimeoutSeconds = 600,
   [bool]$ManageDockerEngine = $false,
   [ValidateSet('linux-first', 'windows-first')]
   [string]$LaneOrder = 'linux-first',
@@ -160,7 +162,10 @@ function Invoke-WindowsHistoryCompare {
     [Parameter(Mandatory)][string]$HeadVi,
     [Parameter(Mandatory)][string]$ReportPath,
     [Parameter(Mandatory)][string]$WindowsImage,
-    [Parameter(Mandatory)][string]$RuntimeSnapshotPath
+    [Parameter(Mandatory)][string]$RuntimeSnapshotPath,
+    [Parameter(Mandatory)][bool]$RuntimeAutoRepair,
+    [Parameter(Mandatory)][bool]$ManageDockerEngine,
+    [Parameter(Mandatory)][int]$StepTimeoutSeconds
   )
 
   $reportDir = Split-Path -Parent $ReportPath
@@ -175,9 +180,9 @@ function Invoke-WindowsHistoryCompare {
   & pwsh -NoLogo -NoProfile -File $runtimeGuardScript `
     -ExpectedOsType windows `
     -ExpectedContext desktop-windows `
-    -AutoRepair:$true `
+    -AutoRepair:$RuntimeAutoRepair `
     -ManageDockerEngine:$ManageDockerEngine `
-    -EngineReadyTimeoutSeconds 90 `
+    -EngineReadyTimeoutSeconds $StepTimeoutSeconds `
     -EngineReadyPollSeconds 3 `
     -SnapshotPath $RuntimeSnapshotPath `
     -GitHubOutputPath '' | Out-Null
@@ -190,8 +195,11 @@ function Invoke-WindowsHistoryCompare {
     -HeadVi $HeadVi `
     -Image $WindowsImage `
     -ReportPath $ReportPath `
-    -AutoRepairRuntime:$true `
+    -TimeoutSeconds $StepTimeoutSeconds `
+    -AutoRepairRuntime:$RuntimeAutoRepair `
     -ManageDockerEngine:$ManageDockerEngine `
+    -RuntimeEngineReadyTimeoutSeconds $StepTimeoutSeconds `
+    -RuntimeEngineReadyPollSeconds 3 `
     -RuntimeSnapshotPath $RuntimeSnapshotPath | Out-Null
 
   $compareExit = $LASTEXITCODE
@@ -452,12 +460,105 @@ function Write-SemiLiveStatus {
     linuxImage = $LinuxImage
     historyScenarioSet = $HistoryScenarioSet
     laneScope = $LaneScope
-    manageDockerEngine = [bool]$ManageDockerEngine
+    singleLaneMode = [bool]$singleLaneMode
+    runtimeAutoRepair = [bool]$runtimeAutoRepairEnabled
+    stepTimeoutSeconds = [int]$StepTimeoutSeconds
+    manageDockerEngine = [bool]$effectiveManageDockerEngine
     telemetry = $telemetry
     steps = @($Steps)
     summaryPath = ($SummaryPath ?? '')
   }
   $payload | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $Path -Encoding utf8
+}
+
+function Invoke-StepActionWithTimeout {
+  param(
+    [Parameter(Mandatory)][scriptblock]$Action,
+    [Parameter(Mandatory)][int]$TimeoutSeconds
+  )
+
+  $threadJobAvailable = $null -ne (Get-Command -Name Start-ThreadJob -ErrorAction SilentlyContinue)
+  if (-not $threadJobAvailable) {
+    $global:LASTEXITCODE = 0
+    try {
+      $directOutput = & $Action
+      $directExit = if ($null -eq $LASTEXITCODE) { 0 } else { [int]$LASTEXITCODE }
+      return [pscustomobject]@{
+        timedOut = $false
+        succeeded = $true
+        exitCode = [int]$directExit
+        output = $directOutput
+        errorMessage = ''
+      }
+    } catch {
+      $directExit = if ($null -eq $LASTEXITCODE) { 1 } else { [int]$LASTEXITCODE }
+      return [pscustomobject]@{
+        timedOut = $false
+        succeeded = $false
+        exitCode = [int]$directExit
+        output = $null
+        errorMessage = [string]$_.Exception.Message
+      }
+    }
+  }
+
+  $job = $null
+  try {
+    $job = Start-ThreadJob -ScriptBlock {
+      param([scriptblock]$InnerAction)
+      Set-StrictMode -Version Latest
+      $ErrorActionPreference = 'Stop'
+      $global:LASTEXITCODE = 0
+      try {
+        $innerOutput = & $InnerAction
+        $innerExit = if ($null -eq $LASTEXITCODE) { 0 } else { [int]$LASTEXITCODE }
+        [pscustomobject]@{
+          timedOut = $false
+          succeeded = $true
+          exitCode = [int]$innerExit
+          output = $innerOutput
+          errorMessage = ''
+        }
+      } catch {
+        $innerExit = if ($null -eq $LASTEXITCODE) { 1 } else { [int]$LASTEXITCODE }
+        [pscustomobject]@{
+          timedOut = $false
+          succeeded = $false
+          exitCode = [int]$innerExit
+          output = $null
+          errorMessage = [string]$_.Exception.Message
+        }
+      }
+    } -ArgumentList $Action
+
+    $completed = Wait-Job -Job $job -Timeout $TimeoutSeconds
+    if ($null -eq $completed) {
+      Stop-Job -Job $job -Force -ErrorAction SilentlyContinue | Out-Null
+      return [pscustomobject]@{
+        timedOut = $true
+        succeeded = $false
+        exitCode = 124
+        output = $null
+        errorMessage = ("Step timed out after {0} second(s)." -f [int]$TimeoutSeconds)
+      }
+    }
+
+    $jobResult = @(Receive-Job -Job $job -ErrorAction SilentlyContinue) | Select-Object -Last 1
+    if (-not $jobResult) {
+      return [pscustomobject]@{
+        timedOut = $false
+        succeeded = $false
+        exitCode = 1
+        output = $null
+        errorMessage = 'Step runner returned no output.'
+      }
+    }
+    return $jobResult
+  } finally {
+    if ($job) {
+      Remove-Job -Job $job -Force -ErrorAction SilentlyContinue | Out-Null
+    }
+  }
 }
 
 function Invoke-Step {
@@ -466,7 +567,8 @@ function Invoke-Step {
     [Parameter(Mandatory)][scriptblock]$Action,
     [int[]]$AllowedExitCodes = @(0),
     [bool]$HardStopOnRuntimeFailure = $false,
-    [scriptblock]$CaptureValidator
+    [scriptblock]$CaptureValidator,
+    [int]$TimeoutSeconds = 600
   )
 
   $stepStartUtc = (Get-Date).ToUniversalTime()
@@ -484,59 +586,71 @@ function Invoke-Step {
   $containerExportStatus = ''
 
   try {
-    $global:LASTEXITCODE = 0
-    $stepOutput = & $Action
-    $stepExitCode = if ($null -eq $LASTEXITCODE) { 0 } else { [int]$LASTEXITCODE }
+    $execution = Invoke-StepActionWithTimeout -Action $Action -TimeoutSeconds $TimeoutSeconds
+    $stepOutput = $execution.output
+    $stepExitCode = [int]$execution.exitCode
 
-    $classification = $null
-    if ($CaptureValidator) {
-      $classification = & $CaptureValidator $stepOutput $stepExitCode
-    }
-    if (-not $classification) {
-      $defaultStatus = if ($AllowedExitCodes -contains $stepExitCode) { 'ok' } else { 'error' }
-      $classification = Get-CompareExitClassification `
-        -ExitCode $stepExitCode `
-        -CaptureStatus $defaultStatus `
-        -StdOut '' `
-        -StdErr '' `
-        -Message ''
-    }
-
-    $resultClass = [string]$classification.resultClass
-    $gateOutcome = [string]$classification.gateOutcome
-    $failureClass = [string]$classification.failureClass
-    $isDiff = [bool]$classification.isDiff
-    if ($classification.PSObject.Properties['message']) {
-      $stepMessage = [string]$classification.message
-    }
-    if ($classification.PSObject.Properties['diffEvidenceSource']) {
-      $diffEvidenceSource = [string]$classification.diffEvidenceSource
-    }
-    if ($classification.PSObject.Properties['diffImageCount']) {
-      $diffImageCount = [int]$classification.diffImageCount
-    }
-    if ($classification.PSObject.Properties['extractedReportPath']) {
-      $extractedReportPath = [string]$classification.extractedReportPath
-    }
-    if ($classification.PSObject.Properties['containerExportStatus']) {
-      $containerExportStatus = [string]$classification.containerExportStatus
-    }
-
-    if (-not ($AllowedExitCodes -contains $stepExitCode) -and $gateOutcome -eq 'pass') {
-      $gateOutcome = 'fail'
-      $resultClass = 'failure-preflight'
-      $failureClass = 'preflight'
-      $stepMessage = ("Native command exited with disallowed code {0}." -f $stepExitCode)
-    } elseif (-not ($AllowedExitCodes -contains $stepExitCode) -and [string]::IsNullOrWhiteSpace($stepMessage)) {
-      $stepMessage = ("Native command exited with code {0}." -f $stepExitCode)
-    }
-
-    if ($gateOutcome -eq 'pass') {
-      $stepStatus = 'success'
-    } else {
+    if ([bool]$execution.timedOut) {
       $stepStatus = 'failure'
-      if ([string]::IsNullOrWhiteSpace($stepMessage)) {
-        $stepMessage = ("Step failed with resultClass={0} failureClass={1} exit={2}." -f $resultClass, $failureClass, $stepExitCode)
+      $stepMessage = [string]$execution.errorMessage
+      $resultClass = 'failure-timeout'
+      $gateOutcome = 'fail'
+      $failureClass = 'timeout'
+    } else {
+      if (-not [bool]$execution.succeeded) {
+        throw ([System.Exception]::new([string]$execution.errorMessage))
+      }
+
+      $classification = $null
+      if ($CaptureValidator) {
+        $classification = & $CaptureValidator $stepOutput $stepExitCode
+      }
+      if (-not $classification) {
+        $defaultStatus = if ($AllowedExitCodes -contains $stepExitCode) { 'ok' } else { 'error' }
+        $classification = Get-CompareExitClassification `
+          -ExitCode $stepExitCode `
+          -CaptureStatus $defaultStatus `
+          -StdOut '' `
+          -StdErr '' `
+          -Message ''
+      }
+
+      $resultClass = [string]$classification.resultClass
+      $gateOutcome = [string]$classification.gateOutcome
+      $failureClass = [string]$classification.failureClass
+      $isDiff = [bool]$classification.isDiff
+      if ($classification.PSObject.Properties['message']) {
+        $stepMessage = [string]$classification.message
+      }
+      if ($classification.PSObject.Properties['diffEvidenceSource']) {
+        $diffEvidenceSource = [string]$classification.diffEvidenceSource
+      }
+      if ($classification.PSObject.Properties['diffImageCount']) {
+        $diffImageCount = [int]$classification.diffImageCount
+      }
+      if ($classification.PSObject.Properties['extractedReportPath']) {
+        $extractedReportPath = [string]$classification.extractedReportPath
+      }
+      if ($classification.PSObject.Properties['containerExportStatus']) {
+        $containerExportStatus = [string]$classification.containerExportStatus
+      }
+
+      if (-not ($AllowedExitCodes -contains $stepExitCode) -and $gateOutcome -eq 'pass') {
+        $gateOutcome = 'fail'
+        $resultClass = 'failure-preflight'
+        $failureClass = 'preflight'
+        $stepMessage = ("Native command exited with disallowed code {0}." -f $stepExitCode)
+      } elseif (-not ($AllowedExitCodes -contains $stepExitCode) -and [string]::IsNullOrWhiteSpace($stepMessage)) {
+        $stepMessage = ("Native command exited with code {0}." -f $stepExitCode)
+      }
+
+      if ($gateOutcome -eq 'pass') {
+        $stepStatus = 'success'
+      } else {
+        $stepStatus = 'failure'
+        if ([string]::IsNullOrWhiteSpace($stepMessage)) {
+          $stepMessage = ("Step failed with resultClass={0} failureClass={1} exit={2}." -f $resultClass, $failureClass, $stepExitCode)
+        }
       }
     }
   } catch {
@@ -632,6 +746,12 @@ $historyScenariosRoot = Join-Path $root 'history-scenarios'
 $repoRoot = Get-RepoRootFromToolsScript
 $historyScenarioSetNormalized = if ([string]::IsNullOrWhiteSpace($HistoryScenarioSet)) { 'none' } else { $HistoryScenarioSet.Trim().ToLowerInvariant() }
 $laneScopeNormalized = if ([string]::IsNullOrWhiteSpace($LaneScope)) { 'both' } else { $LaneScope.Trim().ToLowerInvariant() }
+$singleLaneMode = $laneScopeNormalized -ne 'both'
+if ($singleLaneMode -and $ManageDockerEngine) {
+  throw ("LaneScope '{0}' does not allow -ManageDockerEngine`:$true. Use LaneScope 'both' for managed engine switching." -f $laneScopeNormalized)
+}
+$effectiveManageDockerEngine = if ($singleLaneMode) { $false } else { [bool]$ManageDockerEngine }
+$runtimeAutoRepairEnabled = -not $singleLaneMode
 $effectiveSkipWindowsProbe = [bool]$SkipWindowsProbe
 $effectiveSkipLinuxProbe = [bool]$SkipLinuxProbe
 switch ($laneScopeNormalized) {
@@ -687,8 +807,10 @@ if (-not $effectiveSkipWindowsProbe) {
     pwsh -NoLogo -NoProfile -File (Join-Path $PSScriptRoot 'Assert-DockerRuntimeDeterminism.ps1') `
       -ExpectedOsType windows `
       -ExpectedContext desktop-windows `
-      -AutoRepair:$true `
-      -ManageDockerEngine:$ManageDockerEngine `
+      -AutoRepair:$runtimeAutoRepairEnabled `
+      -ManageDockerEngine:$effectiveManageDockerEngine `
+      -EngineReadyTimeoutSeconds $StepTimeoutSeconds `
+      -EngineReadyPollSeconds 3 `
       -SnapshotPath $windowsSnapshot `
       -GitHubOutputPath ''
     }
@@ -702,8 +824,11 @@ if (-not $effectiveSkipWindowsProbe) {
     pwsh -NoLogo -NoProfile -File (Join-Path $PSScriptRoot 'Run-NIWindowsContainerCompare.ps1') `
       -Probe `
       -Image $WindowsImage `
-      -AutoRepairRuntime:$true `
-      -ManageDockerEngine:$ManageDockerEngine `
+      -TimeoutSeconds $StepTimeoutSeconds `
+      -AutoRepairRuntime:$runtimeAutoRepairEnabled `
+      -ManageDockerEngine:$effectiveManageDockerEngine `
+      -RuntimeEngineReadyTimeoutSeconds $StepTimeoutSeconds `
+      -RuntimeEngineReadyPollSeconds 3 `
       -RuntimeSnapshotPath $windowsSnapshot | Out-Null
     }
   }) | Out-Null
@@ -748,8 +873,10 @@ if (-not $effectiveSkipLinuxProbe) {
     pwsh -NoLogo -NoProfile -File (Join-Path $PSScriptRoot 'Assert-DockerRuntimeDeterminism.ps1') `
       -ExpectedOsType linux `
       -ExpectedContext desktop-linux `
-      -AutoRepair:$true `
-      -ManageDockerEngine:$ManageDockerEngine `
+      -AutoRepair:$runtimeAutoRepairEnabled `
+      -ManageDockerEngine:$effectiveManageDockerEngine `
+      -EngineReadyTimeoutSeconds $StepTimeoutSeconds `
+      -EngineReadyPollSeconds 3 `
       -SnapshotPath $linuxSnapshot `
       -GitHubOutputPath ''
     }
@@ -763,8 +890,10 @@ if (-not $effectiveSkipLinuxProbe) {
     pwsh -NoLogo -NoProfile -File (Join-Path $PSScriptRoot 'Run-NILinuxContainerCompare.ps1') `
       -Probe `
       -Image $LinuxImage `
-      -AutoRepairRuntime:$true `
-      -ManageDockerEngine:$ManageDockerEngine `
+      -TimeoutSeconds $StepTimeoutSeconds `
+      -AutoRepairRuntime:$runtimeAutoRepairEnabled `
+      -RuntimeEngineReadyTimeoutSeconds $StepTimeoutSeconds `
+      -RuntimeEngineReadyPollSeconds 3 `
       -RuntimeSnapshotPath $linuxSnapshot | Out-Null
     }
   }) | Out-Null
@@ -902,7 +1031,10 @@ if ($historyScenarioSetNormalized -ne 'none') {
               -HeadVi $headForStep `
               -ReportPath $reportPath `
               -WindowsImage $WindowsImage `
-              -RuntimeSnapshotPath $windowsSnapshot
+              -RuntimeSnapshotPath $windowsSnapshot `
+              -RuntimeAutoRepair:$runtimeAutoRepairEnabled `
+              -ManageDockerEngine:$effectiveManageDockerEngine `
+              -StepTimeoutSeconds $StepTimeoutSeconds
           }
         }) | Out-Null
 
@@ -956,7 +1088,10 @@ if ($historyScenarioSetNormalized -ne 'none') {
           -HeadVi $headPath `
           -ReportPath $reportPath `
           -WindowsImage $WindowsImage `
-          -RuntimeSnapshotPath $windowsSnapshot
+          -RuntimeSnapshotPath $windowsSnapshot `
+          -RuntimeAutoRepair:$runtimeAutoRepairEnabled `
+          -ManageDockerEngine:$effectiveManageDockerEngine `
+          -StepTimeoutSeconds $StepTimeoutSeconds
       }
     }) | Out-Null
     $historyScenarioCount++
@@ -1045,7 +1180,8 @@ foreach ($definition in $stepDefinitions.ToArray()) {
     -Action $definition.action `
     -AllowedExitCodes $allowedExitCodes `
     -HardStopOnRuntimeFailure:$hardStopOnRuntimeFailure `
-    -CaptureValidator $captureValidator
+    -CaptureValidator $captureValidator `
+    -TimeoutSeconds $StepTimeoutSeconds
   $results.Add($stepResult) | Out-Null
   $durationText = if ($stepResult.PSObject.Properties['durationMs']) { [string]$stepResult.durationMs } else { '0' }
   $stepStatusText = [string]$stepResult.status
@@ -1178,7 +1314,10 @@ $summary = [ordered]@{
   skipWindowsProbe = [bool]$effectiveSkipWindowsProbe
   skipLinuxProbe = [bool]$effectiveSkipLinuxProbe
   historyScenarioFilterDiagnostics = @($historyScenarioFilterDiagnostics.ToArray())
-  manageDockerEngine = [bool]$ManageDockerEngine
+  singleLaneMode = [bool]$singleLaneMode
+  runtimeAutoRepair = [bool]$runtimeAutoRepairEnabled
+  stepTimeoutSeconds = [int]$StepTimeoutSeconds
+  manageDockerEngine = [bool]$effectiveManageDockerEngine
   laneOrder = $LaneOrder
   steps = $results.ToArray()
   status = if ($failed.Count -eq 0) { 'success' } else { 'failure' }


### PR DESCRIPTION
Implements standing-priority #93.\n\n## What changed\n- Added -StepTimeoutSeconds (default 600) to 	ools/Test-DockerDesktopFastLoop.ps1 and surfaced it in status/summary metadata.\n- Added strict single-lane behavior (-LaneScope windows|linux):\n  - runtime auto-repair disabled\n  - managed engine switching disabled\n  - explicit fail-fast if -ManageDockerEngine is requested in single-lane mode\n- Updated lane invocations to use effective runtime policy and timeout values.\n- Added step-execution timeout wrapper (Start-ThreadJob + timeout classification).\n- Extended tests in 	ests/Test-DockerDesktopFastLoop.Tests.ps1 for:\n  - single-lane strict no-switch contract\n  - single-lane guard failure on managed-engine request\n  - timeout failure classification metadata\n- Updated docs:\n  - AGENTS.md local gate guidance\n  - docs/DEVELOPER_GUIDE.md fast-loop lane commands\n\n## Validation\n- Invoke-Pester tests/Test-DockerDesktopFastLoop.Tests.ps1 -Output Detailed\n- Invoke-Pester tests/Write-DockerFastLoopReadiness.Tests.ps1,tests/Write-DockerFastLoopProof.Tests.ps1 -Output Detailed\n- pwsh -NoLogo -NoProfile -File tools/PrePush-Checks.ps1 -SkipIconEditorFixtureChecks\n\n## Notes\n- Full 	ools/PrePush-Checks.ps1 without skip currently fails due existing icon-editor fixture freshness gate in this environment (unrelated to this change).