### PR TITLE
feat(gates): add lane lifecycle telemetry for fast-loop hard stops (#103)

### DIFF
--- a/tests/Test-DockerDesktopFastLoop.Tests.ps1
+++ b/tests/Test-DockerDesktopFastLoop.Tests.ps1
@@ -485,6 +485,44 @@ if (-not [string]::IsNullOrWhiteSpace($GitHubOutputPath)) {
       $summary.steps[0].failureClass | Should -Be 'runtime-determinism'
       $summary.steps[0].hardStopEligible | Should -BeTrue
       $summary.steps[0].hardStopTriggered | Should -BeTrue
+      $summary.laneLifecycle.windows.status | Should -Be 'failure'
+      $summary.laneLifecycle.windows.hardStopTriggered | Should -BeTrue
+      $summary.laneLifecycle.windows.stopClass | Should -Be 'hard-stop'
+      $summary.laneLifecycle.windows.startStep | Should -Be 'windows-runtime-preflight'
+      $summary.laneLifecycle.windows.endStep | Should -Be 'windows-runtime-preflight'
+      $summary.laneLifecycle.linux.status | Should -Be 'skipped'
+    } finally {
+      Remove-Item Env:FASTLOOP_ASSERT_FAIL_WINDOWS -ErrorAction SilentlyContinue
+      Pop-Location | Out-Null
+    }
+  }
+
+  It 'marks opposite lane blocked when hard-stop occurs before it starts in dual-lane mode' {
+    $repoRoot = Join-Path $TestDrive 'fast-loop-hard-stop-blocked-lane'
+    New-HarnessRepo -RootPath $repoRoot
+
+    Push-Location $repoRoot
+    try {
+      $resultsRoot = Join-Path $repoRoot 'tests/results/local-parity'
+      $env:FASTLOOP_ASSERT_FAIL_WINDOWS = '1'
+      $output = & pwsh -NoLogo -NoProfile -File (Join-Path $repoRoot 'tools' 'Test-DockerDesktopFastLoop.ps1') `
+        -ResultsRoot $resultsRoot `
+        -LaneOrder windows-first `
+        -HistoryScenarioSet none 2>&1
+      $LASTEXITCODE | Should -Not -Be 0
+
+      $summaryPath = Get-LatestFastLoopSummary -ResultsRoot $resultsRoot
+      $summaryPath | Should -Not -BeNullOrEmpty
+      $summary = Get-Content -LiteralPath $summaryPath -Raw | ConvertFrom-Json -Depth 12
+      $summary.hardStopTriggered | Should -BeTrue
+      $summary.laneScope | Should -Be 'both'
+      $summary.laneLifecycle.windows.status | Should -Be 'failure'
+      $summary.laneLifecycle.windows.stopClass | Should -Be 'hard-stop'
+      $summary.laneLifecycle.linux.status | Should -Be 'blocked'
+      $summary.laneLifecycle.linux.stopClass | Should -Be 'blocked'
+      $summary.laneLifecycle.linux.executedSteps | Should -Be 0
+      $summary.laneLifecycle.linux.totalPlannedSteps | Should -BeGreaterThan 0
+      $summary.laneLifecycle.linux.stopReason | Should -Match 'Runtime determinism check failed'
     } finally {
       Remove-Item Env:FASTLOOP_ASSERT_FAIL_WINDOWS -ErrorAction SilentlyContinue
       Pop-Location | Out-Null
@@ -557,6 +595,12 @@ if (-not [string]::IsNullOrWhiteSpace($GitHubOutputPath)) {
       foreach ($step in @($summary.steps)) {
         ([string]$step.name) | Should -Match '^windows-'
       }
+      $summary.laneLifecycle.windows.status | Should -Be 'success'
+      $summary.laneLifecycle.windows.stopClass | Should -Be 'completed'
+      $summary.laneLifecycle.windows.started | Should -BeTrue
+      $summary.laneLifecycle.windows.completed | Should -BeTrue
+      $summary.laneLifecycle.linux.status | Should -Be 'skipped'
+      $summary.laneLifecycle.linux.started | Should -BeFalse
 
       Test-Path -LiteralPath $tracePath -PathType Leaf | Should -BeTrue
       $traceLines = @(Get-Content -LiteralPath $tracePath | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })

--- a/tests/Write-DockerFastLoopProof.Tests.ps1
+++ b/tests/Write-DockerFastLoopProof.Tests.ps1
@@ -49,6 +49,22 @@ Describe 'Write-DockerFastLoopProof.ps1' -Tag 'Unit' {
         summaryPath = $summaryPath
         statusPath = $statusPath
       }
+      laneLifecycle = [ordered]@{
+        windows = [ordered]@{
+          status = 'success'
+          stopClass = 'completed'
+          stopReason = 'lane-complete'
+          startStep = 'windows-runtime-preflight'
+          endStep = 'windows-container-probe'
+        }
+        linux = [ordered]@{
+          status = 'success'
+          stopClass = 'completed'
+          stopReason = 'lane-complete'
+          startStep = 'linux-runtime-preflight'
+          endStep = 'linux-container-probe'
+        }
+      }
       lanes = [ordered]@{
         windows = [ordered]@{ status = 'success'; diffDetected = $true; failureClass = 'none' }
         linux = [ordered]@{ status = 'success'; diffDetected = $true; failureClass = 'none' }
@@ -80,6 +96,8 @@ Describe 'Write-DockerFastLoopProof.ps1' -Tag 'Unit' {
     $proof.hashes.summarySha256 | Should -Not -BeNullOrEmpty
     $proof.hashes.statusSha256 | Should -Not -BeNullOrEmpty
     $proof.lanes.windows.diffDetected | Should -BeTrue
+    $proof.laneLifecycle.windows.stopClass | Should -Be 'completed'
+    $proof.laneLifecycle.windows.startStep | Should -Be 'windows-runtime-preflight'
   }
 
   It 'falls back to summary aggregates when readiness omits additive fields' {
@@ -103,6 +121,18 @@ Describe 'Write-DockerFastLoopProof.ps1' -Tag 'Unit' {
       toolFailureCount = 2
       hardStopTriggered = $true
       hardStopReason = 'Runtime determinism check failed at step windows-runtime-preflight'
+      laneLifecycle = [ordered]@{
+        windows = [ordered]@{
+          status = 'failure'
+          stopClass = 'hard-stop'
+          stopReason = 'Runtime determinism check failed at step windows-runtime-preflight'
+        }
+        linux = [ordered]@{
+          status = 'blocked'
+          stopClass = 'blocked'
+          stopReason = 'Runtime determinism check failed at step windows-runtime-preflight'
+        }
+      }
     } | ConvertTo-Json -Depth 8) | Set-Content -LiteralPath $summaryPath -Encoding utf8
 
     ([ordered]@{
@@ -134,6 +164,8 @@ Describe 'Write-DockerFastLoopProof.ps1' -Tag 'Unit' {
     $proof.toolFailureCount | Should -Be 2
     $proof.hardStopTriggered | Should -BeTrue
     $proof.hardStopReason | Should -Match 'Runtime determinism'
+    $proof.laneLifecycle.windows.stopClass | Should -Be 'hard-stop'
+    $proof.laneLifecycle.linux.stopClass | Should -Be 'blocked'
   }
 
   It 'keeps optional hashes null when summary/status files are unavailable' {

--- a/tests/Write-DockerFastLoopReadiness.Tests.ps1
+++ b/tests/Write-DockerFastLoopReadiness.Tests.ps1
@@ -91,6 +91,10 @@ Describe 'Write-DockerFastLoopReadiness.ps1' -Tag 'Unit' {
     $readiness.lanes.windows.diffDetected | Should -BeTrue
     $readiness.lanes.windows.failureClass | Should -Be 'none'
     $readiness.lanes.linux.diffDetected | Should -BeFalse
+    $readiness.laneLifecycle.windows.status | Should -Be 'success'
+    $readiness.laneLifecycle.windows.stopClass | Should -Be 'completed'
+    $readiness.laneLifecycle.windows.startStep | Should -Be 'windows-runtime-preflight'
+    $readiness.laneLifecycle.windows.endStep | Should -Be 'windows-history-attribute'
   }
 
   It 'marks tool failure runs not-ready' {
@@ -216,6 +220,8 @@ Describe 'Write-DockerFastLoopReadiness.ps1' -Tag 'Unit' {
     $readiness.toolFailureCount | Should -Be 0
     $readiness.lanes.windows.failureClass | Should -Be 'runtime-determinism'
     $readiness.lanes.linux.failureClass | Should -Be 'none'
+    $readiness.laneLifecycle.windows.stopClass | Should -Be 'hard-stop'
+    $readiness.laneLifecycle.windows.stopReason | Should -Match 'Runtime determinism'
   }
 
   It 'ignores unknown step lanes while preserving step rows' {

--- a/tools/Test-DockerDesktopFastLoop.ps1
+++ b/tools/Test-DockerDesktopFastLoop.ps1
@@ -345,13 +345,160 @@ function Get-HistoricalStepDurationMedians {
   return $medians
 }
 
+function Get-LaneLifecycleFromPlan {
+  param(
+    [Parameter(Mandatory)][AllowEmptyCollection()][string[]]$StepPlan,
+    [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$ObservedSteps,
+    [Parameter(Mandatory)][string]$Phase,
+    [bool]$HardStopTriggered = $false,
+    [AllowEmptyString()][string]$HardStopReason = ''
+  )
+
+  $laneNames = @('windows', 'linux')
+  $lifecycle = [ordered]@{}
+  foreach ($laneName in $laneNames) {
+    $lifecycle[$laneName] = [ordered]@{
+      totalPlannedSteps = 0
+      executedSteps = 0
+      started = $false
+      completed = $false
+      status = 'skipped'
+      startStep = ''
+      endStep = ''
+      startedAt = ''
+      endedAt = ''
+      hardStopTriggered = $false
+      stopClass = 'none'
+      stopReason = ''
+    }
+  }
+
+  foreach ($planStep in @($StepPlan)) {
+    $laneName = Get-StepLane -StepName $planStep
+    if ([string]::IsNullOrWhiteSpace($laneName) -or -not $lifecycle.Contains($laneName)) { continue }
+    $lifecycle[$laneName].totalPlannedSteps = [int]$lifecycle[$laneName].totalPlannedSteps + 1
+    if ([string]$lifecycle[$laneName].status -eq 'skipped') {
+      $lifecycle[$laneName].status = 'pending'
+    }
+  }
+
+  foreach ($step in @($ObservedSteps)) {
+    if (-not $step -or -not $step.PSObject.Properties['name']) { continue }
+    $stepName = [string]$step.name
+    $laneName = Get-StepLane -StepName $stepName
+    if ([string]::IsNullOrWhiteSpace($laneName) -or -not $lifecycle.Contains($laneName)) { continue }
+
+    $lane = $lifecycle[$laneName]
+    $lane.executedSteps = [int]$lane.executedSteps + 1
+    $lane.started = $true
+    if ([string]::IsNullOrWhiteSpace([string]$lane.startStep)) {
+      $lane.startStep = $stepName
+    }
+    $lane.endStep = $stepName
+    if ([string]::IsNullOrWhiteSpace([string]$lane.startedAt) -and $step.PSObject.Properties['startedAt']) {
+      $lane.startedAt = [string]$step.startedAt
+    }
+    if ($step.PSObject.Properties['finishedAt']) {
+      $lane.endedAt = [string]$step.finishedAt
+    }
+
+    $stepStatus = if ($step.PSObject.Properties['status']) { [string]$step.status } else { '' }
+    if ($stepStatus -ne 'success') {
+      $lane.status = 'failure'
+      $lane.stopClass = 'failure'
+      if ($step.PSObject.Properties['hardStopTriggered'] -and [bool]$step.hardStopTriggered) {
+        $lane.hardStopTriggered = $true
+        $lane.stopClass = 'hard-stop'
+      }
+      $failureClassText = if ($step.PSObject.Properties['failureClass']) { [string]$step.failureClass } else { '' }
+      $messageText = if ($step.PSObject.Properties['message']) { [string]$step.message } else { '' }
+      if (-not [string]::IsNullOrWhiteSpace($messageText)) {
+        $lane.stopReason = $messageText
+      } elseif (-not [string]::IsNullOrWhiteSpace($failureClassText)) {
+        $lane.stopReason = ("failureClass={0}" -f $failureClassText)
+      } else {
+        $lane.stopReason = 'step-failure'
+      }
+      continue
+    }
+
+    if ([string]$lane.status -notin @('failure', 'success', 'incomplete')) {
+      $lane.status = 'running'
+    }
+  }
+
+  foreach ($laneName in $laneNames) {
+    $lane = $lifecycle[$laneName]
+    $planned = [int]$lane.totalPlannedSteps
+    $executed = [int]$lane.executedSteps
+
+    if ($planned -eq 0) {
+      $lane.status = 'skipped'
+      $lane.completed = $false
+      $lane.stopClass = 'none'
+      $lane.stopReason = ''
+      continue
+    }
+
+    if ($executed -eq 0) {
+      if ($HardStopTriggered) {
+        $lane.status = 'blocked'
+        $lane.stopClass = 'blocked'
+        $lane.stopReason = if ([string]::IsNullOrWhiteSpace($HardStopReason)) { 'blocked-by-hard-stop' } else { $HardStopReason }
+      } elseif ($Phase -eq 'completed') {
+        $lane.status = 'blocked'
+        $lane.stopClass = 'blocked'
+        $lane.stopReason = 'lane-not-started'
+      } else {
+        $lane.status = 'pending'
+        $lane.stopClass = 'none'
+      }
+      continue
+    }
+
+    if ([string]$lane.status -eq 'failure') {
+      $lane.completed = ($executed -ge $planned)
+      if ($lane.hardStopTriggered -and [string]::IsNullOrWhiteSpace([string]$lane.stopReason) -and -not [string]::IsNullOrWhiteSpace($HardStopReason)) {
+        $lane.stopReason = $HardStopReason
+      }
+      continue
+    }
+
+    if ($executed -ge $planned) {
+      $lane.status = 'success'
+      $lane.completed = $true
+      $lane.stopClass = 'completed'
+      if ([string]::IsNullOrWhiteSpace([string]$lane.stopReason)) {
+        $lane.stopReason = 'lane-complete'
+      }
+      continue
+    }
+
+    $lane.completed = $false
+    if ($HardStopTriggered) {
+      $lane.status = 'incomplete'
+      $lane.stopClass = 'blocked'
+      $lane.stopReason = if ([string]::IsNullOrWhiteSpace($HardStopReason)) { 'hard-stop-before-lane-complete' } else { $HardStopReason }
+    } else {
+      $lane.status = if ($Phase -eq 'completed') { 'incomplete' } else { 'running' }
+      if ([string]$lane.stopClass -eq 'none') {
+        $lane.stopReason = ''
+      }
+    }
+  }
+
+  return $lifecycle
+}
+
 function New-StatusTelemetry {
   param(
     [Parameter(Mandatory)][string]$RunStatus,
     [Parameter(Mandatory)][string]$Phase,
     [Parameter(Mandatory)][AllowEmptyCollection()][string[]]$StepPlan,
     [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$ObservedSteps,
-    [Parameter(Mandatory)][hashtable]$HistoricalMedians
+    [Parameter(Mandatory)][hashtable]$HistoricalMedians,
+    [bool]$HardStopTriggered = $false,
+    [AllowEmptyString()][string]$HardStopReason = ''
   )
 
   $completedDurationMs = 0
@@ -402,6 +549,12 @@ function New-StatusTelemetry {
   } elseif ($Phase -eq 'completed' -and $RunStatus -ne 'success') {
     $pushRecommendation = 'do-not-push'
   }
+  $laneLifecycle = Get-LaneLifecycleFromPlan `
+    -StepPlan $StepPlan `
+    -ObservedSteps $ObservedSteps `
+    -Phase $Phase `
+    -HardStopTriggered:$HardStopTriggered `
+    -HardStopReason $HardStopReason
 
   return [ordered]@{
     completedDurationMs = [int]$completedDurationMs
@@ -412,6 +565,7 @@ function New-StatusTelemetry {
       windows = [ordered]@{ completed = [int]$laneCompleted.windows; total = [int]$laneTotals.windows }
       linux = [ordered]@{ completed = [int]$laneCompleted.linux; total = [int]$laneTotals.linux }
     }
+    laneLifecycle = $laneLifecycle
     pushRecommendation = $pushRecommendation
     canPush = [bool]$canPush
   }
@@ -429,6 +583,8 @@ function Write-SemiLiveStatus {
     [Parameter(Mandatory)][AllowEmptyCollection()][string[]]$StepPlan,
     [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Steps,
     [Parameter(Mandatory)][hashtable]$HistoricalStepMedians,
+    [bool]$HardStopTriggered = $false,
+    [AllowEmptyString()][string]$HardStopReason = '',
     [AllowEmptyString()][string]$SummaryPath
   )
 
@@ -444,7 +600,9 @@ function Write-SemiLiveStatus {
     -Phase $Phase `
     -StepPlan $StepPlan `
     -ObservedSteps $Steps `
-    -HistoricalMedians $HistoricalStepMedians
+    -HistoricalMedians $HistoricalStepMedians `
+    -HardStopTriggered:$HardStopTriggered `
+    -HardStopReason $HardStopReason
 
   $payload = [ordered]@{
     schema = 'docker-desktop-fast-loop-status@v1'
@@ -464,6 +622,9 @@ function Write-SemiLiveStatus {
     runtimeAutoRepair = [bool]$runtimeAutoRepairEnabled
     stepTimeoutSeconds = [int]$StepTimeoutSeconds
     manageDockerEngine = [bool]$effectiveManageDockerEngine
+    hardStopTriggered = [bool]$HardStopTriggered
+    hardStopReason = ($HardStopReason ?? '')
+    laneLifecycle = $telemetry.laneLifecycle
     telemetry = $telemetry
     steps = @($Steps)
     summaryPath = ($SummaryPath ?? '')
@@ -1183,6 +1344,8 @@ Write-SemiLiveStatus `
   -StepPlan $stepPlan `
   -Steps @() `
   -HistoricalStepMedians $historicalStepMedians `
+  -HardStopTriggered:$hardStopTriggered `
+  -HardStopReason $hardStopReason `
   -SummaryPath ''
 
 foreach ($definition in $stepDefinitions.ToArray()) {
@@ -1199,6 +1362,8 @@ foreach ($definition in $stepDefinitions.ToArray()) {
     -StepPlan $stepPlan `
     -Steps $results.ToArray() `
     -HistoricalStepMedians $historicalStepMedians `
+    -HardStopTriggered:$hardStopTriggered `
+    -HardStopReason $hardStopReason `
     -SummaryPath ''
 
   $allowedExitCodes = @(0)
@@ -1260,6 +1425,8 @@ foreach ($definition in $stepDefinitions.ToArray()) {
     -StepPlan $stepPlan `
     -Steps $results.ToArray() `
     -HistoricalStepMedians $historicalStepMedians `
+    -HardStopTriggered:$hardStopTriggered `
+    -HardStopReason $hardStopReason `
     -SummaryPath ''
 
   if ($hardStopTriggered) {
@@ -1357,6 +1524,12 @@ $summary = [ordered]@{
   stepTimeoutSeconds = [int]$StepTimeoutSeconds
   manageDockerEngine = [bool]$effectiveManageDockerEngine
   laneOrder = $LaneOrder
+  laneLifecycle = (Get-LaneLifecycleFromPlan `
+    -StepPlan $stepPlan `
+    -ObservedSteps $results.ToArray() `
+    -Phase 'completed' `
+    -HardStopTriggered:$hardStopTriggered `
+    -HardStopReason $hardStopReason)
   steps = $results.ToArray()
   status = if ($failed.Count -eq 0) { 'success' } else { 'failure' }
 }
@@ -1374,6 +1547,8 @@ Write-SemiLiveStatus `
   -StepPlan $stepPlan `
   -Steps $results.ToArray() `
   -HistoricalStepMedians $historicalStepMedians `
+  -HardStopTriggered:$hardStopTriggered `
+  -HardStopReason $hardStopReason `
   -SummaryPath $summaryPath
 
 pwsh -NoLogo -NoProfile -File (Join-Path $PSScriptRoot 'Write-DockerFastLoopReadiness.ps1') `

--- a/tools/Write-DockerFastLoopProof.ps1
+++ b/tools/Write-DockerFastLoopProof.ps1
@@ -186,6 +186,7 @@ $proof = [ordered]@{
     summarySha256 = Get-FileHashOrNull -Path $summaryResolved
     statusSha256 = Get-FileHashOrNull -Path $statusResolved
   }
+  laneLifecycle = if ($readiness.PSObject.Properties['laneLifecycle']) { $readiness.laneLifecycle } elseif ($summary -and $summary.PSObject.Properties['laneLifecycle']) { $summary.laneLifecycle } else { $null }
   lanes = if ($readiness.PSObject.Properties['lanes']) { $readiness.lanes } else { $null }
 }
 

--- a/tools/Write-DockerFastLoopReadiness.ps1
+++ b/tools/Write-DockerFastLoopReadiness.ps1
@@ -243,6 +243,80 @@ function Get-LaneFromSteps {
   return $laneState
 }
 
+function Resolve-LaneLifecycle {
+  param(
+    [AllowNull()]$Summary,
+    [Parameter(Mandatory)][hashtable]$LaneState,
+    [Parameter(Mandatory)][object[]]$Steps,
+    [bool]$HardStopTriggered = $false,
+    [AllowEmptyString()][string]$HardStopReason = ''
+  )
+
+  $resolved = [ordered]@{}
+  foreach ($laneName in @('windows', 'linux')) {
+    $laneData = $LaneState[$laneName]
+    $firstStep = @($Steps | Where-Object {
+        $_ -and $_.PSObject -and $_.PSObject.Properties['name'] -and ((Get-StepLane -StepName ([string]$_.name)) -eq $laneName)
+      } | Select-Object -First 1)
+    $lastStep = @($Steps | Where-Object {
+        $_ -and $_.PSObject -and $_.PSObject.Properties['name'] -and ((Get-StepLane -StepName ([string]$_.name)) -eq $laneName)
+      } | Select-Object -Last 1)
+
+    $defaultStopClass = switch ([string]$laneData.status) {
+      'success' { 'completed' }
+      'failure' { if ($HardStopTriggered) { 'hard-stop' } else { 'failure' } }
+      'skipped' { 'none' }
+      default { if ($HardStopTriggered) { 'blocked' } else { 'none' } }
+    }
+    $defaultStopReason = switch ([string]$laneData.status) {
+      'success' { 'lane-complete' }
+      'failure' { if (-not [string]::IsNullOrWhiteSpace($HardStopReason)) { $HardStopReason } else { 'lane-failed' } }
+      'skipped' { '' }
+      default { if (-not [string]::IsNullOrWhiteSpace($HardStopReason)) { $HardStopReason } else { '' } }
+    }
+    $derived = [ordered]@{
+      totalPlannedSteps = [int]$laneData.total
+      executedSteps = [int]$laneData.total
+      started = ([int]$laneData.total -gt 0)
+      completed = ([string]$laneData.status -eq 'success')
+      status = [string]$laneData.status
+      startStep = if ($firstStep.Count -gt 0 -and $firstStep[0].PSObject.Properties['name']) { [string]$firstStep[0].name } else { '' }
+      endStep = if ($lastStep.Count -gt 0 -and $lastStep[0].PSObject.Properties['name']) { [string]$lastStep[0].name } else { '' }
+      startedAt = if ($firstStep.Count -gt 0 -and $firstStep[0].PSObject.Properties['startedAt']) { [string]$firstStep[0].startedAt } else { '' }
+      endedAt = if ($lastStep.Count -gt 0 -and $lastStep[0].PSObject.Properties['finishedAt']) { [string]$lastStep[0].finishedAt } else { '' }
+      hardStopTriggered = ($HardStopTriggered -and [string]$laneData.status -eq 'failure')
+      stopClass = $defaultStopClass
+      stopReason = $defaultStopReason
+    }
+
+    $summaryEntry = $null
+    if ($Summary -and $Summary.PSObject.Properties['laneLifecycle'] -and $Summary.laneLifecycle -and $Summary.laneLifecycle.PSObject.Properties[$laneName]) {
+      $summaryEntry = $Summary.laneLifecycle.$laneName
+    }
+
+    if ($summaryEntry) {
+      $resolved[$laneName] = [ordered]@{
+        totalPlannedSteps = if ($summaryEntry.PSObject.Properties['totalPlannedSteps']) { [int]$summaryEntry.totalPlannedSteps } else { [int]$derived.totalPlannedSteps }
+        executedSteps = if ($summaryEntry.PSObject.Properties['executedSteps']) { [int]$summaryEntry.executedSteps } else { [int]$derived.executedSteps }
+        started = if ($summaryEntry.PSObject.Properties['started']) { [bool]$summaryEntry.started } else { [bool]$derived.started }
+        completed = if ($summaryEntry.PSObject.Properties['completed']) { [bool]$summaryEntry.completed } else { [bool]$derived.completed }
+        status = if ($summaryEntry.PSObject.Properties['status']) { [string]$summaryEntry.status } else { [string]$derived.status }
+        startStep = if ($summaryEntry.PSObject.Properties['startStep']) { [string]$summaryEntry.startStep } else { [string]$derived.startStep }
+        endStep = if ($summaryEntry.PSObject.Properties['endStep']) { [string]$summaryEntry.endStep } else { [string]$derived.endStep }
+        startedAt = if ($summaryEntry.PSObject.Properties['startedAt']) { [string]$summaryEntry.startedAt } else { [string]$derived.startedAt }
+        endedAt = if ($summaryEntry.PSObject.Properties['endedAt']) { [string]$summaryEntry.endedAt } else { [string]$derived.endedAt }
+        hardStopTriggered = if ($summaryEntry.PSObject.Properties['hardStopTriggered']) { [bool]$summaryEntry.hardStopTriggered } else { [bool]$derived.hardStopTriggered }
+        stopClass = if ($summaryEntry.PSObject.Properties['stopClass']) { [string]$summaryEntry.stopClass } else { [string]$derived.stopClass }
+        stopReason = if ($summaryEntry.PSObject.Properties['stopReason']) { [string]$summaryEntry.stopReason } else { [string]$derived.stopReason }
+      }
+    } else {
+      $resolved[$laneName] = $derived
+    }
+  }
+
+  return $resolved
+}
+
 function Get-ClassificationAggregate {
   param([Parameter(Mandatory)][object[]]$Steps)
 
@@ -364,6 +438,12 @@ if ($summary.PSObject.Properties['hardStopTriggered']) {
   $hardStopTriggered = [bool]$summary.hardStopTriggered
 }
 $hardStopReason = if ($summary.PSObject.Properties['hardStopReason']) { [string]$summary.hardStopReason } else { '' }
+$laneLifecycle = Resolve-LaneLifecycle `
+  -Summary $summary `
+  -LaneState $lane `
+  -Steps $steps `
+  -HardStopTriggered:$hardStopTriggered `
+  -HardStopReason $hardStopReason
 $statusRecommendation = ''
 $etaSeconds = 0.0
 if ($status -and $status.PSObject.Properties['telemetry'] -and $status.telemetry) {
@@ -427,6 +507,7 @@ $readiness = [ordered]@{
     totalDurationSeconds = [math]::Round(($totalDurationMs / 1000.0), 3)
     etaSeconds = [math]::Round($etaSeconds, 1)
   }
+  laneLifecycle = $laneLifecycle
   lanes = [ordered]@{
     windows = [ordered]@{
       status = [string]$lane.windows.status
@@ -483,21 +564,31 @@ $mdLines.Add(('| ETA (s) | `{0}` |' -f ([math]::Round($etaSeconds, 1)))) | Out-N
 $mdLines.Add(('| Readiness JSON | `{0}` |' -f $jsonOutResolved)) | Out-Null
 $mdLines.Add('') | Out-Null
 
-$mdLines.Add('| Lane | Status | Diff Detected | Failure Class | Completed | Total | Duration (s) | Hist Median (s) | Hist P90 (s) |') | Out-Null
-$mdLines.Add('| --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: |') | Out-Null
+$mdLines.Add('| Lane | Status | Diff Detected | Failure Class | Stop Class | Start Step | End Step | Completed | Total | Duration (s) | Hist Median (s) | Hist P90 (s) |') | Out-Null
+$mdLines.Add('| --- | --- | --- | --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: |') | Out-Null
 foreach ($laneName in @('windows', 'linux')) {
   $laneData = $readiness.lanes.$laneName
+  $laneTelemetry = $readiness.laneLifecycle.$laneName
   $histLane = $historical.lanes.$laneName
-  $mdLines.Add(('| {0} | `{1}` | `{2}` | `{3}` | {4} | {5} | {6} | {7} | {8} |' -f `
+  $startStepValue = if ($laneTelemetry -and $laneTelemetry.PSObject.Properties['startStep'] -and -not [string]::IsNullOrWhiteSpace([string]$laneTelemetry.startStep)) { [string]$laneTelemetry.startStep } else { '-' }
+  $endStepValue = if ($laneTelemetry -and $laneTelemetry.PSObject.Properties['endStep'] -and -not [string]::IsNullOrWhiteSpace([string]$laneTelemetry.endStep)) { [string]$laneTelemetry.endStep } else { '-' }
+  $stopClassValue = if ($laneTelemetry -and $laneTelemetry.PSObject.Properties['stopClass'] -and -not [string]::IsNullOrWhiteSpace([string]$laneTelemetry.stopClass)) { [string]$laneTelemetry.stopClass } else { 'none' }
+  $mdLines.Add(('| {0} | `{1}` | `{2}` | `{3}` | `{4}` | `{5}` | `{6}` | {7} | {8} | {9} | {10} | {11} |' -f `
       $laneName, `
       $laneData.status, `
       $laneData.diffDetected, `
       $laneData.failureClass, `
+      $stopClassValue, `
+      $startStepValue, `
+      $endStepValue, `
       $laneData.completed, `
       $laneData.total, `
       (Convert-ToSecondsString -Milliseconds ([double]$laneData.durationMs)), `
       (Convert-ToSecondsString -Milliseconds ([double]$histLane.medianMs)), `
       (Convert-ToSecondsString -Milliseconds ([double]$histLane.p90Ms)))) | Out-Null
+  if ($laneTelemetry -and $laneTelemetry.PSObject.Properties['stopReason'] -and -not [string]::IsNullOrWhiteSpace([string]$laneTelemetry.stopReason)) {
+    $mdLines.Add(("| | | | | stop reason | `{0}` | | | | | | |" -f [string]$laneTelemetry.stopReason)) | Out-Null
+  }
 }
 $mdLines.Add('') | Out-Null
 


### PR DESCRIPTION
## Summary
- add explicit lane lifecycle telemetry (startStep, ndStep, startedAt, ndedAt, stopClass, stopReason) to docker fast-loop summary/status artifacts
- propagate lane lifecycle metadata into readiness and proof artifacts for deterministic hard-stop diagnostics
- extend fast-loop/readiness/proof unit tests for single-lane lifecycle, blocked opposite-lane behavior, and lifecycle propagation

## Testing
- Invoke-Pester -Path tests/Test-DockerDesktopFastLoop.Tests.ps1,tests/Write-DockerFastLoopReadiness.Tests.ps1,tests/Write-DockerFastLoopProof.Tests.ps1 -CI
- pwsh -NoLogo -NoProfile -File tools/PrePush-Checks.ps1 -SkipIconEditorFixtureChecks

Closes #103