### PR TITLE
fix(#97): add GH token fallback to priority policy auth

### DIFF
--- a/tools/priority/__tests__/check-policy-apply.test.mjs
+++ b/tools/priority/__tests__/check-policy-apply.test.mjs
@@ -588,7 +588,8 @@ test('priority:policy skips when repository settings require admin access', asyn
     argv: ['node', 'check-policy.mjs'],
     env: {
       ...process.env,
-      GITHUB_REPOSITORY: 'test-org/test-repo'
+      GITHUB_REPOSITORY: 'test-org/test-repo',
+      GITHUB_TOKEN: 'fake-token'
     },
     fetchFn: fetchMock,
     execSyncFn: () => {
@@ -604,4 +605,225 @@ test('priority:policy skips when repository settings require admin access', asyn
     'skip message expected when admin permissions unavailable'
   );
   assert.deepEqual(errorMessages, []);
+});
+
+test('priority:policy keeps GH_TOKEN when valid and does not fallback', async () => {
+  const repoUrl = 'https://api.github.com/repos/test-org/test-repo';
+  const rulesetDevelopUrl = `${repoUrl}/rulesets/8811898`;
+  const rulesetMainUrl = `${repoUrl}/rulesets/8614140`;
+  const rulesetReleaseUrl = `${repoUrl}/rulesets/8614172`;
+  const repoState = {
+    permissions: {
+      admin: false
+    }
+  };
+  const rulesetDevelop = {
+    id: 8811898,
+    name: 'develop',
+    target: 'branch',
+    enforcement: 'active',
+    conditions: { ref_name: { include: ['refs/heads/develop'], exclude: [] } },
+    bypass_actors: [],
+    rules: []
+  };
+  const rulesetMain = {
+    id: 8614140,
+    name: 'main',
+    target: 'branch',
+    enforcement: 'active',
+    conditions: { ref_name: { include: ['refs/heads/main'], exclude: [] } },
+    bypass_actors: [],
+    rules: []
+  };
+  const rulesetRelease = {
+    id: 8614172,
+    name: 'release',
+    target: 'branch',
+    enforcement: 'active',
+    conditions: { ref_name: { include: ['refs/heads/release/*'], exclude: [] } },
+    bypass_actors: [],
+    rules: []
+  };
+
+  const tokensSeen = [];
+  const fetchMock = async (url, options = {}) => {
+    const method = options.method ?? 'GET';
+    const authHeader = options.headers?.Authorization ?? '';
+    const token = String(authHeader).replace(/^Bearer\s+/i, '');
+    tokensSeen.push(token);
+    if (token !== 'gh-valid') {
+      return createResponse({ message: 'Bad credentials', status: '401' }, 401, 'Unauthorized');
+    }
+
+    if (method === 'GET' && url === repoUrl) {
+      return createResponse(repoState);
+    }
+    if (method === 'GET' && url === rulesetDevelopUrl) {
+      return createResponse(rulesetDevelop);
+    }
+    if (method === 'GET' && url === rulesetMainUrl) {
+      return createResponse(rulesetMain);
+    }
+    if (method === 'GET' && url === rulesetReleaseUrl) {
+      return createResponse(rulesetRelease);
+    }
+    throw new Error(`Unexpected request ${method} ${url}`);
+  };
+
+  const logMessages = [];
+  const errorMessages = [];
+  const code = await run({
+    argv: ['node', 'check-policy.mjs'],
+    env: {
+      ...process.env,
+      GITHUB_REPOSITORY: 'test-org/test-repo',
+      GH_TOKEN: 'gh-valid',
+      GITHUB_TOKEN: 'github-valid'
+    },
+    fetchFn: fetchMock,
+    execSyncFn: () => {
+      throw new Error('execSync should not be called when GITHUB_REPOSITORY is set');
+    },
+    log: (msg) => logMessages.push(msg),
+    error: (msg) => errorMessages.push(msg)
+  });
+
+  assert.equal(code, 0, 'run should exit cleanly with valid GH_TOKEN');
+  assert.ok(tokensSeen.length > 0, 'expected at least one authenticated request');
+  assert.ok(tokensSeen.every((token) => token === 'gh-valid'), 'requests should remain on GH_TOKEN');
+  assert.ok(
+    logMessages.some((msg) => msg.includes('auth source: GH_TOKEN')),
+    'auth source log should report GH_TOKEN'
+  );
+  assert.ok(
+    !logMessages.some((msg) => msg.includes('auth fallback:')),
+    'fallback should not occur when GH_TOKEN is valid'
+  );
+  assert.deepEqual(errorMessages, []);
+});
+
+test('priority:policy falls back from GH_TOKEN to GITHUB_TOKEN on 401', async () => {
+  const repoUrl = 'https://api.github.com/repos/test-org/test-repo';
+  const rulesetDevelopUrl = `${repoUrl}/rulesets/8811898`;
+  const rulesetMainUrl = `${repoUrl}/rulesets/8614140`;
+  const rulesetReleaseUrl = `${repoUrl}/rulesets/8614172`;
+  const repoState = {
+    permissions: {
+      admin: false
+    }
+  };
+  const rulesetDevelop = {
+    id: 8811898,
+    name: 'develop',
+    target: 'branch',
+    enforcement: 'active',
+    conditions: { ref_name: { include: ['refs/heads/develop'], exclude: [] } },
+    bypass_actors: [],
+    rules: []
+  };
+  const rulesetMain = {
+    id: 8614140,
+    name: 'main',
+    target: 'branch',
+    enforcement: 'active',
+    conditions: { ref_name: { include: ['refs/heads/main'], exclude: [] } },
+    bypass_actors: [],
+    rules: []
+  };
+  const rulesetRelease = {
+    id: 8614172,
+    name: 'release',
+    target: 'branch',
+    enforcement: 'active',
+    conditions: { ref_name: { include: ['refs/heads/release/*'], exclude: [] } },
+    bypass_actors: [],
+    rules: []
+  };
+
+  const tokensSeen = [];
+  const fetchMock = async (url, options = {}) => {
+    const method = options.method ?? 'GET';
+    const authHeader = options.headers?.Authorization ?? '';
+    const token = String(authHeader).replace(/^Bearer\s+/i, '');
+    tokensSeen.push(token);
+
+    if (token === 'gh-stale') {
+      return createResponse({ message: 'Bad credentials', status: '401' }, 401, 'Unauthorized');
+    }
+    if (token !== 'github-valid') {
+      return createResponse({ message: 'Bad credentials', status: '401' }, 401, 'Unauthorized');
+    }
+
+    if (method === 'GET' && url === repoUrl) {
+      return createResponse(repoState);
+    }
+    if (method === 'GET' && url === rulesetDevelopUrl) {
+      return createResponse(rulesetDevelop);
+    }
+    if (method === 'GET' && url === rulesetMainUrl) {
+      return createResponse(rulesetMain);
+    }
+    if (method === 'GET' && url === rulesetReleaseUrl) {
+      return createResponse(rulesetRelease);
+    }
+    throw new Error(`Unexpected request ${method} ${url}`);
+  };
+
+  const logMessages = [];
+  const errorMessages = [];
+  const code = await run({
+    argv: ['node', 'check-policy.mjs'],
+    env: {
+      ...process.env,
+      GITHUB_REPOSITORY: 'test-org/test-repo',
+      GH_TOKEN: 'gh-stale',
+      GITHUB_TOKEN: 'github-valid'
+    },
+    fetchFn: fetchMock,
+    execSyncFn: () => {
+      throw new Error('execSync should not be called when GITHUB_REPOSITORY is set');
+    },
+    log: (msg) => logMessages.push(msg),
+    error: (msg) => errorMessages.push(msg)
+  });
+
+  assert.equal(code, 0, 'run should succeed after auth fallback');
+  assert.ok(tokensSeen.includes('gh-stale'), 'GH token should be attempted first');
+  assert.ok(tokensSeen.includes('github-valid'), 'GITHUB token should be used as fallback');
+  assert.ok(
+    logMessages.some((msg) => msg.includes('auth fallback: GH_TOKEN -> GITHUB_TOKEN')),
+    'fallback log should report GH_TOKEN -> GITHUB_TOKEN'
+  );
+  assert.deepEqual(errorMessages, []);
+});
+
+test('priority:policy fails with actionable message when GH_TOKEN 401 has no fallback', async () => {
+  const fetchMock = async () => createResponse({ message: 'Bad credentials', status: '401' }, 401, 'Unauthorized');
+  const logMessages = [];
+  const errorMessages = [];
+
+  await assert.rejects(
+    () =>
+      run({
+        argv: ['node', 'check-policy.mjs'],
+        env: {
+          ...process.env,
+          GITHUB_REPOSITORY: 'test-org/test-repo',
+          GH_TOKEN: 'gh-stale',
+          GITHUB_TOKEN: ''
+        },
+        fetchFn: fetchMock,
+        execSyncFn: () => {
+          throw new Error('execSync should not be called when GITHUB_REPOSITORY is set');
+        },
+        log: (msg) => logMessages.push(msg),
+        error: (msg) => errorMessages.push(msg)
+      }),
+    /No fallback token available/
+  );
+
+  assert.ok(
+    logMessages.some((msg) => msg.includes('auth source: GH_TOKEN')),
+    'auth source log should report GH_TOKEN'
+  );
 });

--- a/tools/priority/check-policy.mjs
+++ b/tools/priority/check-policy.mjs
@@ -110,43 +110,64 @@ function getRepoFromEnv(env = process.env, execSyncFn = execSync) {
 }
 
 async function resolveToken(env = process.env, { readFileFn = readFile, accessFn = access, logFn = console.log } = {}) {
-  if (env.GH_TOKEN && env.GH_TOKEN.trim()) {
-    logFn('[policy] auth source: GH_TOKEN');
-    return { token: env.GH_TOKEN.trim(), source: 'GH_TOKEN' };
+  const candidates = await resolveTokenCandidates(env, { readFileFn, accessFn });
+  if (candidates.length === 0) {
+    return null;
   }
+  logFn(`[policy] auth source: ${candidates[0].source}`);
+  return candidates[0];
+}
 
-  if (env.GITHUB_TOKEN && env.GITHUB_TOKEN.trim()) {
-    logFn('[policy] auth source: GITHUB_TOKEN');
-    return { token: env.GITHUB_TOKEN.trim(), source: 'GITHUB_TOKEN' };
-  }
+async function resolveTokenCandidates(
+  env = process.env,
+  { readFileFn = readFile, accessFn = access } = {}
+) {
+  const candidates = [];
+  const seen = new Set();
+  const addCandidate = (tokenValue, source) => {
+    if (!tokenValue || !tokenValue.trim()) {
+      return;
+    }
+    const token = tokenValue.trim();
+    const key = `${source}:${token}`;
+    if (seen.has(key)) {
+      return;
+    }
+    candidates.push({ token, source });
+    seen.add(key);
+  };
 
-  if (env.GH_ENTERPRISE_TOKEN && env.GH_ENTERPRISE_TOKEN.trim()) {
-    logFn('[policy] auth source: GH_ENTERPRISE_TOKEN');
-    return { token: env.GH_ENTERPRISE_TOKEN.trim(), source: 'GH_ENTERPRISE_TOKEN' };
-  }
+  addCandidate(env.GH_TOKEN, 'GH_TOKEN');
+  addCandidate(env.GITHUB_TOKEN, 'GITHUB_TOKEN');
+  addCandidate(env.GH_ENTERPRISE_TOKEN, 'GH_ENTERPRISE_TOKEN');
 
-  const candidates = [env.GH_TOKEN_FILE];
+  const fileCandidates = [env.GH_TOKEN_FILE];
   if (process.platform === 'win32') {
-    candidates.push('C:\\github_token.txt');
+    fileCandidates.push('C:\\github_token.txt');
   }
 
-  for (const candidate of candidates) {
+  for (const candidate of fileCandidates) {
     if (!candidate) {
       continue;
     }
     try {
       await accessFn(candidate);
       const fileToken = (await readFileFn(candidate, 'utf8')).trim();
-      if (fileToken) {
-        logFn(`[policy] auth source: file:${candidate}`);
-        return { token: fileToken, source: `file:${candidate}` };
-      }
+      addCandidate(fileToken, `file:${candidate}`);
     } catch {
       // ignore missing/invalid file
     }
   }
 
-  return null;
+  return candidates;
+}
+
+function isUnauthorizedAuthError(error) {
+  if (!error) {
+    return false;
+  }
+  const message = typeof error.message === 'string' ? error.message : String(error);
+  return /401/.test(message) && /unauthorized/i.test(message);
 }
 
 async function requestJson(url, token, { method = 'GET', body, fetchFn } = {}) {
@@ -654,20 +675,58 @@ export async function run({
 
   const manifest = await loadManifest();
   const forkRun = await detectForkRun(env);
-  const tokenResult = await resolveToken(env);
-  const token = tokenResult?.token;
-  if (!token) {
+  const tokenCandidates = await resolveTokenCandidates(env);
+  if (tokenCandidates.length === 0) {
     throw new Error('GitHub token not found. Set GITHUB_TOKEN, GH_TOKEN, or GH_TOKEN_FILE.');
   }
+  let activeTokenIndex = 0;
+  let activeTokenResult = tokenCandidates[activeTokenIndex];
+  log(`[policy] auth source: ${activeTokenResult.source}`);
+
+  const invokeWithAuthFallback = async (operationName, operationFn) => {
+    try {
+      return await operationFn(activeTokenResult.token);
+    } catch (initialError) {
+      if (!isUnauthorizedAuthError(initialError)) {
+        throw initialError;
+      }
+
+      const fallback = tokenCandidates.find(
+        (candidate, index) => index > activeTokenIndex && candidate.token !== activeTokenResult.token
+      );
+      if (!fallback) {
+        throw new Error(
+          `${operationName} failed with 401 Unauthorized using ${activeTokenResult.source}. No fallback token available.`
+        );
+      }
+
+      log(`[policy] auth fallback: ${activeTokenResult.source} -> ${fallback.source} (401 Unauthorized)`);
+      activeTokenIndex = tokenCandidates.indexOf(fallback);
+      activeTokenResult = fallback;
+
+      try {
+        return await operationFn(activeTokenResult.token);
+      } catch (fallbackError) {
+        if (isUnauthorizedAuthError(fallbackError)) {
+          throw new Error(
+            `${operationName} failed after auth fallback ${tokenCandidates[0].source} -> ${activeTokenResult.source}: ${fallbackError.message}`
+          );
+        }
+        throw fallbackError;
+      }
+    }
+  };
 
   const { owner, repo } = getRepoFromEnv(env, execSyncFn);
   dbg(`Resolved repository ${owner}/${repo}`);
-  if (tokenResult?.source) {
-    dbg(`Token source ${tokenResult.source}`);
+  if (activeTokenResult?.source) {
+    dbg(`Token source ${activeTokenResult.source}`);
   }
   const repoUrl = `https://api.github.com/repos/${owner}/${repo}`;
 
-  const initialState = await collectState(manifest, repoUrl, token, fetchFn);
+  const initialState = await invokeWithAuthFallback('collectState', (token) =>
+    collectState(manifest, repoUrl, token, fetchFn)
+  );
   if (options.debug) {
     const repoKeys = initialState.repoData ? Object.keys(initialState.repoData) : [];
     dbg(`Repo response keys: ${repoKeys.length ? repoKeys.join(', ') : '(none)'}`);
@@ -723,14 +782,16 @@ export async function run({
     });
 
     for (const entry of branchStatesNeedingUpdates) {
-      await applyBranchProtection(
-        repoUrl,
-        token,
-        entry.branch,
-        entry.expectations,
-        entry.protection,
-        fetchFn,
-        log
+      await invokeWithAuthFallback(`applyBranchProtection(${entry.branch})`, (token) =>
+        applyBranchProtection(
+          repoUrl,
+          token,
+          entry.branch,
+          entry.expectations,
+          entry.protection,
+          fetchFn,
+          log
+        )
       );
     }
 
@@ -743,18 +804,22 @@ export async function run({
     });
 
     for (const entry of rulesetStatesNeedingUpdates) {
-      await applyRuleset(
-        repoUrl,
-        token,
-        entry.id,
-        entry.expectations,
-        entry.ruleset,
-        fetchFn,
-        log
+      await invokeWithAuthFallback(`applyRuleset(${entry.id})`, (token) =>
+        applyRuleset(
+          repoUrl,
+          token,
+          entry.id,
+          entry.expectations,
+          entry.ruleset,
+          fetchFn,
+          log
+        )
       );
     }
 
-    const postState = await collectState(manifest, repoUrl, token, fetchFn);
+    const postState = await invokeWithAuthFallback('collectState(post-apply)', (token) =>
+      collectState(manifest, repoUrl, token, fetchFn)
+    );
     const postDiffs = evaluateDiffs(manifest, postState);
     const remainingDiffs = [
       ...postDiffs.repoDiffs,


### PR DESCRIPTION
## Summary
- add deterministic auth fallback in priority:policy for GH_TOKEN 401 failures
- retry once with GITHUB_TOKEN when available and distinct
- keep non-auth failure behavior unchanged

## Changes
- 	ools/priority/check-policy.mjs
  - add candidate token chain resolution (GH, GITHUB, enterprise, file)
  - add single-step 401 fallback wrapper with explicit telemetry
  - keep no-retry-loop behavior (one fallback only)
- 	ools/priority/__tests__/check-policy-apply.test.mjs
  - add tests for:
    - valid GH token (no fallback)
    - GH 401 -> GITHUB fallback success
    - GH 401 with no fallback token (actionable failure)

## Validation
- 
ode --test tools/priority/__tests__/check-policy-apply.test.mjs
- 
ode tools/npm/run-script.mjs priority:test
- pwsh -File tools/PrePush-Checks.ps1 -SkipIconEditorFixtureChecks

Closes #97
