### PR TITLE
Add host-managed Docker runtime manager job to fixture drift (#110)

### DIFF
--- a/.github/workflows/fixture-drift.yml
+++ b/.github/workflows/fixture-drift.yml
@@ -54,6 +54,121 @@ jobs:
         $lv = Get-Process -Name 'LabVIEW' -ErrorAction SilentlyContinue
         if ($lv) { $pids = ($lv | ForEach-Object Id); $msg = '::notice::LabVIEW.exe is running (PID(s): {0}).' -f ([string]::Join(',', $pids)); Write-Host $msg } else { Write-Host 'LabVIEW not running.' }
         Write-Host 'Preflight check complete.'
+
+  docker-runtime-manager:
+    name: Docker Runtime Manager (Host)
+    runs-on: [self-hosted, Windows, X64]
+    needs:
+    - preflight-windows
+    timeout-minutes: 6
+    env:
+      NI_WINDOWS_IMAGE: nationalinstruments/labview:2026q1-windows
+      NI_LINUX_IMAGE: nationalinstruments/labview:2026q1-linux
+    steps:
+    - uses: actions/checkout@v5
+    - name: Validate Docker Desktop windows/linux runtime + NI image tags
+      shell: pwsh
+      run: |
+        Set-StrictMode -Version Latest
+        $ErrorActionPreference = 'Stop'
+
+        if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
+          throw 'Docker CLI not found on host. Install Docker Desktop and ensure docker.exe is on PATH.'
+        }
+
+        function Set-ContextAndWait {
+          param(
+            [Parameter(Mandatory)][string]$ContextName,
+            [Parameter(Mandatory)][string]$ExpectedOsType,
+            [int]$TimeoutSeconds = 120
+          )
+
+          $contextOut = & docker context use $ContextName 2>&1
+          if ($LASTEXITCODE -ne 0) {
+            throw ("Failed to switch Docker context to '{0}'. Output: {1}" -f $ContextName, ($contextOut -join ' '))
+          }
+
+          $deadline = (Get-Date).ToUniversalTime().AddSeconds($TimeoutSeconds)
+          do {
+            $osTypeOut = (& docker info --format '{{.OSType}}' 2>$null)
+            if ($LASTEXITCODE -eq 0) {
+              $osType = ([string]$osTypeOut).Trim().ToLowerInvariant()
+              if ($osType -eq $ExpectedOsType) {
+                return $osType
+              }
+            }
+            Start-Sleep -Seconds 2
+          } while ((Get-Date).ToUniversalTime() -lt $deadline)
+
+          $lastOs = ''
+          try {
+            $lastOs = [string](& docker info --format '{{.OSType}}' 2>$null)
+          } catch {}
+          throw ("Docker context '{0}' did not reach expected OSType '{1}' (last='{2}')." -f $ContextName, $ExpectedOsType, ($lastOs.Trim()))
+        }
+
+        function Assert-ManifestPlatform {
+          param(
+            [Parameter(Mandatory)][string]$Image,
+            [Parameter(Mandatory)][string]$ExpectedOs
+          )
+
+          $manifestOut = & docker manifest inspect $Image 2>&1
+          if ($LASTEXITCODE -ne 0) {
+            throw ("Failed to inspect image '{0}'. Output: {1}" -f $Image, ($manifestOut -join ' '))
+          }
+
+          $manifest = $manifestOut | ConvertFrom-Json -Depth 20
+          if ($manifest -and $manifest.PSObject.Properties['manifests'] -and $manifest.manifests) {
+            $platformOk = $false
+            foreach ($entry in @($manifest.manifests)) {
+              $platform = $entry.platform
+              if (-not $platform) { continue }
+              $os = if ($platform.PSObject.Properties['os']) { [string]$platform.os } else { '' }
+              $arch = if ($platform.PSObject.Properties['architecture']) { [string]$platform.architecture } else { '' }
+              if ($os.Trim().ToLowerInvariant() -eq $ExpectedOs -and $arch.Trim().ToLowerInvariant() -eq 'amd64') {
+                $platformOk = $true
+                break
+              }
+            }
+            if (-not $platformOk) {
+              throw ("Image '{0}' does not expose expected platform '{1}/amd64'." -f $Image, $ExpectedOs)
+            }
+          }
+
+          Write-Host ("Image manifest validated: {0} ({1}/amd64)" -f $Image, $ExpectedOs)
+        }
+
+        $contextAtStart = ''
+        try { $contextAtStart = ([string](& docker context show 2>$null)).Trim() } catch {}
+        if ([string]::IsNullOrWhiteSpace($contextAtStart)) { $contextAtStart = 'unknown' }
+        Write-Host ("Docker context at start: {0}" -f $contextAtStart)
+
+        try {
+          $null = Set-ContextAndWait -ContextName 'desktop-windows' -ExpectedOsType 'windows'
+          Assert-ManifestPlatform -Image $env:NI_WINDOWS_IMAGE -ExpectedOs 'windows'
+
+          $null = Set-ContextAndWait -ContextName 'desktop-linux' -ExpectedOsType 'linux'
+          Assert-ManifestPlatform -Image $env:NI_LINUX_IMAGE -ExpectedOs 'linux'
+        } finally {
+          try {
+            $null = Set-ContextAndWait -ContextName 'desktop-windows' -ExpectedOsType 'windows' -TimeoutSeconds 90
+            Write-Host 'Docker context restored to desktop-windows for downstream Windows job steps.'
+          } catch {
+            Write-Host ("::warning::Unable to restore Docker context to desktop-windows: {0}" -f $_.Exception.Message)
+          }
+        }
+
+        if ($env:GITHUB_STEP_SUMMARY) {
+          @(
+            '### Docker Runtime Manager',
+            '',
+            "- start context: $contextAtStart",
+            "- validated: `$($env:NI_WINDOWS_IMAGE)` (windows/amd64)",
+            "- validated: `$($env:NI_LINUX_IMAGE)` (linux/amd64)",
+            '- final context: desktop-windows'
+          ) -join "`n" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+        }
   validate-ubuntu:
     name: Fixture Drift (Ubuntu)
     runs-on: ubuntu-latest
@@ -131,7 +246,9 @@ jobs:
     concurrency:
       group: lv-fixture-win
       cancel-in-progress: false
-    needs: preflight-windows
+    needs:
+    - preflight-windows
+    - docker-runtime-manager
     timeout-minutes: 3
     env:
       INVOKER_REQUIRED: '1'


### PR DESCRIPTION
## Summary
- add a dedicated `docker-runtime-manager` job on the self-hosted Windows host
- move Docker Desktop engine/image validation into that manager job (single owner)
- validate both NI tags from this host:
  - `nationalinstruments/labview:2026q1-windows` (windows/amd64)
  - `nationalinstruments/labview:2026q1-linux` (linux/amd64)
- enforce Docker Desktop context switching and OSType checks (`desktop-windows` -> `desktop-linux` -> restore `desktop-windows`)
- wire `validate-windows` to depend on `docker-runtime-manager`

## Validation
- `pwsh -NoLogo -NoProfile -File tools/PrePush-Checks.ps1 -SkipIconEditorFixtureChecks`

Closes #110
