### PR TITLE
Workflow readiness lane lifecycle parity (#105)

### DIFF
--- a/tests/Write-VIHistoryWorkflowReadiness.Tests.ps1
+++ b/tests/Write-VIHistoryWorkflowReadiness.Tests.ps1
@@ -12,7 +12,7 @@ Describe 'Write-VIHistoryWorkflowReadiness.ps1' -Tag 'Unit' {
     }
   }
 
-  It 'writes envelope with explicit diff/failure lane metadata and markdown columns' {
+  It 'writes envelope with explicit lane lifecycle metadata and markdown columns' {
     $work = Join-Path $TestDrive 'workflow-readiness-explicit'
     New-Item -ItemType Directory -Path $work -Force | Out-Null
 
@@ -26,6 +26,15 @@ Describe 'Write-VIHistoryWorkflowReadiness.ps1' -Tag 'Unit' {
       -LinuxDiffDetected false `
       -WindowsFailureClass none `
       -LinuxFailureClass preflight `
+      -WindowsLaneStopClass completed `
+      -LinuxLaneStopClass hard-stop `
+      -WindowsLaneStopReason lane-complete `
+      -LinuxLaneStopReason runtime-determinism-hard-stop `
+      -WindowsLaneStartStep windows-runtime-preflight `
+      -WindowsLaneEndStep windows-container-probe `
+      -LinuxLaneStartStep linux-runtime-preflight `
+      -LinuxLaneEndStep linux-runtime-preflight `
+      -LinuxLaneHardStopTriggered true `
       -ResultsRoot $work `
       -SummaryPath 'D:\tmp\summary.json' `
       -LinuxSmokeSummaryPath 'D:\tmp\linux-smoke-summary.json' `
@@ -50,14 +59,24 @@ Describe 'Write-VIHistoryWorkflowReadiness.ps1' -Tag 'Unit' {
     $envelope.lanes.windows.status | Should -Be 'success'
     $envelope.lanes.windows.diffDetected | Should -BeTrue
     $envelope.lanes.windows.failureClass | Should -Be 'none'
+    $envelope.lanes.windows.stopClass | Should -Be 'completed'
+    $envelope.lanes.windows.stopReason | Should -Be 'lane-complete'
     $envelope.lanes.linux.status | Should -Be 'failure'
     $envelope.lanes.linux.diffDetected | Should -BeFalse
     $envelope.lanes.linux.failureClass | Should -Be 'preflight'
+    $envelope.lanes.linux.stopClass | Should -Be 'hard-stop'
+    $envelope.lanes.linux.stopReason | Should -Be 'runtime-determinism-hard-stop'
+    $envelope.laneLifecycle.windows.startStep | Should -Be 'windows-runtime-preflight'
+    $envelope.laneLifecycle.windows.endStep | Should -Be 'windows-container-probe'
+    $envelope.laneLifecycle.linux.startStep | Should -Be 'linux-runtime-preflight'
+    $envelope.laneLifecycle.linux.endStep | Should -Be 'linux-runtime-preflight'
+    $envelope.laneLifecycle.linux.hardStopTriggered | Should -BeTrue
 
     $markdown = Get-Content -LiteralPath $mdPath -Raw
-    $markdown | Should -Match '\| Lane \| Status \| Diff Detected \| Failure Class \| Runtime Snapshot \| Summary \|'
+    $markdown | Should -Match '\| Lane \| Status \| Diff Detected \| Failure Class \| Stop Class \| Start Step \| End Step \| Runtime Snapshot \| Summary \|'
     $markdown | Should -Match '\| windows \| `success` \| `True` \| `none` \|'
-    $markdown | Should -Match '\| linux \| `failure` \| `False` \| `preflight` \|'
+    $markdown | Should -Match '\| linux \| `failure` \| `False` \| `preflight` \| `hard-stop` \|'
+    $markdown | Should -Match '\| \| \| \| \| stop reason \| runtime-determinism-hard-stop \|'
   }
 
   It 'applies fallback failure classes when not provided' {
@@ -81,8 +100,11 @@ Describe 'Write-VIHistoryWorkflowReadiness.ps1' -Tag 'Unit' {
     $envelope.verdict | Should -Be 'not-ready'
     $envelope.lanes.windows.failureClass | Should -Be 'cli/tool'
     $envelope.lanes.windows.diffDetected | Should -BeFalse
+    $envelope.lanes.windows.stopClass | Should -Be 'failure'
+    $envelope.laneLifecycle.windows.stopReason | Should -Match 'lane-failed'
     $envelope.lanes.linux.failureClass | Should -Be 'none'
     $envelope.lanes.linux.diffDetected | Should -BeFalse
+    $envelope.lanes.linux.stopClass | Should -Be 'completed'
   }
 
   It 'normalizes lane statuses and bool-like diff flags' {
@@ -113,6 +135,8 @@ Describe 'Write-VIHistoryWorkflowReadiness.ps1' -Tag 'Unit' {
     $envelope.lanes.linux.diffDetected | Should -BeFalse
     $envelope.lanes.windows.failureClass | Should -Be 'none'
     $envelope.lanes.linux.failureClass | Should -Be 'cli/tool'
+    $envelope.lanes.windows.stopClass | Should -Be 'completed'
+    $envelope.lanes.linux.stopClass | Should -Be 'failure'
   }
 
   It 'marks ready only when both lanes are success' {
@@ -135,6 +159,64 @@ Describe 'Write-VIHistoryWorkflowReadiness.ps1' -Tag 'Unit' {
     $envelope = Get-Content -LiteralPath $jsonPath -Raw | ConvertFrom-Json -Depth 10
     $envelope.verdict | Should -Be 'ready'
     $envelope.recommendation | Should -Be 'proceed'
+    $envelope.laneLifecycle.windows.stopClass | Should -Be 'completed'
+    $envelope.laneLifecycle.linux.stopClass | Should -Be 'completed'
+  }
+
+  It 'imports lane lifecycle from fast-loop readiness artifact when explicit values are not provided' {
+    $work = Join-Path $TestDrive 'workflow-readiness-fastloop-import'
+    New-Item -ItemType Directory -Path $work -Force | Out-Null
+
+    $jsonPath = Join-Path $work 'vi-history-workflow-readiness.json'
+    $mdPath = Join-Path $work 'vi-history-workflow-readiness.md'
+    $fastLoopPath = Join-Path $work 'docker-runtime-fastloop-readiness.json'
+
+    ([ordered]@{
+      schema = 'vi-history/docker-fast-loop-readiness@v1'
+      generatedAt = (Get-Date).ToUniversalTime().ToString('o')
+      laneLifecycle = [ordered]@{
+        windows = [ordered]@{
+          stopClass = 'completed'
+          stopReason = 'lane-complete'
+          startStep = 'windows-runtime-preflight'
+          endStep = 'windows-container-probe'
+          started = $true
+          completed = $true
+          totalPlannedSteps = 2
+          executedSteps = 2
+        }
+        linux = [ordered]@{
+          stopClass = 'blocked'
+          stopReason = 'Runtime determinism check failed at step windows-runtime-preflight'
+          startStep = ''
+          endStep = ''
+          started = $false
+          completed = $false
+          totalPlannedSteps = 3
+          executedSteps = 0
+        }
+      }
+    } | ConvertTo-Json -Depth 12) | Set-Content -LiteralPath $fastLoopPath -Encoding utf8
+
+    $output = & pwsh -NoLogo -NoProfile -File $script:ReadinessScript `
+      -WindowsLaneStatus success `
+      -LinuxLaneStatus failure `
+      -LinuxFailureClass runtime-determinism `
+      -FastLoopReadinessPath $fastLoopPath `
+      -ResultsRoot $work `
+      -OutputJsonPath $jsonPath `
+      -OutputMarkdownPath $mdPath `
+      -GitHubOutputPath '' `
+      -StepSummaryPath '' 2>&1
+    $LASTEXITCODE | Should -Be 0 -Because ($output -join "`n")
+
+    $envelope = Get-Content -LiteralPath $jsonPath -Raw | ConvertFrom-Json -Depth 12
+    $envelope.source.fastLoopReadinessPath | Should -Be $fastLoopPath
+    $envelope.laneLifecycle.windows.startStep | Should -Be 'windows-runtime-preflight'
+    $envelope.laneLifecycle.windows.endStep | Should -Be 'windows-container-probe'
+    $envelope.laneLifecycle.linux.stopClass | Should -Be 'blocked'
+    $envelope.laneLifecycle.linux.stopReason | Should -Match 'Runtime determinism'
+    $envelope.lanes.linux.stopClass | Should -Be 'blocked'
   }
 
   It 'writes GitHub output keys and appends step summary markdown' {
@@ -170,6 +252,6 @@ Describe 'Write-VIHistoryWorkflowReadiness.ps1' -Tag 'Unit' {
 
     $stepText = Get-Content -LiteralPath $stepSummary -Raw
     $stepText | Should -Match '### VI History Workflow Readiness'
-    $stepText | Should -Match '\| Lane \| Status \| Diff Detected \| Failure Class \|'
+    $stepText | Should -Match '\| Lane \| Status \| Diff Detected \| Failure Class \| Stop Class \|'
   }
 }

--- a/tools/Write-VIHistoryWorkflowReadiness.ps1
+++ b/tools/Write-VIHistoryWorkflowReadiness.ps1
@@ -16,6 +16,22 @@ param(
   [string]$LinuxDiffDetected = '',
   [string]$WindowsFailureClass = '',
   [string]$LinuxFailureClass = '',
+  [string]$WindowsLaneStopClass = '',
+  [string]$LinuxLaneStopClass = '',
+  [string]$WindowsLaneStopReason = '',
+  [string]$LinuxLaneStopReason = '',
+  [string]$WindowsLaneStartStep = '',
+  [string]$LinuxLaneStartStep = '',
+  [string]$WindowsLaneEndStep = '',
+  [string]$LinuxLaneEndStep = '',
+  [string]$WindowsLaneStartedAt = '',
+  [string]$LinuxLaneStartedAt = '',
+  [string]$WindowsLaneEndedAt = '',
+  [string]$LinuxLaneEndedAt = '',
+  [string]$WindowsLaneHardStopTriggered = '',
+  [string]$LinuxLaneHardStopTriggered = '',
+  [string]$FastLoopReadinessPath = '',
+  [string]$FastLoopProofPath = '',
   [string]$ResultsRoot = 'tests/results/pr-vi-history',
   [string]$SummaryPath = '',
   [string]$LinuxSmokeSummaryPath = '',
@@ -60,6 +76,30 @@ function Normalize-Status {
   }
 }
 
+function Normalize-StopClass {
+  param([AllowNull()][AllowEmptyString()][string]$Value)
+  if ([string]::IsNullOrWhiteSpace($Value)) { return '' }
+  $normalized = $Value.Trim().ToLowerInvariant()
+  switch -Regex ($normalized) {
+    '^(completed|complete)$' { return 'completed' }
+    '^(hard-stop|hardstop|hard_stop)$' { return 'hard-stop' }
+    '^(blocked|block)$' { return 'blocked' }
+    '^(failure|failed|error)$' { return 'failure' }
+    default { return $normalized }
+  }
+}
+
+function Read-JsonOrNull {
+  param([AllowNull()][AllowEmptyString()][string]$Path)
+  if ([string]::IsNullOrWhiteSpace($Path)) { return $null }
+  if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) { return $null }
+  try {
+    return (Get-Content -LiteralPath $Path -Raw | ConvertFrom-Json -Depth 20)
+  } catch {
+    return $null
+  }
+}
+
 function Convert-ToBool {
   param(
     [AllowNull()][AllowEmptyString()][string]$Value,
@@ -70,6 +110,51 @@ function Convert-ToBool {
     '^(true|1|yes|y|on)$' { return $true }
     '^(false|0|no|n|off)$' { return $false }
     default { return $Default }
+  }
+}
+
+function Escape-MarkdownCell {
+  param([AllowNull()][AllowEmptyString()][string]$Value)
+  if ([string]::IsNullOrWhiteSpace($Value)) { return '' }
+  return ($Value -replace '\|', '\|')
+}
+
+function Resolve-DefaultStopClass {
+  param(
+    [Parameter(Mandatory)][string]$LaneStatus,
+    [Parameter(Mandatory)][string]$FailureClass
+  )
+  switch ($LaneStatus) {
+    'success' { return 'completed' }
+    'failure' {
+      if ($FailureClass -eq 'runtime-determinism') {
+        return 'hard-stop'
+      }
+      return 'failure'
+    }
+    'skipped' { return 'none' }
+    default { return 'blocked' }
+  }
+}
+
+function Resolve-DefaultStopReason {
+  param(
+    [Parameter(Mandatory)][string]$LaneStatus,
+    [Parameter(Mandatory)][string]$FailureClass
+  )
+  switch ($LaneStatus) {
+    'success' { return 'lane-complete' }
+    'failure' {
+      if ($FailureClass -eq 'runtime-determinism') {
+        return 'runtime-determinism-hard-stop'
+      }
+      if ([string]::IsNullOrWhiteSpace($FailureClass) -or $FailureClass -eq 'none') {
+        return 'lane-failed'
+      }
+      return ("lane-failed ({0})" -f $FailureClass)
+    }
+    'skipped' { return '' }
+    default { return 'lane-not-started' }
   }
 }
 
@@ -85,6 +170,100 @@ function Write-GitHubOutput {
     New-Item -ItemType File -Path $DestPath -Force | Out-Null
   }
   Add-Content -LiteralPath $DestPath -Value ("{0}={1}" -f $Key, ($Value ?? '')) -Encoding utf8
+}
+
+function Resolve-LaneLifecycleEntry {
+  param(
+    [Parameter(Mandatory)][string]$LaneName,
+    [Parameter(Mandatory)][string]$LaneStatus,
+    [Parameter(Mandatory)][string]$FailureClass,
+    [AllowNull()]$ArtifactEntry,
+    [AllowNull()][AllowEmptyString()][string]$ExplicitStopClass,
+    [AllowNull()][AllowEmptyString()][string]$ExplicitStopReason,
+    [AllowNull()][AllowEmptyString()][string]$ExplicitStartStep,
+    [AllowNull()][AllowEmptyString()][string]$ExplicitEndStep,
+    [AllowNull()][AllowEmptyString()][string]$ExplicitStartedAt,
+    [AllowNull()][AllowEmptyString()][string]$ExplicitEndedAt,
+    [AllowNull()][AllowEmptyString()][string]$ExplicitHardStopTriggered
+  )
+
+  $defaultStopClass = Resolve-DefaultStopClass -LaneStatus $LaneStatus -FailureClass $FailureClass
+  $defaultStopReason = Resolve-DefaultStopReason -LaneStatus $LaneStatus -FailureClass $FailureClass
+
+  $artifactStopClass = ''
+  $artifactStopReason = ''
+  $artifactStartStep = ''
+  $artifactEndStep = ''
+  $artifactStartedAt = ''
+  $artifactEndedAt = ''
+  $artifactTotal = 0
+  $artifactExecuted = 0
+  $artifactStarted = $false
+  $artifactCompleted = $false
+  $artifactHardStop = $false
+  if ($ArtifactEntry) {
+    if ($ArtifactEntry.PSObject.Properties['stopClass']) { $artifactStopClass = Normalize-StopClass -Value ([string]$ArtifactEntry.stopClass) }
+    if ($ArtifactEntry.PSObject.Properties['stopReason']) { $artifactStopReason = [string]$ArtifactEntry.stopReason }
+    if ($ArtifactEntry.PSObject.Properties['startStep']) { $artifactStartStep = [string]$ArtifactEntry.startStep }
+    if ($ArtifactEntry.PSObject.Properties['endStep']) { $artifactEndStep = [string]$ArtifactEntry.endStep }
+    if ($ArtifactEntry.PSObject.Properties['startedAt']) { $artifactStartedAt = [string]$ArtifactEntry.startedAt }
+    if ($ArtifactEntry.PSObject.Properties['endedAt']) { $artifactEndedAt = [string]$ArtifactEntry.endedAt }
+    if ($ArtifactEntry.PSObject.Properties['totalPlannedSteps']) { $artifactTotal = [int]$ArtifactEntry.totalPlannedSteps }
+    if ($ArtifactEntry.PSObject.Properties['executedSteps']) { $artifactExecuted = [int]$ArtifactEntry.executedSteps }
+    if ($ArtifactEntry.PSObject.Properties['started']) { $artifactStarted = [bool]$ArtifactEntry.started }
+    if ($ArtifactEntry.PSObject.Properties['completed']) { $artifactCompleted = [bool]$ArtifactEntry.completed }
+    if ($ArtifactEntry.PSObject.Properties['hardStopTriggered']) { $artifactHardStop = [bool]$ArtifactEntry.hardStopTriggered }
+  }
+
+  $stopClass = Normalize-StopClass -Value $ExplicitStopClass
+  if ([string]::IsNullOrWhiteSpace($stopClass)) { $stopClass = $artifactStopClass }
+  if ([string]::IsNullOrWhiteSpace($stopClass)) { $stopClass = $defaultStopClass }
+
+  $stopReason = if (-not [string]::IsNullOrWhiteSpace($ExplicitStopReason)) { [string]$ExplicitStopReason } else { $artifactStopReason }
+  if ([string]::IsNullOrWhiteSpace($stopReason)) { $stopReason = $defaultStopReason }
+
+  $startStep = if (-not [string]::IsNullOrWhiteSpace($ExplicitStartStep)) { [string]$ExplicitStartStep } else { $artifactStartStep }
+  $endStep = if (-not [string]::IsNullOrWhiteSpace($ExplicitEndStep)) { [string]$ExplicitEndStep } else { $artifactEndStep }
+  $startedAt = if (-not [string]::IsNullOrWhiteSpace($ExplicitStartedAt)) { [string]$ExplicitStartedAt } else { $artifactStartedAt }
+  $endedAt = if (-not [string]::IsNullOrWhiteSpace($ExplicitEndedAt)) { [string]$ExplicitEndedAt } else { $artifactEndedAt }
+
+  $defaultStarted = ($LaneStatus -in @('success', 'failure'))
+  $defaultCompleted = ($LaneStatus -in @('success', 'failure'))
+  $defaultTotal = if ($LaneStatus -eq 'skipped') { 0 } else { 1 }
+  $defaultExecuted = if ($defaultStarted) { $defaultTotal } else { 0 }
+
+  $hardStopTriggered = Convert-ToBool -Value $ExplicitHardStopTriggered -Default $artifactHardStop
+  if (-not $hardStopTriggered -and $stopClass -eq 'hard-stop') {
+    $hardStopTriggered = $true
+  }
+
+  $totalPlannedSteps = if ($artifactTotal -gt 0 -or $LaneStatus -eq 'skipped') { $artifactTotal } else { $defaultTotal }
+  if ($LaneStatus -eq 'skipped') { $totalPlannedSteps = 0 }
+  $executedSteps = if ($artifactExecuted -gt 0 -or $totalPlannedSteps -eq 0) { $artifactExecuted } else { $defaultExecuted }
+  if ($executedSteps -gt $totalPlannedSteps -and $totalPlannedSteps -gt 0) {
+    $executedSteps = $totalPlannedSteps
+  }
+  $started = if ($ArtifactEntry -and $ArtifactEntry.PSObject.Properties['started']) { $artifactStarted } else { $defaultStarted }
+  $completed = if ($ArtifactEntry -and $ArtifactEntry.PSObject.Properties['completed']) { $artifactCompleted } else { $defaultCompleted }
+  if ($LaneStatus -eq 'skipped') {
+    $started = $false
+    $completed = $false
+  }
+
+  return [ordered]@{
+    status = $LaneStatus
+    totalPlannedSteps = [int]$totalPlannedSteps
+    executedSteps = [int]$executedSteps
+    started = [bool]$started
+    completed = [bool]$completed
+    startStep = ($startStep ?? '')
+    endStep = ($endStep ?? '')
+    startedAt = ($startedAt ?? '')
+    endedAt = ($endedAt ?? '')
+    hardStopTriggered = [bool]$hardStopTriggered
+    stopClass = ($stopClass ?? 'none')
+    stopReason = ($stopReason ?? '')
+  }
 }
 
 $resultsRootResolved = Resolve-AbsolutePath -Path $ResultsRoot
@@ -107,6 +286,47 @@ $linuxFailure = if ([string]::IsNullOrWhiteSpace($LinuxFailureClass)) {
   $LinuxFailureClass.Trim().ToLowerInvariant()
 }
 
+$fastLoopReadinessResolved = if ([string]::IsNullOrWhiteSpace($FastLoopReadinessPath)) { '' } else { Resolve-AbsolutePath -Path $FastLoopReadinessPath }
+$fastLoopProofResolved = if ([string]::IsNullOrWhiteSpace($FastLoopProofPath)) { '' } else { Resolve-AbsolutePath -Path $FastLoopProofPath }
+$fastLoopReadiness = Read-JsonOrNull -Path $fastLoopReadinessResolved
+$fastLoopProof = Read-JsonOrNull -Path $fastLoopProofResolved
+$artifactLaneLifecycle = if ($fastLoopReadiness -and $fastLoopReadiness.PSObject.Properties['laneLifecycle']) {
+  $fastLoopReadiness.laneLifecycle
+} elseif ($fastLoopProof -and $fastLoopProof.PSObject.Properties['laneLifecycle']) {
+  $fastLoopProof.laneLifecycle
+} else {
+  $null
+}
+
+$windowsArtifactLifecycle = if ($artifactLaneLifecycle -and $artifactLaneLifecycle.PSObject.Properties['windows']) { $artifactLaneLifecycle.windows } else { $null }
+$linuxArtifactLifecycle = if ($artifactLaneLifecycle -and $artifactLaneLifecycle.PSObject.Properties['linux']) { $artifactLaneLifecycle.linux } else { $null }
+
+$windowsLaneLifecycle = Resolve-LaneLifecycleEntry `
+  -LaneName 'windows' `
+  -LaneStatus $windows `
+  -FailureClass $windowsFailure `
+  -ArtifactEntry $windowsArtifactLifecycle `
+  -ExplicitStopClass $WindowsLaneStopClass `
+  -ExplicitStopReason $WindowsLaneStopReason `
+  -ExplicitStartStep $WindowsLaneStartStep `
+  -ExplicitEndStep $WindowsLaneEndStep `
+  -ExplicitStartedAt $WindowsLaneStartedAt `
+  -ExplicitEndedAt $WindowsLaneEndedAt `
+  -ExplicitHardStopTriggered $WindowsLaneHardStopTriggered
+
+$linuxLaneLifecycle = Resolve-LaneLifecycleEntry `
+  -LaneName 'linux' `
+  -LaneStatus $linux `
+  -FailureClass $linuxFailure `
+  -ArtifactEntry $linuxArtifactLifecycle `
+  -ExplicitStopClass $LinuxLaneStopClass `
+  -ExplicitStopReason $LinuxLaneStopReason `
+  -ExplicitStartStep $LinuxLaneStartStep `
+  -ExplicitEndStep $LinuxLaneEndStep `
+  -ExplicitStartedAt $LinuxLaneStartedAt `
+  -ExplicitEndedAt $LinuxLaneEndedAt `
+  -ExplicitHardStopTriggered $LinuxLaneHardStopTriggered
+
 $verdict = if ($windows -eq 'success' -and $linux -eq 'success') { 'ready' } else { 'not-ready' }
 $recommendation = if ($verdict -eq 'ready') { 'proceed' } else { 'hold' }
 
@@ -128,11 +348,21 @@ $envelope = [ordered]@{
   recommendation = $recommendation
   pullRequestNumber = $PrNumber
   runUrl = $RunUrl
+  source = [ordered]@{
+    fastLoopReadinessPath = if (-not [string]::IsNullOrWhiteSpace($fastLoopReadinessResolved) -and (Test-Path -LiteralPath $fastLoopReadinessResolved -PathType Leaf)) { $fastLoopReadinessResolved } else { '' }
+    fastLoopProofPath = if (-not [string]::IsNullOrWhiteSpace($fastLoopProofResolved) -and (Test-Path -LiteralPath $fastLoopProofResolved -PathType Leaf)) { $fastLoopProofResolved } else { '' }
+  }
+  laneLifecycle = [ordered]@{
+    windows = $windowsLaneLifecycle
+    linux = $linuxLaneLifecycle
+  }
   lanes = [ordered]@{
     windows = [ordered]@{
       status = $windows
       diffDetected = [bool]$windowsDiff
       failureClass = $windowsFailure
+      stopClass = [string]$windowsLaneLifecycle.stopClass
+      stopReason = [string]$windowsLaneLifecycle.stopReason
       runtimeSnapshotPath = $WindowsRuntimeSnapshotPath
       summaryPath = $SummaryPath
     }
@@ -140,6 +370,8 @@ $envelope = [ordered]@{
       status = $linux
       diffDetected = [bool]$linuxDiff
       failureClass = $linuxFailure
+      stopClass = [string]$linuxLaneLifecycle.stopClass
+      stopReason = [string]$linuxLaneLifecycle.stopReason
       runtimeSnapshotPath = $LinuxRuntimeSnapshotPath
       smokeSummaryPath = $LinuxSmokeSummaryPath
     }
@@ -160,10 +392,32 @@ $md.Add(('| PR Number | `{0}` |' -f ($PrNumber ?? ''))) | Out-Null
 $runUrlCell = if ([string]::IsNullOrWhiteSpace($RunUrl)) { '`' } else { "[link]($RunUrl)" }
 $md.Add(('| Run URL | {0} |' -f $runUrlCell)) | Out-Null
 $md.Add('') | Out-Null
-$md.Add('| Lane | Status | Diff Detected | Failure Class | Runtime Snapshot | Summary |') | Out-Null
-$md.Add('| --- | --- | --- | --- | --- | --- |') | Out-Null
-$md.Add(('| windows | `{0}` | `{1}` | `{2}` | `{3}` | `{4}` |' -f $windows, $windowsDiff, $windowsFailure, ($WindowsRuntimeSnapshotPath ?? ''), ($SummaryPath ?? ''))) | Out-Null
-$md.Add(('| linux | `{0}` | `{1}` | `{2}` | `{3}` | `{4}` |' -f $linux, $linuxDiff, $linuxFailure, ($LinuxRuntimeSnapshotPath ?? ''), ($LinuxSmokeSummaryPath ?? ''))) | Out-Null
+$md.Add('| Lane | Status | Diff Detected | Failure Class | Stop Class | Start Step | End Step | Runtime Snapshot | Summary |') | Out-Null
+$md.Add('| --- | --- | --- | --- | --- | --- | --- | --- | --- |') | Out-Null
+$md.Add(('| windows | `{0}` | `{1}` | `{2}` | `{3}` | `{4}` | `{5}` | `{6}` | `{7}` |' -f `
+    $windows, `
+    $windowsDiff, `
+    $windowsFailure, `
+    ([string]$windowsLaneLifecycle.stopClass), `
+    (Escape-MarkdownCell -Value ([string]$windowsLaneLifecycle.startStep)), `
+    (Escape-MarkdownCell -Value ([string]$windowsLaneLifecycle.endStep)), `
+    (Escape-MarkdownCell -Value ($WindowsRuntimeSnapshotPath ?? '')), `
+    (Escape-MarkdownCell -Value ($SummaryPath ?? '')))) | Out-Null
+if (-not [string]::IsNullOrWhiteSpace([string]$windowsLaneLifecycle.stopReason)) {
+  $md.Add(("| | | | | stop reason | `{0}` | | | |" -f (Escape-MarkdownCell -Value ([string]$windowsLaneLifecycle.stopReason)))) | Out-Null
+}
+$md.Add(('| linux | `{0}` | `{1}` | `{2}` | `{3}` | `{4}` | `{5}` | `{6}` | `{7}` |' -f `
+    $linux, `
+    $linuxDiff, `
+    $linuxFailure, `
+    ([string]$linuxLaneLifecycle.stopClass), `
+    (Escape-MarkdownCell -Value ([string]$linuxLaneLifecycle.startStep)), `
+    (Escape-MarkdownCell -Value ([string]$linuxLaneLifecycle.endStep)), `
+    (Escape-MarkdownCell -Value ($LinuxRuntimeSnapshotPath ?? '')), `
+    (Escape-MarkdownCell -Value ($LinuxSmokeSummaryPath ?? '')))) | Out-Null
+if (-not [string]::IsNullOrWhiteSpace([string]$linuxLaneLifecycle.stopReason)) {
+  $md.Add(("| | | | | stop reason | `{0}` | | | |" -f (Escape-MarkdownCell -Value ([string]$linuxLaneLifecycle.stopReason)))) | Out-Null
+}
 $md.Add('') | Out-Null
 $md.Add(('- Readiness JSON: `{0}`' -f $jsonOutResolved)) | Out-Null
 


### PR DESCRIPTION
## Summary
- add lane lifecycle/stop metadata inputs to `tools/Write-VIHistoryWorkflowReadiness.ps1`
- support fallback lane lifecycle import from fast-loop readiness/proof artifacts
- extend readiness markdown/envelope with stop class, start/end step, and stop reason rows
- expand `tests/Write-VIHistoryWorkflowReadiness.Tests.ps1` for explicit lifecycle and artifact import coverage

## Validation
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Path tests/Write-VIHistoryWorkflowReadiness.Tests.ps1 -Output Detailed"`
- `pwsh -NoLogo -NoProfile -File tools/PrePush-Checks.ps1 -SkipIconEditorFixtureChecks`

Closes #105
