### PR TITLE
Enforce 10-minute timeout budget defaults for PR VI history (#108)

### DIFF
--- a/.github/workflows/pr-vi-history.yml
+++ b/.github/workflows/pr-vi-history.yml
@@ -24,9 +24,9 @@ on:
         required: false
         default: '10'
       compare_timeout_seconds:
-        description: 'Per-compare timeout in seconds passed to history compare (default 900)'
+        description: 'Per-compare timeout in seconds passed to history compare (default 600)'
         required: false
-        default: '900'
+        default: '600'
       labview_path:
         description: 'LabVIEW.exe path used by headless compare operations'
         required: false
@@ -56,7 +56,7 @@ jobs:
       NOTE: ${{ inputs.note }}
       MAX_PAIRS: ${{ inputs.max_pairs || '6' }}
       FETCH_DEPTH: ${{ github.event.inputs.fetch_depth || '20' }}
-      COMPARE_TIMEOUT_SECONDS: ${{ github.event.inputs.compare_timeout_seconds || '900' }}
+      COMPARE_TIMEOUT_SECONDS: ${{ github.event.inputs.compare_timeout_seconds || '600' }}
       LABVIEW_PATH: ${{ github.event.inputs.labview_path || 'C:\Program Files\National Instruments\LabVIEW 2026\LabVIEW.exe' }}
     steps:
       - name: Resolve pull request metadata

--- a/tools/Test-PRVIHistorySmoke.ps1
+++ b/tools/Test-PRVIHistorySmoke.ps1
@@ -31,11 +31,11 @@ Optional override for the `max_pairs` workflow input. Defaults to `6`.
 
 .PARAMETER WorkflowTimeoutMinutes
 Optional override for the `history_timeout_minutes` workflow input used by
-`pr-vi-history.yml`. Defaults to `25` for smoke evidence runs.
+`pr-vi-history.yml`. Defaults to `10` for smoke evidence runs.
 
 .PARAMETER CompareTimeoutSeconds
 Optional override for the `compare_timeout_seconds` workflow input used by
-`pr-vi-history.yml`. Defaults to `900` for smoke evidence runs.
+`pr-vi-history.yml`. Defaults to `600` for smoke evidence runs.
 
 .PARAMETER BenchmarkBaselineWindow
 Rolling baseline window (same scenario) used when computing KPI deltas.
@@ -51,8 +51,8 @@ param(
     [ValidateSet('attribute', 'sequential', 'mixed-same-commit', 'sequential-masscompile')]
     [string]$Scenario = 'attribute',
     [int]$MaxPairs = 6,
-    [int]$WorkflowTimeoutMinutes = 25,
-    [int]$CompareTimeoutSeconds = 900,
+    [int]$WorkflowTimeoutMinutes = 10,
+    [int]$CompareTimeoutSeconds = 600,
     [ValidateRange(1, 50)]
     [int]$BenchmarkBaselineWindow = 5,
     [int]$EvidenceIssueNumber = 0


### PR DESCRIPTION
## Summary
- set `compare_timeout_seconds` workflow default from `900` to `600`
- align workflow env fallback for `COMPARE_TIMEOUT_SECONDS` to `600`
- align `tools/Test-PRVIHistorySmoke.ps1` defaults to the 10-minute budget (`WorkflowTimeoutMinutes=10`, `CompareTimeoutSeconds=600`)
- update smoke help text to match the new defaults

## Validation
- `pwsh -NoLogo -NoProfile -File tools/Test-PRVIHistorySmoke.ps1 -DryRun`
- `pwsh -NoLogo -NoProfile -File tools/PrePush-Checks.ps1 -SkipIconEditorFixtureChecks`
- Confirmed Windows image defaults remain `nationalinstruments/labview:2026q1-windows` (no 2025 Windows image tags in repo defaults)

Closes #108
