### PR TITLE
fix(#99): skip non-apply policy check on auth-unavailable

### DIFF
--- a/tools/priority/__tests__/check-policy-apply.test.mjs
+++ b/tools/priority/__tests__/check-policy-apply.test.mjs
@@ -797,7 +797,40 @@ test('priority:policy falls back from GH_TOKEN to GITHUB_TOKEN on 401', async ()
   assert.deepEqual(errorMessages, []);
 });
 
-test('priority:policy fails with actionable message when GH_TOKEN 401 has no fallback', async () => {
+test('priority:policy skips non-apply validation when GH_TOKEN 401 has no fallback', async () => {
+  const fetchMock = async () => createResponse({ message: 'Bad credentials', status: '401' }, 401, 'Unauthorized');
+  const logMessages = [];
+  const errorMessages = [];
+
+  const code = await run({
+    argv: ['node', 'check-policy.mjs'],
+    env: {
+      ...process.env,
+      GITHUB_REPOSITORY: 'test-org/test-repo',
+      GH_TOKEN: 'gh-stale',
+      GITHUB_TOKEN: ''
+    },
+    fetchFn: fetchMock,
+    execSyncFn: () => {
+      throw new Error('execSync should not be called when GITHUB_REPOSITORY is set');
+    },
+    log: (msg) => logMessages.push(msg),
+    error: (msg) => errorMessages.push(msg)
+  });
+
+  assert.equal(code, 0, 'non-apply mode should skip on auth-unavailable path');
+  assert.ok(
+    logMessages.some((msg) => msg.includes('auth source: GH_TOKEN')),
+    'auth source log should report GH_TOKEN'
+  );
+  assert.ok(
+    logMessages.some((msg) => msg.includes('Authorization unavailable for policy check')),
+    'skip log should report authorization-unavailable reason'
+  );
+  assert.deepEqual(errorMessages, []);
+});
+
+test('priority:policy --apply fails when GH_TOKEN 401 has no fallback', async () => {
   const fetchMock = async () => createResponse({ message: 'Bad credentials', status: '401' }, 401, 'Unauthorized');
   const logMessages = [];
   const errorMessages = [];
@@ -805,7 +838,7 @@ test('priority:policy fails with actionable message when GH_TOKEN 401 has no fal
   await assert.rejects(
     () =>
       run({
-        argv: ['node', 'check-policy.mjs'],
+        argv: ['node', 'check-policy.mjs', '--apply'],
         env: {
           ...process.env,
           GITHUB_REPOSITORY: 'test-org/test-repo',
@@ -819,11 +852,12 @@ test('priority:policy fails with actionable message when GH_TOKEN 401 has no fal
         log: (msg) => logMessages.push(msg),
         error: (msg) => errorMessages.push(msg)
       }),
-    /No fallback token available/
+    /authorization unavailable/i
   );
 
   assert.ok(
     logMessages.some((msg) => msg.includes('auth source: GH_TOKEN')),
     'auth source log should report GH_TOKEN'
   );
+  assert.deepEqual(errorMessages, []);
 });

--- a/tools/priority/check-policy.mjs
+++ b/tools/priority/check-policy.mjs
@@ -170,6 +170,15 @@ function isUnauthorizedAuthError(error) {
   return /401/.test(message) && /unauthorized/i.test(message);
 }
 
+function createAuthUnavailableError(operationName, attemptedSources = [], reason = '') {
+  const chain = attemptedSources.length > 0 ? attemptedSources.join(' -> ') : 'unknown';
+  const suffix = reason && reason.trim() ? ` ${reason.trim()}` : '';
+  const error = new Error(`${operationName} authorization unavailable after sources: ${chain}.${suffix}`);
+  error.code = 'POLICY_AUTH_UNAVAILABLE';
+  error.attemptedSources = attemptedSources;
+  return error;
+}
+
 async function requestJson(url, token, { method = 'GET', body, fetchFn } = {}) {
   const fetchImpl = fetchFn ?? globalThis.fetch;
   if (typeof fetchImpl !== 'function') {
@@ -684,6 +693,7 @@ export async function run({
   log(`[policy] auth source: ${activeTokenResult.source}`);
 
   const invokeWithAuthFallback = async (operationName, operationFn) => {
+    const attemptedSources = [activeTokenResult.source];
     try {
       return await operationFn(activeTokenResult.token);
     } catch (initialError) {
@@ -695,21 +705,26 @@ export async function run({
         (candidate, index) => index > activeTokenIndex && candidate.token !== activeTokenResult.token
       );
       if (!fallback) {
-        throw new Error(
-          `${operationName} failed with 401 Unauthorized using ${activeTokenResult.source}. No fallback token available.`
+        throw createAuthUnavailableError(
+          operationName,
+          attemptedSources,
+          `No fallback token available. Last error: ${initialError.message}`
         );
       }
 
       log(`[policy] auth fallback: ${activeTokenResult.source} -> ${fallback.source} (401 Unauthorized)`);
       activeTokenIndex = tokenCandidates.indexOf(fallback);
       activeTokenResult = fallback;
+      attemptedSources.push(activeTokenResult.source);
 
       try {
         return await operationFn(activeTokenResult.token);
       } catch (fallbackError) {
         if (isUnauthorizedAuthError(fallbackError)) {
-          throw new Error(
-            `${operationName} failed after auth fallback ${tokenCandidates[0].source} -> ${activeTokenResult.source}: ${fallbackError.message}`
+          throw createAuthUnavailableError(
+            operationName,
+            attemptedSources,
+            `Last error: ${fallbackError.message}`
           );
         }
         throw fallbackError;
@@ -724,9 +739,23 @@ export async function run({
   }
   const repoUrl = `https://api.github.com/repos/${owner}/${repo}`;
 
-  const initialState = await invokeWithAuthFallback('collectState', (token) =>
-    collectState(manifest, repoUrl, token, fetchFn)
-  );
+  let initialState;
+  try {
+    initialState = await invokeWithAuthFallback('collectState', (token) =>
+      collectState(manifest, repoUrl, token, fetchFn)
+    );
+  } catch (authError) {
+    if (!options.apply && authError?.code === 'POLICY_AUTH_UNAVAILABLE') {
+      const attempted = Array.isArray(authError.attemptedSources) && authError.attemptedSources.length > 0
+        ? authError.attemptedSources.join(' -> ')
+        : 'unknown';
+      log(
+        `[policy] Authorization unavailable for policy check (attempted: ${attempted}); skipping non-apply validation. Upstream status "Policy Guard (Upstream) / policy-guard" remains authoritative.`
+      );
+      return 0;
+    }
+    throw authError;
+  }
   if (options.debug) {
     const repoKeys = initialState.repoData ? Object.keys(initialState.repoData) : [];
     dbg(`Repo response keys: ${repoKeys.length ? repoKeys.join(', ') : '(none)'}`);


### PR DESCRIPTION
## Summary
- convert auth-unavailable priority:policy path to deterministic skip in non-apply mode
- keep --apply strict (still fails on auth-unavailable)

## Changes
- 	ools/priority/check-policy.mjs
  - add typed auth-unavailable error with attempted source chain metadata
  - skip and return   in non-apply mode when all auth attempts are unauthorized
  - preserve failure behavior for --apply
- 	ools/priority/__tests__/check-policy-apply.test.mjs
  - non-apply unauthorized path now asserts skip behavior
  - add explicit apply-mode unauthorized failure test

## Validation
- 
ode --test tools/priority/__tests__/check-policy-apply.test.mjs
- 
ode tools/npm/run-script.mjs priority:test
- pwsh -File tools/PrePush-Checks.ps1 -SkipIconEditorFixtureChecks

Closes #99
