### PR TITLE
feat(priority): automate sync merge mode selection (#101)

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "priority:branch:rename": "node tools/priority/rename-issue-branch.mjs",
     "priority:handoff": "pwsh -NoLogo -NoProfile -File tools/priority/Import-HandoffState.ps1",
     "priority:handoff-tests": "node tools/priority/run-handoff-tests.mjs",
+    "priority:merge-sync": "node tools/priority/merge-sync-pr.mjs",
     "priority:policy": "node tools/priority/check-policy.mjs",
     "priority:pr": "node tools/priority/create-pr.mjs",
     "priority:release": "pwsh -NoLogo -NoProfile -File tools/priority/Simulate-Release.ps1",

--- a/tools/priority/__tests__/merge-sync-pr.test.mjs
+++ b/tools/priority/__tests__/merge-sync-pr.test.mjs
@@ -1,0 +1,92 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { selectMergeMode, shouldRetryWithAuto } from '../merge-sync-pr.mjs';
+
+test('selectMergeMode chooses auto for policy-blocked merge states', () => {
+  const selection = selectMergeMode({
+    state: 'OPEN',
+    isDraft: false,
+    mergeStateStatus: 'BLOCKED',
+    mergeable: 'MERGEABLE'
+  });
+  assert.equal(selection.mode, 'auto');
+  assert.match(selection.reason, /merge-state-blocked/);
+});
+
+test('selectMergeMode chooses direct for clean mergeable PRs', () => {
+  const selection = selectMergeMode({
+    state: 'OPEN',
+    isDraft: false,
+    mergeStateStatus: 'CLEAN',
+    mergeable: 'MERGEABLE'
+  });
+  assert.deepEqual(selection, {
+    mode: 'direct',
+    reason: 'clean-mergeable'
+  });
+});
+
+test('selectMergeMode honors explicit admin override', () => {
+  const selection = selectMergeMode(
+    {
+      state: 'OPEN',
+      isDraft: false,
+      mergeStateStatus: 'CLEAN',
+      mergeable: 'MERGEABLE'
+    },
+    { admin: true }
+  );
+  assert.deepEqual(selection, {
+    mode: 'admin',
+    reason: 'explicit-admin-override'
+  });
+});
+
+test('selectMergeMode throws on conflicting or dirty PRs', () => {
+  assert.throws(
+    () =>
+      selectMergeMode({
+        state: 'OPEN',
+        isDraft: false,
+        mergeStateStatus: 'DIRTY',
+        mergeable: 'CONFLICTING'
+      }),
+    /merge conflicts/i
+  );
+});
+
+test('selectMergeMode returns none when PR is already merged', () => {
+  const selection = selectMergeMode({
+    state: 'MERGED',
+    mergeStateStatus: 'CLEAN',
+    mergeable: 'MERGEABLE'
+  });
+  assert.deepEqual(selection, {
+    mode: 'none',
+    reason: 'already-merged'
+  });
+});
+
+test('shouldRetryWithAuto detects policy-blocked direct merge failures', () => {
+  assert.equal(
+    shouldRetryWithAuto({
+      mode: 'direct',
+      stderr: 'Base branch policy requires merge queue; direct merge blocked.'
+    }),
+    true
+  );
+  assert.equal(
+    shouldRetryWithAuto({
+      mode: 'direct',
+      stderr: 'Merge conflict detected'
+    }),
+    false
+  );
+  assert.equal(
+    shouldRetryWithAuto({
+      mode: 'auto',
+      stderr: 'Base branch policy requires merge queue'
+    }),
+    false
+  );
+});

--- a/tools/priority/merge-sync-pr.mjs
+++ b/tools/priority/merge-sync-pr.mjs
@@ -1,0 +1,344 @@
+#!/usr/bin/env node
+
+import { writeFile } from 'node:fs/promises';
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+import { ensureGhCli, resolveUpstream } from './lib/remote-utils.mjs';
+import { getRepoRoot } from './lib/branch-utils.mjs';
+
+const USAGE_LINES = [
+  'Usage: node tools/priority/merge-sync-pr.mjs --pr <number> [options]',
+  '',
+  'Options:',
+  '  --pr <number>            Pull request number to merge (required)',
+  '  --repo <owner/repo>      Target repository (defaults to upstream remote)',
+  '  --method <merge|squash|rebase>',
+  '                           Merge method (default: squash)',
+  '  --admin                  Explicitly use admin merge override',
+  '  --keep-branch            Keep head branch after merge',
+  '  --dry-run                Print selected mode and merge command without executing',
+  '  --summary-path <path>    Write JSON summary payload',
+  '  -h, --help               Show this message and exit'
+];
+
+const MERGE_METHODS = new Set(['merge', 'squash', 'rebase']);
+const POLICY_BLOCK_PATTERNS = [
+  /merge queue/i,
+  /required checks?.*not (?:passing|successful|complete)/i,
+  /required status checks?.*pending/i,
+  /base branch policy/i,
+  /protected branch/i,
+  /cannot be merged automatically/i
+];
+
+function printUsage() {
+  for (const line of USAGE_LINES) {
+    console.log(line);
+  }
+}
+
+function parseArgs(argv = process.argv) {
+  const args = argv.slice(2);
+  const options = {
+    pr: null,
+    repo: null,
+    method: 'squash',
+    admin: false,
+    keepBranch: false,
+    dryRun: false,
+    summaryPath: null
+  };
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === '-h' || arg === '--help') {
+      printUsage();
+      process.exit(0);
+    }
+    if (arg === '--admin') {
+      options.admin = true;
+      continue;
+    }
+    if (arg === '--keep-branch') {
+      options.keepBranch = true;
+      continue;
+    }
+    if (arg === '--dry-run') {
+      options.dryRun = true;
+      continue;
+    }
+    if (arg === '--pr' || arg === '--repo' || arg === '--method' || arg === '--summary-path') {
+      const value = args[i + 1];
+      if (!value || value.startsWith('-')) {
+        throw new Error(`Missing value for ${arg}`);
+      }
+      i += 1;
+      if (arg === '--pr') {
+        const parsed = Number(value);
+        if (!Number.isInteger(parsed) || parsed <= 0) {
+          throw new Error(`Invalid --pr value '${value}'. Expected positive integer.`);
+        }
+        options.pr = parsed;
+      } else if (arg === '--repo') {
+        if (!value.includes('/')) {
+          throw new Error(`Invalid --repo value '${value}'. Expected owner/repo.`);
+        }
+        options.repo = value;
+      } else if (arg === '--method') {
+        if (!MERGE_METHODS.has(value)) {
+          throw new Error(`Invalid --method '${value}'. Expected one of: ${Array.from(MERGE_METHODS).join(', ')}`);
+        }
+        options.method = value;
+      } else if (arg === '--summary-path') {
+        options.summaryPath = value;
+      }
+      continue;
+    }
+
+    throw new Error(`Unknown option: ${arg}`);
+  }
+
+  if (!options.pr) {
+    printUsage();
+    throw new Error('Missing required option --pr <number>.');
+  }
+
+  return options;
+}
+
+function normalizeUpper(value) {
+  return typeof value === 'string' ? value.toUpperCase() : '';
+}
+
+export function selectMergeMode(prInfo, { admin = false } = {}) {
+  const state = normalizeUpper(prInfo?.state);
+  const mergeState = normalizeUpper(prInfo?.mergeStateStatus);
+  const mergeable = normalizeUpper(prInfo?.mergeable);
+  const isDraft = Boolean(prInfo?.isDraft);
+
+  if (state === 'MERGED') {
+    return { mode: 'none', reason: 'already-merged' };
+  }
+  if (state && state !== 'OPEN') {
+    throw new Error(`PR state ${state} is not mergeable.`);
+  }
+  if (admin) {
+    return { mode: 'admin', reason: 'explicit-admin-override' };
+  }
+  if (isDraft || mergeState === 'DRAFT') {
+    return { mode: 'auto', reason: 'draft-pr' };
+  }
+  if (mergeState === 'DIRTY' || mergeable === 'CONFLICTING') {
+    throw new Error('PR has merge conflicts (DIRTY/CONFLICTING). Resolve conflicts before merge automation.');
+  }
+  if (mergeable === 'UNMERGEABLE') {
+    throw new Error('PR is UNMERGEABLE. Resolve branch/ruleset blockers before merge automation.');
+  }
+
+  if (mergeState === 'CLEAN' && (mergeable === 'MERGEABLE' || mergeable === '')) {
+    return { mode: 'direct', reason: 'clean-mergeable' };
+  }
+
+  if (mergeState === 'UNKNOWN') {
+    return { mode: 'auto', reason: 'unknown-merge-state' };
+  }
+
+  if (mergeState === 'BLOCKED' || mergeState === 'BEHIND' || mergeState === 'HAS_HOOKS' || mergeState === 'UNSTABLE') {
+    return { mode: 'auto', reason: `merge-state-${mergeState.toLowerCase()}` };
+  }
+
+  return { mode: 'auto', reason: mergeState ? `merge-state-${mergeState.toLowerCase()}` : 'merge-state-unspecified' };
+}
+
+export function shouldRetryWithAuto({ mode, stdout = '', stderr = '' } = {}) {
+  if (mode !== 'direct') {
+    return false;
+  }
+  const combined = `${stdout}\n${stderr}`;
+  return POLICY_BLOCK_PATTERNS.some((pattern) => pattern.test(combined));
+}
+
+function parseJsonOutput(raw, { label }) {
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    throw new Error(`Unable to parse ${label}: ${error.message}`);
+  }
+}
+
+function readPrInfo({ repoRoot, repo, pr }) {
+  const result = spawnSync(
+    'gh',
+    ['pr', 'view', String(pr), '--repo', repo, '--json', 'number,state,isDraft,mergeStateStatus,mergeable,url'],
+    {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe']
+    }
+  );
+  if (result.status !== 0) {
+    const combined = `${result.stderr ?? ''}${result.stdout ?? ''}`.trim();
+    throw new Error(`gh pr view failed for #${pr}: ${combined || `exit ${result.status}`}`);
+  }
+  return parseJsonOutput(result.stdout ?? '{}', { label: 'gh pr view output' });
+}
+
+function buildMergeArgs({ pr, repo, method, mode, keepBranch }) {
+  const args = ['pr', 'merge', String(pr), '--repo', repo, `--${method}`];
+  if (!keepBranch) {
+    args.push('--delete-branch');
+  }
+  if (mode === 'auto') {
+    args.push('--auto');
+  } else if (mode === 'admin') {
+    args.push('--admin');
+  }
+  return args;
+}
+
+function runMergeAttempt({ repoRoot, args, dryRun }) {
+  if (dryRun) {
+    console.log(`[priority:merge-sync] dry-run command: gh ${args.join(' ')}`);
+    return { status: 0, stdout: '', stderr: '' };
+  }
+  const result = spawnSync('gh', args, {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe']
+  });
+  if (result.stdout) {
+    process.stdout.write(result.stdout);
+  }
+  if (result.stderr) {
+    process.stderr.write(result.stderr);
+  }
+  return result;
+}
+
+async function maybeWriteSummary(summaryPath, payload) {
+  if (!summaryPath) {
+    return;
+  }
+  const resolved = path.resolve(summaryPath);
+  await writeFile(resolved, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+  console.log(`[priority:merge-sync] wrote summary: ${resolved}`);
+}
+
+export async function runMergeSync({
+  argv = process.argv,
+  repoRoot = getRepoRoot(),
+  ensureGhCliFn = ensureGhCli,
+  resolveUpstreamFn = resolveUpstream
+} = {}) {
+  const options = parseArgs(argv);
+
+  ensureGhCliFn();
+  const resolvedRepo = options.repo ?? (() => {
+    const upstream = resolveUpstreamFn(repoRoot);
+    return `${upstream.owner}/${upstream.repo}`;
+  })();
+
+  const prInfo = readPrInfo({
+    repoRoot,
+    repo: resolvedRepo,
+    pr: options.pr
+  });
+  const selection = selectMergeMode(prInfo, { admin: options.admin });
+  console.log(
+    `[priority:merge-sync] selected mode=${selection.mode} reason=${selection.reason} mergeState=${prInfo.mergeStateStatus ?? 'n/a'}`
+  );
+
+  const attempts = [];
+  let finalMode = selection.mode;
+  let finalReason = selection.reason;
+
+  if (selection.mode !== 'none') {
+    const initialArgs = buildMergeArgs({
+      pr: options.pr,
+      repo: resolvedRepo,
+      method: options.method,
+      mode: selection.mode,
+      keepBranch: options.keepBranch
+    });
+    const initialResult = runMergeAttempt({ repoRoot, args: initialArgs, dryRun: options.dryRun });
+    attempts.push({
+      mode: selection.mode,
+      args: initialArgs,
+      exitCode: initialResult.status ?? 1
+    });
+
+    if (initialResult.status !== 0) {
+      const retryEligible = shouldRetryWithAuto({
+        mode: selection.mode,
+        stdout: initialResult.stdout ?? '',
+        stderr: initialResult.stderr ?? ''
+      });
+      if (retryEligible && !options.admin) {
+        finalMode = 'auto';
+        finalReason = 'direct-merge-policy-block-retry-auto';
+        console.log('[priority:merge-sync] direct merge blocked by policy; retrying with --auto.');
+        const retryArgs = buildMergeArgs({
+          pr: options.pr,
+          repo: resolvedRepo,
+          method: options.method,
+          mode: 'auto',
+          keepBranch: options.keepBranch
+        });
+        const retryResult = runMergeAttempt({ repoRoot, args: retryArgs, dryRun: options.dryRun });
+        attempts.push({
+          mode: 'auto',
+          args: retryArgs,
+          exitCode: retryResult.status ?? 1
+        });
+        if (retryResult.status !== 0) {
+          throw new Error(
+            `[priority:merge-sync] auto-merge retry failed. Use --admin only when explicitly required for policy exception.`
+          );
+        }
+      } else {
+        if (!options.admin) {
+          throw new Error(
+            '[priority:merge-sync] merge failed. Re-run with --admin only if privileged override is required.'
+          );
+        }
+        throw new Error('[priority:merge-sync] merge failed in admin mode. Resolve policy or branch state and retry.');
+      }
+    }
+  }
+
+  const payload = {
+    schema: 'priority/sync-merge@v1',
+    createdAt: new Date().toISOString(),
+    repo: resolvedRepo,
+    pr: options.pr,
+    mergeMethod: options.method,
+    selectedMode: selection.mode,
+    selectedReason: selection.reason,
+    finalMode,
+    finalReason,
+    dryRun: options.dryRun,
+    attempts,
+    prState: {
+      state: prInfo.state ?? null,
+      mergeStateStatus: prInfo.mergeStateStatus ?? null,
+      mergeable: prInfo.mergeable ?? null,
+      isDraft: Boolean(prInfo.isDraft)
+    },
+    prUrl: prInfo.url ?? null
+  };
+  await maybeWriteSummary(options.summaryPath, payload);
+
+  console.log(`[priority:merge-sync] final mode=${finalMode} reason=${finalReason}`);
+  return payload;
+}
+
+const modulePath = path.resolve(fileURLToPath(import.meta.url));
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : null;
+if (invokedPath && invokedPath === modulePath) {
+  runMergeSync().catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
## Summary
- add 	ools/priority/merge-sync-pr.mjs to automate policy-aware merge mode selection for upstream sync PRs
- choose direct/auto/admin based on PR merge state, with retry from direct to auto when policy blocks direct merge
- emit merge-mode telemetry and optional JSON summary payload (priority/sync-merge@v1)

## Testing
- 
ode --test tools/priority/__tests__/merge-sync-pr.test.mjs
- 
ode tools/npm/run-script.mjs priority:test
- pwsh -NoLogo -NoProfile -File tools/PrePush-Checks.ps1 -SkipIconEditorFixtureChecks

Closes #101