### PR TITLE
fix(#95): normalize fast-loop exit telemetry for failure tuples

### DIFF
--- a/tests/Test-DockerDesktopFastLoop.Tests.ps1
+++ b/tests/Test-DockerDesktopFastLoop.Tests.ps1
@@ -591,14 +591,14 @@ if (-not [string]::IsNullOrWhiteSpace($GitHubOutputPath)) {
     }
   }
 
-  It 'classifies timeout failures as blocking in summary metadata' {
+  It 'normalizes conflicting timeout classification to non-zero exit telemetry' {
     $repoRoot = Join-Path $TestDrive 'fast-loop-timeout-classification'
     New-HarnessRepo -RootPath $repoRoot
 
     Push-Location $repoRoot
     try {
       $resultsRoot = Join-Path $repoRoot 'tests/results/local-parity'
-      $env:FASTLOOP_WINDOWS_EXIT = '124'
+      $env:FASTLOOP_WINDOWS_EXIT = '0'
       $env:FASTLOOP_WINDOWS_STATUS = 'timeout'
       $env:FASTLOOP_WINDOWS_RESULT_CLASS = 'failure-timeout'
       $env:FASTLOOP_WINDOWS_GATE_OUTCOME = 'fail'
@@ -622,6 +622,64 @@ if (-not [string]::IsNullOrWhiteSpace($GitHubOutputPath)) {
       $summary.steps.Count | Should -BeGreaterThan 0
       $summary.steps[0].failureClass | Should -Be 'timeout'
       $summary.steps[0].resultClass | Should -Be 'failure-timeout'
+      $summary.steps[0].exitCode | Should -Be 124
+      $summary.steps[0].gateOutcome | Should -Be 'fail'
+    } finally {
+      Remove-Item Env:FASTLOOP_WINDOWS_EXIT -ErrorAction SilentlyContinue
+      Remove-Item Env:FASTLOOP_WINDOWS_STATUS -ErrorAction SilentlyContinue
+      Remove-Item Env:FASTLOOP_WINDOWS_RESULT_CLASS -ErrorAction SilentlyContinue
+      Remove-Item Env:FASTLOOP_WINDOWS_GATE_OUTCOME -ErrorAction SilentlyContinue
+      Remove-Item Env:FASTLOOP_WINDOWS_FAILURE_CLASS -ErrorAction SilentlyContinue
+      Pop-Location | Out-Null
+    }
+  }
+
+  It 'normalizes conflicting runtime and tool classified failures to deterministic exits' {
+    $repoRoot = Join-Path $TestDrive 'fast-loop-failure-exit-normalization'
+    New-HarnessRepo -RootPath $repoRoot
+
+    Push-Location $repoRoot
+    try {
+      $resultsRoot = Join-Path $repoRoot 'tests/results/local-parity'
+      $cases = @(
+        @{
+          Name = 'runtime'
+          ResultClass = 'failure-runtime'
+          FailureClass = 'runtime-determinism'
+          ExpectedExit = 2
+        },
+        @{
+          Name = 'tool'
+          ResultClass = 'failure-tool'
+          FailureClass = 'cli/tool'
+          ExpectedExit = 1
+        }
+      )
+
+      foreach ($case in $cases) {
+        $env:FASTLOOP_WINDOWS_EXIT = '0'
+        $env:FASTLOOP_WINDOWS_STATUS = 'error'
+        $env:FASTLOOP_WINDOWS_RESULT_CLASS = $case.ResultClass
+        $env:FASTLOOP_WINDOWS_GATE_OUTCOME = 'fail'
+        $env:FASTLOOP_WINDOWS_FAILURE_CLASS = $case.FailureClass
+
+        $output = & pwsh -NoLogo -NoProfile -File (Join-Path $repoRoot 'tools' 'Test-DockerDesktopFastLoop.ps1') `
+          -ResultsRoot $resultsRoot `
+          -SkipWindowsProbe `
+          -SkipLinuxProbe `
+          -HistoryScenarioSet history-core 2>&1
+        $LASTEXITCODE | Should -Not -Be 0 -Because ($output -join "`n")
+
+        $summaryPath = Get-LatestFastLoopSummary -ResultsRoot $resultsRoot
+        $summaryPath | Should -Not -BeNullOrEmpty
+        $summary = Get-Content -LiteralPath $summaryPath -Raw | ConvertFrom-Json -Depth 12
+        $summary.steps.Count | Should -BeGreaterThan 0
+        $step = $summary.steps[0]
+        $step.resultClass | Should -Be $case.ResultClass -Because $case.Name
+        $step.failureClass | Should -Be $case.FailureClass -Because $case.Name
+        $step.gateOutcome | Should -Be 'fail' -Because $case.Name
+        $step.exitCode | Should -Be $case.ExpectedExit -Because $case.Name
+      }
     } finally {
       Remove-Item Env:FASTLOOP_WINDOWS_EXIT -ErrorAction SilentlyContinue
       Remove-Item Env:FASTLOOP_WINDOWS_STATUS -ErrorAction SilentlyContinue

--- a/tools/Test-DockerDesktopFastLoop.ps1
+++ b/tools/Test-DockerDesktopFastLoop.ps1
@@ -561,6 +561,39 @@ function Invoke-StepActionWithTimeout {
   }
 }
 
+function Get-NormalizedStepExitCode {
+  param(
+    [Parameter(Mandatory)][int]$ExitCode,
+    [AllowNull()][AllowEmptyString()][string]$ResultClass,
+    [AllowNull()][AllowEmptyString()][string]$GateOutcome,
+    [AllowNull()][AllowEmptyString()][string]$FailureClass
+  )
+
+  $normalizedExit = [int]$ExitCode
+  $gate = if ([string]::IsNullOrWhiteSpace($GateOutcome)) { '' } else { $GateOutcome.Trim().ToLowerInvariant() }
+  $result = if ([string]::IsNullOrWhiteSpace($ResultClass)) { '' } else { $ResultClass.Trim().ToLowerInvariant() }
+  $failure = if ([string]::IsNullOrWhiteSpace($FailureClass)) { '' } else { $FailureClass.Trim().ToLowerInvariant() }
+
+  if ($gate -ne 'fail' -or $normalizedExit -ne 0) {
+    return $normalizedExit
+  }
+
+  switch ($failure) {
+    'timeout' { return 124 }
+    'runtime-determinism' { return 2 }
+    'preflight' { return 2 }
+    'startup-connectivity' { return 1 }
+    'cli/tool' { return 1 }
+  }
+
+  switch ($result) {
+    'failure-timeout' { return 124 }
+    'failure-runtime' { return 2 }
+    'failure-preflight' { return 2 }
+    default { return 1 }
+  }
+}
+
 function Invoke-Step {
   param(
     [Parameter(Mandatory)][string]$Name,
@@ -634,6 +667,11 @@ function Invoke-Step {
       if ($classification.PSObject.Properties['containerExportStatus']) {
         $containerExportStatus = [string]$classification.containerExportStatus
       }
+      $stepExitCode = Get-NormalizedStepExitCode `
+        -ExitCode $stepExitCode `
+        -ResultClass $resultClass `
+        -GateOutcome $gateOutcome `
+        -FailureClass $failureClass
 
       if (-not ($AllowedExitCodes -contains $stepExitCode) -and $gateOutcome -eq 'pass') {
         $gateOutcome = 'fail'


### PR DESCRIPTION
## Summary
- normalize fast-loop step exit telemetry when helper classification indicates blocking failure but helper exit is  
- enforce deterministic non-zero telemetry for failure classes (	imeout, untime-determinism, preflight, startup-connectivity, cli/tool)
- keep diff-as-pass and runtime hard-stop behavior unchanged

## Changes
- add Get-NormalizedStepExitCode to 	ools/Test-DockerDesktopFastLoop.ps1
- apply normalization before exit-code allowlist checks so failure tuples are internally consistent
- expand 	ests/Test-DockerDesktopFastLoop.Tests.ps1:
  - conflicting timeout classification (xit=0) now asserts normalized xitCode=124
  - conflicting runtime/tool classification (xit=0) asserts normalized exits (2 / 1)

## Validation
- Invoke-Pester -Path tests/Test-DockerDesktopFastLoop.Tests.ps1 -Output Detailed
- Invoke-Pester -Path tests/Write-DockerFastLoopReadiness.Tests.ps1,tests/Write-DockerFastLoopProof.Tests.ps1 -Output Detailed
- pwsh -File tools/PrePush-Checks.ps1 -SkipIconEditorFixtureChecks

Closes #95
