### PR TITLE
Add NI 2026q1 bootstrap preflight and fixture-drift contracts (#117 #116)

### DIFF
--- a/.github/workflows/fixture-drift.yml
+++ b/.github/workflows/fixture-drift.yml
@@ -60,7 +60,7 @@ jobs:
     runs-on: [self-hosted, Windows, X64, self-hosted-docker]
     needs:
     - preflight-windows
-    timeout-minutes: 6
+    timeout-minutes: 10
     outputs:
       manager_status: ${{ steps.manager.outputs.manager_status }}
       manager_summary_path: ${{ steps.manager.outputs.manager_summary_path }}
@@ -80,6 +80,8 @@ jobs:
         pwsh -NoLogo -NoProfile -File tools/Invoke-DockerRuntimeManager.ps1 `
           -WindowsImage $env:NI_WINDOWS_IMAGE `
           -LinuxImage $env:NI_LINUX_IMAGE `
+          -BootstrapWindowsImage:$true `
+          -BootstrapLinuxImage:$true `
           -OutputJsonPath 'results/fixture-drift/docker-runtime-manager.json' `
           -GitHubOutputPath $env:GITHUB_OUTPUT `
           -StepSummaryPath $env:GITHUB_STEP_SUMMARY
@@ -217,63 +219,14 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        $ErrorActionPreference = 'Stop'
-        $requiredLabel = 'self-hosted-docker'
-        $runnerName = '${{ runner.name }}'
-        $repo = '${{ github.repository }}'
-        $runId = '${{ github.run_id }}'
-        $token = $env:GITHUB_TOKEN
-        if ([string]::IsNullOrWhiteSpace($token)) {
-          throw 'GITHUB_TOKEN is required to validate runner labels. Set permissions.actions=read.'
-        }
-
-        $headers = @{
-          Authorization = "Bearer $token"
-          Accept = 'application/vnd.github+json'
-          'X-GitHub-Api-Version' = '2022-11-28'
-        }
-
-        $page = 1
-        $perPage = 100
-        $jobs = @()
-        do {
-          $uri = "https://api.github.com/repos/$repo/actions/runs/$runId/jobs?per_page=$perPage&page=$page"
-          $response = Invoke-RestMethod -Method Get -Uri $uri -Headers $headers -ErrorAction Stop
-          $candidates = @($response.jobs)
-          if ($candidates.Count -gt 0) {
-            $jobs += $candidates
-          }
-          $page++
-        } while ($candidates.Count -eq $perPage)
-
-        $currentJob = $jobs |
-          Where-Object { $_.runner_name -eq $runnerName -and $_.status -eq 'in_progress' } |
-          Select-Object -First 1
-        if (-not $currentJob) {
-          $currentJob = $jobs |
-            Where-Object { $_.runner_name -eq $runnerName } |
-            Sort-Object started_at -Descending |
-            Select-Object -First 1
-        }
-        if (-not $currentJob) {
-          throw ("Unable to resolve current job metadata for runner '{0}' in run {1}. Remediation: verify Actions run-jobs API visibility and rerun fixture-drift." -f $runnerName, $runId)
-        }
-
-        $labels = @($currentJob.labels | ForEach-Object { [string]$_ } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
-        $labelsSorted = @($labels | Sort-Object -Unique)
-        $hasRequiredLabel = $labelsSorted -contains $requiredLabel
-        $labelsCsv = $labelsSorted -join ','
-
-        "has_required_label=$($hasRequiredLabel.ToString().ToLowerInvariant())" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
-        "labels=$labelsCsv" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
-        "runner_id=$($currentJob.runner_id)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
-
-        if (-not $hasRequiredLabel) {
-          $message = "Runner '$runnerName' (id=$($currentJob.runner_id)) is missing required label '$requiredLabel'. Remediation: add the label in Repository Settings > Actions > Runners, then re-run fixture-drift."
-          Write-Host "::error::$message"
-          throw $message
-        }
-        Write-Host ("Runner label contract satisfied for '{0}' (id={1}): {2}" -f $runnerName, $currentJob.runner_id, $labelsCsv)
+        pwsh -NoLogo -NoProfile -File tools/Assert-RunnerLabelContract.ps1 `
+          -Repository '${{ github.repository }}' `
+          -RunId '${{ github.run_id }}' `
+          -RunnerName '${{ runner.name }}' `
+          -RequiredLabel 'self-hosted-docker' `
+          -OutputJsonPath 'results/fixture-drift/runner-label-contract.json' `
+          -GitHubOutputPath $env:GITHUB_OUTPUT `
+          -StepSummaryPath $env:GITHUB_STEP_SUMMARY
 
     - name: Persist docker runtime manager context
       id: docker_manager_context
@@ -541,35 +494,20 @@ jobs:
       if: always()
       shell: pwsh
       run: |
-        $ErrorActionPreference = 'Stop'
-        $resultsDir = 'results/fixture-drift'
-        $sessionPath = Join-Path $resultsDir 'session-index.json'
-        if (-not (Test-Path -LiteralPath $sessionPath -PathType Leaf)) {
-          Write-Host "::warning::session-index.json not found at $sessionPath; docker manager metadata was not attached."
-          exit 0
-        }
-
-        $contextPath = Join-Path $resultsDir 'docker-runtime-manager-context.json'
-        $idx = Get-Content -LiteralPath $sessionPath -Raw | ConvertFrom-Json -Depth 30
-        if (-not $idx.PSObject.Properties['runContext'] -or $null -eq $idx.runContext) {
-          $idx | Add-Member -MemberType NoteProperty -Name 'runContext' -Value ([ordered]@{}) -Force
-        }
-        $idx.runContext.dockerRuntimeManager = [ordered]@{
-          status = [string]$env:DOCKER_MANAGER_STATUS
-          summaryPath = [string]$env:DOCKER_MANAGER_SUMMARY_PATH
-          windowsImageDigest = [string]$env:DOCKER_MANAGER_WINDOWS_IMAGE_DIGEST
-          linuxImageDigest = [string]$env:DOCKER_MANAGER_LINUX_IMAGE_DIGEST
-          startContext = [string]$env:DOCKER_MANAGER_START_CONTEXT
-          finalContext = [string]$env:DOCKER_MANAGER_FINAL_CONTEXT
-          contextArtifactPath = if (Test-Path -LiteralPath $contextPath -PathType Leaf) { $contextPath } else { '' }
-        }
-        $idx.runContext.runnerLabelContract = [ordered]@{
-          requiredLabel = 'self-hosted-docker'
-          hasRequiredLabel = ('${{ steps.runner_label_contract.outputs.has_required_label }}' -eq 'true')
-          labels = @('${{ steps.runner_label_contract.outputs.labels }}' -split ',' | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
-        }
-        ($idx | ConvertTo-Json -Depth 30) | Set-Content -LiteralPath $sessionPath -Encoding utf8
-        Write-Host "Attached docker manager metadata to session index: $sessionPath"
+        $hasRequiredLabel = ('${{ steps.runner_label_contract.outputs.has_required_label }}' -eq 'true')
+        pwsh -NoLogo -NoProfile -File tools/Update-FixtureDriftSessionIndex.ps1 `
+          -ResultsDir 'results/fixture-drift' `
+          -ContextPath '${{ steps.docker_manager_context.outputs.context_path }}' `
+          -RequiredLabel 'self-hosted-docker' `
+          -HasRequiredLabel:$hasRequiredLabel `
+          -RunnerLabelsCsv '${{ steps.runner_label_contract.outputs.labels }}' `
+          -ManagerStatus $env:DOCKER_MANAGER_STATUS `
+          -ManagerSummaryPath $env:DOCKER_MANAGER_SUMMARY_PATH `
+          -WindowsImageDigest $env:DOCKER_MANAGER_WINDOWS_IMAGE_DIGEST `
+          -LinuxImageDigest $env:DOCKER_MANAGER_LINUX_IMAGE_DIGEST `
+          -StartContext $env:DOCKER_MANAGER_START_CONTEXT `
+          -FinalContext $env:DOCKER_MANAGER_FINAL_CONTEXT `
+          -IgnoreMissingSessionIndex
 
     - name: Wire Session Index (S1)
       if: always()
@@ -660,7 +598,7 @@ jobs:
       if: always()
       shell: pwsh
       run: |
-        $list = 'results/fixture-drift/drift-summary.json;results/fixture-drift/compare-report.html;results/fixture-drift/session-index.json;results/fixture-drift/docker-runtime-manager-context.json;results/fixture-drift/docker-runtime-manager.json'
+        $list = 'results/fixture-drift/drift-summary.json;results/fixture-drift/compare-report.html;results/fixture-drift/session-index.json;results/fixture-drift/docker-runtime-manager-context.json;results/fixture-drift/docker-runtime-manager.json;results/fixture-drift/runner-label-contract.json'
         pwsh -File tools/Write-ArtifactMap.ps1 -PathsList $list -Title 'Artifacts'
 
     - name: Re-run hint

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -87,6 +87,24 @@ Notes:
 - Capture JSON (`ni-windows-container-capture.json`) records machine-readable classification fields
   (`classification`, `labviewCliErrorCode`, `recommendation`, `reportExists`) for deterministic triage.
 
+### NI 2026 q1 host bootstrap preflight
+
+Use this when the NI Windows image is missing locally or to re-verify host readiness:
+
+```powershell
+node tools/npm/run-script.mjs docker:ni:windows:bootstrap
+```
+
+Default artifact path:
+
+- `tests/results/local-parity/windows-ni-2026q1-host-preflight.json`
+
+Common remediation:
+
+- Docker mode mismatch: switch Docker Desktop to Windows containers (`desktop-windows`) and retry.
+- Image pull failure: verify Docker Hub/GHCR connectivity and authentication, then rerun bootstrap.
+- Runtime probe failure: confirm the host can run Windows containers and that the NI tag is available.
+
 ## Tooling helpers
 
 | Variable | Purpose |

--- a/docs/FIXTURE_DRIFT.md
+++ b/docs/FIXTURE_DRIFT.md
@@ -45,6 +45,19 @@ Reusable output keys emitted by the manager step:
 The Windows fixture lane consumes these fields into step summary output and injects them into
 `session-index.json` under `runContext.dockerRuntimeManager` for downstream evidence review.
 
+The manager also bootstraps NI images when missing (`docker pull`) and records local runtime probe
+results per lane (`probes.<lane>.probe`), so evidence includes:
+
+- host OS + Docker start/final context metadata
+- local image presence and digest (`probes.<lane>.bootstrap.localDigest`)
+- probe command outcome (`probes.<lane>.probe.status` / `exitCode`)
+
+Quick local host bootstrap command:
+
+```powershell
+node tools/npm/run-script.mjs docker:ni:windows:bootstrap
+```
+
 ## Manual manifest updates
 
 For intentional fixture updates (outside automation):

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "cli:validate": "tsc -p tsconfig.cli.json && node dist/tools/cli/validate-cli.js",
     "compare:docker:ni:windows": "pwsh -NoLogo -NoProfile -File tools/Run-NIWindowsContainerCompare.ps1 -BaseVi $env:LV_BASE_VI -HeadVi $env:LV_HEAD_VI",
     "compare:docker:ni:windows:probe": "pwsh -NoLogo -NoProfile -File tools/Run-NIWindowsContainerCompare.ps1 -Probe",
+    "docker:ni:windows:bootstrap": "pwsh -NoLogo -NoProfile -File tools/Test-WindowsNI2026q1HostPreflight.ps1",
     "derive:env": "node dist/src/env/derive-env.js --json",
     "dev:watcher:autotrim": "pwsh -NoLogo -NoProfile -File tools/Dev-WatcherManager.ps1 -AutoTrim",
     "dev:watcher:ensure": "pwsh -NoLogo -NoProfile -File tools/Dev-WatcherManager.ps1 -Ensure",

--- a/tests/Assert-RunnerLabelContract.Tests.ps1
+++ b/tests/Assert-RunnerLabelContract.Tests.ps1
@@ -1,0 +1,132 @@
+#Requires -Version 7.0
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Describe 'Assert-RunnerLabelContract.ps1' -Tag 'Unit' {
+  BeforeAll {
+    $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+    $script:ToolPath = Join-Path $script:RepoRoot 'tools' 'Assert-RunnerLabelContract.ps1'
+    if (-not (Test-Path -LiteralPath $script:ToolPath -PathType Leaf)) {
+      throw "Assert-RunnerLabelContract.ps1 not found: $script:ToolPath"
+    }
+  }
+
+  It 'passes when required label is present in run-jobs payload' {
+    $work = Join-Path $TestDrive 'success'
+    New-Item -ItemType Directory -Path $work -Force | Out-Null
+
+    $jobsPayloadPath = Join-Path $work 'jobs.json'
+    $payload = [ordered]@{
+      jobs = @(
+        [ordered]@{
+          runner_name = 'host-a'
+          runner_id = 42
+          status = 'in_progress'
+          started_at = '2026-03-02T00:00:00Z'
+          labels = @('self-hosted', 'windows', 'self-hosted-docker')
+        }
+      )
+    }
+    ($payload | ConvertTo-Json -Depth 10) | Set-Content -LiteralPath $jobsPayloadPath -Encoding utf8
+
+    $outputJsonPath = Join-Path $work 'runner-label-contract.json'
+    $githubOutputPath = Join-Path $work 'github-output.txt'
+    $stepSummaryPath = Join-Path $work 'step-summary.md'
+
+    {
+      & $script:ToolPath `
+        -Repository 'owner/repo' `
+        -RunId '100' `
+        -RunnerName 'host-a' `
+        -RequiredLabel 'self-hosted-docker' `
+        -JobsPayloadPath $jobsPayloadPath `
+        -OutputJsonPath $outputJsonPath `
+        -GitHubOutputPath $githubOutputPath `
+        -StepSummaryPath $stepSummaryPath
+    } | Should -Not -Throw
+
+    $json = Get-Content -LiteralPath $outputJsonPath -Raw | ConvertFrom-Json -Depth 20
+    $json.schema | Should -Be 'runner-label-contract@v1'
+    $json.status | Should -Be 'success'
+    $json.failureClass | Should -Be 'none'
+    $json.hasRequiredLabel | Should -BeTrue
+    $json.runnerId | Should -Be '42'
+    @($json.labels) | Should -Contain 'self-hosted-docker'
+
+    $ghOutput = Get-Content -LiteralPath $githubOutputPath -Raw
+    $ghOutput | Should -Match 'has_required_label=true'
+    $ghOutput | Should -Match 'runner_label_contract_status=success'
+    $ghOutput | Should -Match 'runner_id=42'
+
+    $summary = Get-Content -LiteralPath $stepSummaryPath -Raw
+    $summary | Should -Match '### Runner Label Contract'
+    $summary | Should -Match 'status: `success`'
+  }
+
+  It 'fails with missing-label class when required label is absent' {
+    $work = Join-Path $TestDrive 'missing-label'
+    New-Item -ItemType Directory -Path $work -Force | Out-Null
+
+    $jobsPayloadPath = Join-Path $work 'jobs.json'
+    $payload = [ordered]@{
+      jobs = @(
+        [ordered]@{
+          runner_name = 'host-b'
+          runner_id = 77
+          status = 'completed'
+          started_at = '2026-03-02T00:01:00Z'
+          labels = @('self-hosted', 'windows')
+        }
+      )
+    }
+    ($payload | ConvertTo-Json -Depth 10) | Set-Content -LiteralPath $jobsPayloadPath -Encoding utf8
+
+    $outputJsonPath = Join-Path $work 'runner-label-contract.json'
+
+    {
+      & $script:ToolPath `
+        -Repository 'owner/repo' `
+        -RunId '101' `
+        -RunnerName 'host-b' `
+        -RequiredLabel 'self-hosted-docker' `
+        -JobsPayloadPath $jobsPayloadPath `
+        -OutputJsonPath $outputJsonPath
+    } | Should -Throw
+
+    $json = Get-Content -LiteralPath $outputJsonPath -Raw | ConvertFrom-Json -Depth 20
+    $json.status | Should -Be 'failure'
+    $json.failureClass | Should -Be 'missing-label'
+    $json.failureMessage | Should -Match 'missing required label'
+    $json.hasRequiredLabel | Should -BeFalse
+  }
+
+  It 'classifies 403 payload failures as api-permission' {
+    $work = Join-Path $TestDrive 'api-permission'
+    New-Item -ItemType Directory -Path $work -Force | Out-Null
+
+    $jobsPayloadPath = Join-Path $work 'jobs.json'
+    $payload = [ordered]@{
+      status = 403
+      message = 'Resource not accessible by integration'
+    }
+    ($payload | ConvertTo-Json -Depth 10) | Set-Content -LiteralPath $jobsPayloadPath -Encoding utf8
+
+    $outputJsonPath = Join-Path $work 'runner-label-contract.json'
+
+    {
+      & $script:ToolPath `
+        -Repository 'owner/repo' `
+        -RunId '102' `
+        -RunnerName 'host-c' `
+        -RequiredLabel 'self-hosted-docker' `
+        -JobsPayloadPath $jobsPayloadPath `
+        -OutputJsonPath $outputJsonPath
+    } | Should -Throw
+
+    $json = Get-Content -LiteralPath $outputJsonPath -Raw | ConvertFrom-Json -Depth 20
+    $json.status | Should -Be 'failure'
+    $json.failureClass | Should -Be 'api-permission'
+    $json.failureMessage | Should -Match 'Resource not accessible'
+  }
+}

--- a/tests/Invoke-DockerRuntimeManager.Tests.ps1
+++ b/tests/Invoke-DockerRuntimeManager.Tests.ps1
@@ -30,6 +30,16 @@ function Get-StatePath {
   return $path
 }
 
+function New-SeedState {
+  $initial = [Environment]::GetEnvironmentVariable('DOCKER_STUB_INITIAL_CONTEXT')
+  if ([string]::IsNullOrWhiteSpace($initial)) { $initial = 'desktop-windows' }
+  return [ordered]@{
+    activeContext = $initial
+    pulledWindows = $false
+    pulledLinux = $false
+  }
+}
+
 function Get-State {
   $statePath = Get-StatePath
   if (Test-Path -LiteralPath $statePath -PathType Leaf) {
@@ -38,10 +48,8 @@ function Get-State {
     } catch {
     }
   }
-  $initial = [Environment]::GetEnvironmentVariable('DOCKER_STUB_INITIAL_CONTEXT')
-  if ([string]::IsNullOrWhiteSpace($initial)) { $initial = 'desktop-windows' }
-  $seed = [ordered]@{ activeContext = $initial }
-  ($seed | ConvertTo-Json -Depth 5) | Set-Content -LiteralPath $statePath -Encoding utf8
+  $seed = New-SeedState
+  ($seed | ConvertTo-Json -Depth 10) | Set-Content -LiteralPath $statePath -Encoding utf8
   return (Get-Content -LiteralPath $statePath -Raw | ConvertFrom-Json -ErrorAction Stop)
 }
 
@@ -51,7 +59,15 @@ function Set-State([object]$State) {
   if ($parent -and -not (Test-Path -LiteralPath $parent -PathType Container)) {
     New-Item -ItemType Directory -Path $parent -Force | Out-Null
   }
-  ($State | ConvertTo-Json -Depth 5) | Set-Content -LiteralPath $statePath -Encoding utf8
+  ($State | ConvertTo-Json -Depth 10) | Set-Content -LiteralPath $statePath -Encoding utf8
+}
+
+function Is-WindowsImage([string]$Image) {
+  return ($Image -match '(?i)windows')
+}
+
+function Is-LinuxImage([string]$Image) {
+  return ($Image -match '(?i)linux')
 }
 
 if ($Args.Count -eq 0) { exit 0 }
@@ -93,14 +109,14 @@ if ($Args[0] -eq 'manifest' -and $Args.Count -ge 3 -and $Args[1] -eq 'inspect') 
     schemaVersion = 2
     manifests = @(
       [ordered]@{
-        digest = 'sha256:stubwindows'
+        digest = 'sha256:1111111111111111111111111111111111111111111111111111111111111111'
         platform = [ordered]@{
           os = 'windows'
           architecture = 'amd64'
         }
       },
       [ordered]@{
-        digest = 'sha256:stublinux'
+        digest = 'sha256:2222222222222222222222222222222222222222222222222222222222222222'
         platform = [ordered]@{
           os = 'linux'
           architecture = 'amd64'
@@ -109,6 +125,65 @@ if ($Args[0] -eq 'manifest' -and $Args.Count -ge 3 -and $Args[1] -eq 'inspect') 
     )
   }
   ($manifest | ConvertTo-Json -Depth 10) | Write-Output
+  exit 0
+}
+
+if ($Args[0] -eq 'image' -and $Args.Count -ge 3 -and $Args[1] -eq 'inspect') {
+  $image = [string]$Args[2]
+  $requirePullWindows = ([Environment]::GetEnvironmentVariable('DOCKER_STUB_REQUIRE_PULL_WINDOWS') -eq '1')
+  $requirePullLinux = ([Environment]::GetEnvironmentVariable('DOCKER_STUB_REQUIRE_PULL_LINUX') -eq '1')
+
+  $needsPull = $false
+  if ($requirePullWindows -and (Is-WindowsImage -Image $image) -and -not [bool]$state.pulledWindows) { $needsPull = $true }
+  if ($requirePullLinux -and (Is-LinuxImage -Image $image) -and -not [bool]$state.pulledLinux) { $needsPull = $true }
+
+  if ($needsPull) {
+    [Console]::Error.WriteLine(("Error: No such image: {0}" -f $image))
+    exit 1
+  }
+
+  $digest = if (Is-WindowsImage -Image $image) { 'sha256:3333333333333333333333333333333333333333333333333333333333333333' } else { 'sha256:4444444444444444444444444444444444444444444444444444444444444444' }
+  $id = if (Is-WindowsImage -Image $image) { 'sha256:stub-image-id-windows' } else { 'sha256:stub-image-id-linux' }
+  $payload = [ordered]@{
+    Id = $id
+    RepoDigests = @("$image@$digest")
+  }
+  ($payload | ConvertTo-Json -Depth 10 -Compress) | Write-Output
+  exit 0
+}
+
+if ($Args[0] -eq 'pull' -and $Args.Count -ge 2) {
+  $image = [string]$Args[1]
+  if (([Environment]::GetEnvironmentVariable('DOCKER_STUB_PULL_FAIL_WINDOWS') -eq '1') -and (Is-WindowsImage -Image $image)) {
+    [Console]::Error.WriteLine(("pull denied for {0}" -f $image))
+    exit 1
+  }
+  if (([Environment]::GetEnvironmentVariable('DOCKER_STUB_PULL_FAIL_LINUX') -eq '1') -and (Is-LinuxImage -Image $image)) {
+    [Console]::Error.WriteLine(("pull denied for {0}" -f $image))
+    exit 1
+  }
+
+  if (Is-WindowsImage -Image $image) { $state.pulledWindows = $true }
+  if (Is-LinuxImage -Image $image) { $state.pulledLinux = $true }
+  Set-State -State $state
+  $digest = if (Is-WindowsImage -Image $image) { 'sha256:3333333333333333333333333333333333333333333333333333333333333333' } else { 'sha256:4444444444444444444444444444444444444444444444444444444444444444' }
+  Write-Output ("Digest: {0}" -f $digest)
+  exit 0
+}
+
+if ($Args[0] -eq 'run') {
+  $joined = ($Args -join ' ')
+  $runFailWindows = ([Environment]::GetEnvironmentVariable('DOCKER_STUB_RUN_FAIL_WINDOWS') -eq '1')
+  $runFailLinux = ([Environment]::GetEnvironmentVariable('DOCKER_STUB_RUN_FAIL_LINUX') -eq '1')
+  if ($runFailWindows -and $joined -match '(?i)windows') {
+    [Console]::Error.WriteLine('runtime probe failed (windows)')
+    exit 5
+  }
+  if ($runFailLinux -and $joined -match '(?i)linux') {
+    [Console]::Error.WriteLine('runtime probe failed (linux)')
+    exit 6
+  }
+  Write-Output 'ni-runtime-probe-ok'
   exit 0
 }
 
@@ -133,6 +208,12 @@ exit 0
       DOCKER_STUB_INITIAL_CONTEXT = $env:DOCKER_STUB_INITIAL_CONTEXT
       DOCKER_STUB_FAIL_CONTEXT = $env:DOCKER_STUB_FAIL_CONTEXT
       DOCKER_STUB_FORCE_INFO_FAILURE = $env:DOCKER_STUB_FORCE_INFO_FAILURE
+      DOCKER_STUB_REQUIRE_PULL_WINDOWS = $env:DOCKER_STUB_REQUIRE_PULL_WINDOWS
+      DOCKER_STUB_REQUIRE_PULL_LINUX = $env:DOCKER_STUB_REQUIRE_PULL_LINUX
+      DOCKER_STUB_PULL_FAIL_WINDOWS = $env:DOCKER_STUB_PULL_FAIL_WINDOWS
+      DOCKER_STUB_PULL_FAIL_LINUX = $env:DOCKER_STUB_PULL_FAIL_LINUX
+      DOCKER_STUB_RUN_FAIL_WINDOWS = $env:DOCKER_STUB_RUN_FAIL_WINDOWS
+      DOCKER_STUB_RUN_FAIL_LINUX = $env:DOCKER_STUB_RUN_FAIL_LINUX
       RUNNER_TEMP = $env:RUNNER_TEMP
     }
   }
@@ -170,26 +251,61 @@ exit 0
       -SwitchTimeoutSeconds 30 2>&1
     $LASTEXITCODE | Should -Be 0 -Because ($output -join "`n")
 
-    $json = Get-Content -LiteralPath $jsonPath -Raw | ConvertFrom-Json -Depth 25
+    $json = Get-Content -LiteralPath $jsonPath -Raw | ConvertFrom-Json -Depth 30
     $json.schema | Should -Be 'docker-runtime-manager@v1'
     $json.status | Should -Be 'success'
     $json.failureClass | Should -Be 'none'
     $json.lock.acquired | Should -BeTrue
     $json.probes.windows.status | Should -Be 'success'
     $json.probes.linux.status | Should -Be 'success'
-    $json.probes.windows.digest | Should -Be 'sha256:stubwindows'
-    $json.probes.linux.digest | Should -Be 'sha256:stublinux'
+    $json.probes.windows.digest | Should -Be 'sha256:1111111111111111111111111111111111111111111111111111111111111111'
+    $json.probes.linux.digest | Should -Be 'sha256:2222222222222222222222222222222222222222222222222222222222222222'
+    $json.probes.windows.bootstrap.imagePresent | Should -BeTrue
+    $json.probes.linux.bootstrap.imagePresent | Should -BeTrue
+    $json.probes.windows.bootstrap.localDigest | Should -Be 'sha256:3333333333333333333333333333333333333333333333333333333333333333'
+    $json.probes.linux.bootstrap.localDigest | Should -Be 'sha256:4444444444444444444444444444444444444444444444444444444444444444'
+    $json.probes.windows.probe.status | Should -Be 'success'
+    $json.probes.linux.probe.status | Should -Be 'success'
     $json.contexts.start | Should -Be 'desktop-linux'
     $json.contexts.final | Should -Be 'desktop-windows'
 
     $ghOutput = Get-Content -LiteralPath $outputPath -Raw
     $ghOutput | Should -Match 'manager_status=success'
-    $ghOutput | Should -Match 'windows_image_digest=sha256:stubwindows'
-    $ghOutput | Should -Match 'linux_image_digest=sha256:stublinux'
+    $ghOutput | Should -Match 'windows_image_digest=sha256:3333333333333333333333333333333333333333333333333333333333333333'
+    $ghOutput | Should -Match 'linux_image_digest=sha256:4444444444444444444444444444444444444444444444444444444444444444'
+    $ghOutput | Should -Match 'windows_probe_status=success'
+    $ghOutput | Should -Match 'linux_probe_status=success'
 
     $summary = Get-Content -LiteralPath $summaryPath -Raw
     $summary | Should -Match '### Docker Runtime Manager'
     $summary | Should -Match 'status: `success`'
+    $summary | Should -Match 'probe=`success`'
+  }
+
+  It 'bootstraps missing windows image when windows-only probe scope is selected' {
+    $work = Join-Path $TestDrive 'bootstrap-windows'
+    New-Item -ItemType Directory -Path $work -Force | Out-Null
+    & $script:CreateDockerStub -WorkRoot $work
+
+    Set-Item Env:DOCKER_STUB_STATE_PATH (Join-Path $work 'docker-state.json')
+    Set-Item Env:DOCKER_STUB_INITIAL_CONTEXT 'desktop-windows'
+    Set-Item Env:DOCKER_STUB_REQUIRE_PULL_WINDOWS '1'
+    Set-Item Env:RUNNER_TEMP (Join-Path $work 'runner-temp')
+
+    $jsonPath = Join-Path $work 'docker-runtime-manager.json'
+    $output = & pwsh -NoLogo -NoProfile -File $script:ManagerScript `
+      -ProbeScope windows `
+      -OutputJsonPath $jsonPath `
+      -SwitchRetryCount 1 `
+      -SwitchTimeoutSeconds 30 2>&1
+    $LASTEXITCODE | Should -Be 0 -Because ($output -join "`n")
+
+    $json = Get-Content -LiteralPath $jsonPath -Raw | ConvertFrom-Json -Depth 30
+    $json.status | Should -Be 'success'
+    $json.probes.windows.bootstrap.pulled | Should -BeTrue
+    $json.probes.windows.bootstrap.imagePresent | Should -BeTrue
+    $json.probes.windows.probe.status | Should -Be 'success'
+    $json.probes.linux.status | Should -Be 'skipped'
   }
 
   It 'classifies context switch failure as runtime-determinism failure' {
@@ -214,7 +330,7 @@ exit 0
     $text = $output -join "`n"
     $text | Should -Match 'Failed to switch Docker context to'
 
-    $json = Get-Content -LiteralPath $jsonPath -Raw | ConvertFrom-Json -Depth 25
+    $json = Get-Content -LiteralPath $jsonPath -Raw | ConvertFrom-Json -Depth 30
     $json.status | Should -Be 'failure'
     $json.failureClass | Should -Be 'runtime-determinism'
     $json.probes.windows.status | Should -Be 'success'
@@ -223,6 +339,33 @@ exit 0
 
     $ghOutput = Get-Content -LiteralPath $outputPath -Raw
     $ghOutput | Should -Match 'manager_status=failure'
+  }
+
+  It 'fails with image-bootstrap classification when windows image is missing and bootstrap is disabled' {
+    $work = Join-Path $TestDrive 'bootstrap-disabled'
+    New-Item -ItemType Directory -Path $work -Force | Out-Null
+    & $script:CreateDockerStub -WorkRoot $work
+
+    Set-Item Env:DOCKER_STUB_STATE_PATH (Join-Path $work 'docker-state.json')
+    Set-Item Env:DOCKER_STUB_INITIAL_CONTEXT 'desktop-windows'
+    Set-Item Env:DOCKER_STUB_REQUIRE_PULL_WINDOWS '1'
+    Set-Item Env:RUNNER_TEMP (Join-Path $work 'runner-temp')
+
+    $jsonPath = Join-Path $work 'docker-runtime-manager.json'
+    $output = & pwsh -NoLogo -NoProfile -File $script:ManagerScript `
+      -ProbeScope windows `
+      -BootstrapWindowsImage:$false `
+      -OutputJsonPath $jsonPath `
+      -SwitchRetryCount 1 `
+      -SwitchTimeoutSeconds 30 2>&1
+
+    $LASTEXITCODE | Should -Not -Be 0
+    ($output -join "`n") | Should -Match 'Local image inspect failed'
+
+    $json = Get-Content -LiteralPath $jsonPath -Raw | ConvertFrom-Json -Depth 30
+    $json.status | Should -Be 'failure'
+    $json.failureClass | Should -Be 'image-bootstrap'
+    $json.probes.windows.status | Should -Be 'success'
   }
 
   It 'fails with lock timeout when the runtime manager lock is held by another process' {
@@ -249,7 +392,7 @@ exit 0
       $LASTEXITCODE | Should -Not -Be 0
       ($output -join "`n") | Should -Match 'Timed out waiting for Docker manager lock'
 
-      $json = Get-Content -LiteralPath $jsonPath -Raw | ConvertFrom-Json -Depth 25
+      $json = Get-Content -LiteralPath $jsonPath -Raw | ConvertFrom-Json -Depth 30
       $json.status | Should -Be 'failure'
       $json.failureClass | Should -Be 'runtime-determinism'
       $json.failureMessage | Should -Match 'Timed out waiting for Docker manager lock'

--- a/tests/Update-FixtureDriftSessionIndex.Tests.ps1
+++ b/tests/Update-FixtureDriftSessionIndex.Tests.ps1
@@ -1,0 +1,64 @@
+#Requires -Version 7.0
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Describe 'Update-FixtureDriftSessionIndex.ps1' -Tag 'Unit' {
+  BeforeAll {
+    $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+    $script:ToolPath = Join-Path $script:RepoRoot 'tools' 'Update-FixtureDriftSessionIndex.ps1'
+    if (-not (Test-Path -LiteralPath $script:ToolPath -PathType Leaf)) {
+      throw "Update-FixtureDriftSessionIndex.ps1 not found: $script:ToolPath"
+    }
+  }
+
+  It 'persists docker manager and runner label metadata into session-index runContext' {
+    $resultsDir = Join-Path $TestDrive 'results'
+    New-Item -ItemType Directory -Path $resultsDir -Force | Out-Null
+
+    $sessionIndexPath = Join-Path $resultsDir 'session-index.json'
+    $sessionIndex = [ordered]@{
+      schema = 'session-index/v1'
+      status = 'ok'
+    }
+    ($sessionIndex | ConvertTo-Json -Depth 10) | Set-Content -LiteralPath $sessionIndexPath -Encoding utf8
+
+    $contextPath = Join-Path $resultsDir 'docker-runtime-manager-context.json'
+    $context = [ordered]@{
+      schema = 'fixture-drift/docker-runtime-manager-context@v1'
+    }
+    ($context | ConvertTo-Json -Depth 10) | Set-Content -LiteralPath $contextPath -Encoding utf8
+
+    $resultPath = & $script:ToolPath `
+      -ResultsDir $resultsDir `
+      -ContextPath $contextPath `
+      -RequiredLabel 'self-hosted-docker' `
+      -HasRequiredLabel:$true `
+      -RunnerLabelsCsv 'self-hosted,windows,self-hosted-docker' `
+      -ManagerStatus 'success' `
+      -ManagerSummaryPath 'results/fixture-drift/docker-runtime-manager.json' `
+      -WindowsImageDigest 'sha256:windows' `
+      -LinuxImageDigest 'sha256:linux' `
+      -StartContext 'desktop-windows' `
+      -FinalContext 'desktop-windows'
+
+    [string]$resultPath | Should -Be $sessionIndexPath
+
+    $updated = Get-Content -LiteralPath $sessionIndexPath -Raw | ConvertFrom-Json -Depth 30
+    $updated.runContext.dockerRuntimeManager.status | Should -Be 'success'
+    $updated.runContext.dockerRuntimeManager.windowsImageDigest | Should -Be 'sha256:windows'
+    $updated.runContext.dockerRuntimeManager.contextArtifactPath | Should -Be $contextPath
+    $updated.runContext.runnerLabelContract.requiredLabel | Should -Be 'self-hosted-docker'
+    $updated.runContext.runnerLabelContract.hasRequiredLabel | Should -BeTrue
+    @($updated.runContext.runnerLabelContract.labels) | Should -Contain 'self-hosted-docker'
+  }
+
+  It 'does not throw when session-index is missing and IgnoreMissingSessionIndex is enabled' {
+    $resultsDir = Join-Path $TestDrive 'missing'
+    New-Item -ItemType Directory -Path $resultsDir -Force | Out-Null
+
+    {
+      & $script:ToolPath -ResultsDir $resultsDir -IgnoreMissingSessionIndex
+    } | Should -Not -Throw
+  }
+}

--- a/tests/Write-FixtureDriftSummary.Tests.ps1
+++ b/tests/Write-FixtureDriftSummary.Tests.ps1
@@ -1,0 +1,77 @@
+#Requires -Version 7.0
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Describe 'Write-FixtureDriftSummary.ps1' -Tag 'Unit' {
+  BeforeAll {
+    $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+    $script:ToolPath = Join-Path $script:RepoRoot 'tools' 'Write-FixtureDriftSummary.ps1'
+    if (-not (Test-Path -LiteralPath $script:ToolPath -PathType Leaf)) {
+      throw "Write-FixtureDriftSummary.ps1 not found: $script:ToolPath"
+    }
+  }
+
+  BeforeEach {
+    $script:SummaryPath = Join-Path $TestDrive 'step-summary.md'
+    $env:GITHUB_STEP_SUMMARY = $script:SummaryPath
+  }
+
+  AfterEach {
+    Remove-Item Env:GITHUB_STEP_SUMMARY -ErrorAction SilentlyContinue
+  }
+
+  It 'renders docker runtime manager details when context file is present' {
+    $resultsDir = Join-Path $TestDrive 'results'
+    New-Item -ItemType Directory -Path $resultsDir -Force | Out-Null
+
+    $driftSummary = [ordered]@{
+      summaryCounts = [ordered]@{
+        passed = 3
+        failed = 0
+      }
+      notes = @('fixture drift ok')
+    }
+    ($driftSummary | ConvertTo-Json -Depth 10) | Set-Content -LiteralPath (Join-Path $resultsDir 'drift-summary.json') -Encoding utf8
+
+    $dockerContext = [ordered]@{
+      manager = [ordered]@{
+        status = 'success'
+        startContext = 'desktop-windows'
+        finalContext = 'desktop-windows'
+        windowsImageDigest = 'sha256:windowsdigest'
+        linuxImageDigest = 'sha256:linuxdigest'
+        summaryPath = 'results/fixture-drift/docker-runtime-manager.json'
+      }
+    }
+    ($dockerContext | ConvertTo-Json -Depth 10) | Set-Content -LiteralPath (Join-Path $resultsDir 'docker-runtime-manager-context.json') -Encoding utf8
+
+    & $script:ToolPath -Dir $resultsDir
+
+    $summary = Get-Content -LiteralPath $script:SummaryPath -Raw
+    $summary | Should -Match '### Fixture Drift'
+    $summary | Should -Match 'Docker Runtime Manager'
+    $summary | Should -Match 'Status: success'
+    $summary | Should -Match 'Start Context: desktop-windows'
+    $summary | Should -Match 'Windows Digest: sha256:windowsdigest'
+    $summary | Should -Match 'Linux Digest: sha256:linuxdigest'
+  }
+
+  It 'emits parse-failed note when docker context file is invalid json' {
+    $resultsDir = Join-Path $TestDrive 'parse-failure'
+    New-Item -ItemType Directory -Path $resultsDir -Force | Out-Null
+
+    $driftSummary = [ordered]@{
+      summaryCounts = [ordered]@{
+        passed = 1
+      }
+    }
+    ($driftSummary | ConvertTo-Json -Depth 10) | Set-Content -LiteralPath (Join-Path $resultsDir 'drift-summary.json') -Encoding utf8
+    Set-Content -LiteralPath (Join-Path $resultsDir 'docker-runtime-manager-context.json') -Value '{invalid' -Encoding utf8
+
+    & $script:ToolPath -Dir $resultsDir
+
+    $summary = Get-Content -LiteralPath $script:SummaryPath -Raw
+    $summary | Should -Match 'Docker Runtime Manager context parse failed'
+  }
+}

--- a/tools/Assert-RunnerLabelContract.ps1
+++ b/tools/Assert-RunnerLabelContract.ps1
@@ -1,0 +1,286 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+  Validates that the current Actions job runner includes a required label.
+
+.DESCRIPTION
+  Resolves runner metadata from the GitHub Actions run-jobs API and fails with
+  deterministic remediation text when the required label is missing.
+
+  This script supports test/offline execution through -JobsPayloadPath.
+#>
+[CmdletBinding()]
+param(
+  [string]$Repository = $env:GITHUB_REPOSITORY,
+  [string]$RunId = $env:GITHUB_RUN_ID,
+  [string]$RunnerName = $env:RUNNER_NAME,
+  [string]$RequiredLabel = 'self-hosted-docker',
+  [string]$Token = $env:GITHUB_TOKEN,
+  [string]$OutputJsonPath = 'results/fixture-drift/runner-label-contract.json',
+  [string]$GitHubOutputPath = $env:GITHUB_OUTPUT,
+  [string]$StepSummaryPath = $env:GITHUB_STEP_SUMMARY,
+  [string]$JobsPayloadPath = ''
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Resolve-AbsolutePath {
+  param([Parameter(Mandatory)][string]$Path)
+  if ([System.IO.Path]::IsPathRooted($Path)) {
+    return [System.IO.Path]::GetFullPath($Path)
+  }
+  return [System.IO.Path]::GetFullPath((Join-Path (Get-Location).Path $Path))
+}
+
+function Write-GitHubOutput {
+  param(
+    [Parameter(Mandatory)][string]$Key,
+    [AllowNull()][AllowEmptyString()][string]$Value,
+    [AllowNull()][AllowEmptyString()][string]$Path
+  )
+
+  if ([string]::IsNullOrWhiteSpace($Path)) { return }
+  $dest = Resolve-AbsolutePath -Path $Path
+  $parent = Split-Path -Parent $dest
+  if ($parent -and -not (Test-Path -LiteralPath $parent -PathType Container)) {
+    New-Item -ItemType Directory -Path $parent -Force | Out-Null
+  }
+  Add-Content -LiteralPath $dest -Value ("{0}={1}" -f $Key, ($Value ?? '')) -Encoding utf8
+}
+
+function New-ApiException {
+  param(
+    [Parameter(Mandatory)][string]$Message,
+    [AllowNull()][int]$StatusCode
+  )
+
+  $exception = [System.Exception]::new($Message)
+  if ($null -ne $StatusCode -and $StatusCode -gt 0) {
+    $exception.Data['HttpStatusCode'] = [int]$StatusCode
+  }
+  return $exception
+}
+
+function Get-StatusCodeFromError {
+  param([Parameter(Mandatory)][System.Management.Automation.ErrorRecord]$ErrorRecord)
+
+  $statusCode = 0
+  try {
+    $ex = $ErrorRecord.Exception
+    if ($ex -and $ex.Data -and $ex.Data.Contains('HttpStatusCode')) {
+      return [int]$ex.Data['HttpStatusCode']
+    }
+    if ($ex -and $ex.PSObject.Properties['Response'] -and $ex.Response) {
+      if ($ex.Response.PSObject.Properties['StatusCode'] -and $ex.Response.StatusCode) {
+        return [int]$ex.Response.StatusCode
+      }
+    }
+  } catch {}
+
+  $message = [string]$ErrorRecord.Exception.Message
+  if ($message -match '"status"\s*:\s*"?(\d{3})"?' -or $message -match 'HTTP\s*(\d{3})') {
+    [void][int]::TryParse($Matches[1], [ref]$statusCode)
+  }
+  return $statusCode
+}
+
+function Convert-JobLabelsToArray {
+  param([AllowNull()]$Labels)
+
+  $values = New-Object System.Collections.Generic.List[string]
+  foreach ($entry in @($Labels)) {
+    if ($entry -is [string]) {
+      $candidate = [string]$entry
+    } elseif ($entry -and $entry.PSObject.Properties['name']) {
+      $candidate = [string]$entry.name
+    } else {
+      $candidate = ''
+    }
+    if (-not [string]::IsNullOrWhiteSpace($candidate)) {
+      $values.Add($candidate) | Out-Null
+    }
+  }
+  return @($values.ToArray() | Sort-Object -Unique)
+}
+
+function Get-RunJobs {
+  param(
+    [Parameter(Mandatory)][string]$Repository,
+    [Parameter(Mandatory)][string]$RunId,
+    [string]$Token,
+    [string]$JobsPayloadPath
+  )
+
+  if (-not [string]::IsNullOrWhiteSpace($JobsPayloadPath)) {
+    $payloadResolved = Resolve-AbsolutePath -Path $JobsPayloadPath
+    if (-not (Test-Path -LiteralPath $payloadResolved -PathType Leaf)) {
+      throw (New-ApiException -Message ("Jobs payload file not found: {0}" -f $payloadResolved) -StatusCode 0)
+    }
+    $payload = Get-Content -LiteralPath $payloadResolved -Raw | ConvertFrom-Json -Depth 30
+    if ($payload -is [System.Array]) {
+      return @($payload)
+    }
+    if ($payload.PSObject.Properties['jobs'] -and $payload.jobs) {
+      return @($payload.jobs)
+    }
+    if ($payload.PSObject.Properties['status'] -and $payload.PSObject.Properties['message']) {
+      $status = 0
+      [void][int]::TryParse([string]$payload.status, [ref]$status)
+      throw (New-ApiException -Message ([string]$payload.message) -StatusCode $status)
+    }
+    throw (New-ApiException -Message ("Unsupported jobs payload format: {0}" -f $payloadResolved) -StatusCode 0)
+  }
+
+  if ([string]::IsNullOrWhiteSpace($Token)) {
+    throw (New-ApiException -Message 'GITHUB_TOKEN is required to validate runner labels. Set permissions.actions=read.' -StatusCode 401)
+  }
+
+  $headers = @{
+    Authorization = "Bearer $Token"
+    Accept = 'application/vnd.github+json'
+    'X-GitHub-Api-Version' = '2022-11-28'
+  }
+
+  $jobs = New-Object System.Collections.Generic.List[object]
+  $page = 1
+  $perPage = 100
+  do {
+    $uri = "https://api.github.com/repos/$Repository/actions/runs/$RunId/jobs?per_page=$perPage&page=$page"
+    try {
+      $response = Invoke-RestMethod -Method Get -Uri $uri -Headers $headers -ErrorAction Stop
+    } catch {
+      $status = Get-StatusCodeFromError -ErrorRecord $_
+      $message = [string]$_.Exception.Message
+      throw (New-ApiException -Message $message -StatusCode $status)
+    }
+
+    $candidates = @($response.jobs)
+    foreach ($job in $candidates) {
+      $jobs.Add($job) | Out-Null
+    }
+    $page++
+  } while ($candidates.Count -eq $perPage)
+
+  return @($jobs.ToArray())
+}
+
+$outputJsonResolved = Resolve-AbsolutePath -Path $OutputJsonPath
+$outputParent = Split-Path -Parent $outputJsonResolved
+if ($outputParent -and -not (Test-Path -LiteralPath $outputParent -PathType Container)) {
+  New-Item -ItemType Directory -Path $outputParent -Force | Out-Null
+}
+
+$summary = [ordered]@{
+  schema = 'runner-label-contract@v1'
+  generatedAtUtc = (Get-Date).ToUniversalTime().ToString('o')
+  repository = $Repository
+  runId = $RunId
+  runnerName = $RunnerName
+  runnerId = ''
+  requiredLabel = $RequiredLabel
+  labels = @()
+  hasRequiredLabel = $false
+  status = 'failure'
+  failureClass = 'preflight'
+  failureMessage = ''
+  jobsPayloadPath = if ([string]::IsNullOrWhiteSpace($JobsPayloadPath)) { '' } else { Resolve-AbsolutePath -Path $JobsPayloadPath }
+}
+
+$caught = $null
+try {
+  if ([string]::IsNullOrWhiteSpace($Repository)) { throw 'Repository is required.' }
+  if ([string]::IsNullOrWhiteSpace($RunId)) { throw 'RunId is required.' }
+  if ([string]::IsNullOrWhiteSpace($RunnerName)) { throw 'RunnerName is required.' }
+  if ([string]::IsNullOrWhiteSpace($RequiredLabel)) { throw 'RequiredLabel is required.' }
+
+  $jobs = Get-RunJobs -Repository $Repository -RunId $RunId -Token $Token -JobsPayloadPath $JobsPayloadPath
+  if (-not $jobs -or $jobs.Count -eq 0) {
+    throw (New-ApiException -Message ("No jobs returned for run {0} in {1}." -f $RunId, $Repository) -StatusCode 0)
+  }
+
+  $currentJob = $jobs |
+    Where-Object { $_.runner_name -eq $RunnerName -and $_.status -eq 'in_progress' } |
+    Select-Object -First 1
+  if (-not $currentJob) {
+    $currentJob = $jobs |
+      Where-Object { $_.runner_name -eq $RunnerName } |
+      Sort-Object started_at -Descending |
+      Select-Object -First 1
+  }
+  if (-not $currentJob) {
+    throw (New-ApiException -Message ("Unable to resolve current job metadata for runner '{0}' in run {1}. Remediation: verify Actions run-jobs API visibility and rerun fixture-drift." -f $RunnerName, $RunId) -StatusCode 0)
+  }
+
+  $labels = Convert-JobLabelsToArray -Labels $currentJob.labels
+  $hasRequiredLabel = $labels -contains $RequiredLabel
+  $summary.runnerId = [string]$currentJob.runner_id
+  $summary.labels = @($labels)
+  $summary.hasRequiredLabel = [bool]$hasRequiredLabel
+
+  if (-not $hasRequiredLabel) {
+    $summary.status = 'failure'
+    $summary.failureClass = 'missing-label'
+    $summary.failureMessage = ("Runner '{0}' (id={1}) is missing required label '{2}'. Remediation: add the label in Repository Settings > Actions > Runners, then re-run fixture-drift." -f $RunnerName, [string]$summary.runnerId, $RequiredLabel)
+  } else {
+    $summary.status = 'success'
+    $summary.failureClass = 'none'
+    $summary.failureMessage = ''
+  }
+} catch {
+  $caught = $_
+  $statusCode = Get-StatusCodeFromError -ErrorRecord $_
+  $summary.status = 'failure'
+  if ($statusCode -eq 403) {
+    $summary.failureClass = 'api-permission'
+  } elseif ($statusCode -eq 401) {
+    $summary.failureClass = 'auth'
+  } elseif ($statusCode -eq 404) {
+    $summary.failureClass = 'api-not-found'
+  } elseif ([string]::IsNullOrWhiteSpace([string]$summary.failureClass) -or [string]$summary.failureClass -eq 'preflight') {
+    $summary.failureClass = 'api-error'
+  }
+  if ([string]::IsNullOrWhiteSpace([string]$summary.failureMessage)) {
+    $summary.failureMessage = [string]$_.Exception.Message
+  }
+} finally {
+  ($summary | ConvertTo-Json -Depth 20) | Set-Content -LiteralPath $outputJsonResolved -Encoding utf8
+
+  $labelsCsv = if ($summary.labels -and @($summary.labels).Count -gt 0) { [string]::Join(',', @($summary.labels)) } else { '' }
+  Write-GitHubOutput -Key 'has_required_label' -Value ([string]$summary.hasRequiredLabel).ToLowerInvariant() -Path $GitHubOutputPath
+  Write-GitHubOutput -Key 'labels' -Value $labelsCsv -Path $GitHubOutputPath
+  Write-GitHubOutput -Key 'runner_id' -Value ([string]$summary.runnerId) -Path $GitHubOutputPath
+  Write-GitHubOutput -Key 'runner_label_contract_status' -Value ([string]$summary.status) -Path $GitHubOutputPath
+  Write-GitHubOutput -Key 'runner_label_contract_summary_path' -Value $outputJsonResolved -Path $GitHubOutputPath
+  Write-GitHubOutput -Key 'runner_label_contract_failure_class' -Value ([string]$summary.failureClass) -Path $GitHubOutputPath
+
+  if (-not [string]::IsNullOrWhiteSpace($StepSummaryPath)) {
+    $summaryLines = @(
+      '### Runner Label Contract',
+      '',
+      ('- status: `{0}`' -f [string]$summary.status),
+      ('- required label: `{0}`' -f [string]$summary.requiredLabel),
+      ('- runner: `{0}` (id=`{1}`)' -f [string]$summary.runnerName, [string]$summary.runnerId),
+      ('- labels: `{0}`' -f $labelsCsv),
+      ('- summary json: `{0}`' -f $outputJsonResolved)
+    )
+    if ($summary.status -ne 'success') {
+      $summaryLines += ('- failure class: `{0}`' -f [string]$summary.failureClass)
+      if (-not [string]::IsNullOrWhiteSpace([string]$summary.failureMessage)) {
+        $summaryLines += ('- failure: {0}' -f [string]$summary.failureMessage)
+      }
+    }
+    $stepSummaryResolved = Resolve-AbsolutePath -Path $StepSummaryPath
+    $stepSummaryParent = Split-Path -Parent $stepSummaryResolved
+    if ($stepSummaryParent -and -not (Test-Path -LiteralPath $stepSummaryParent -PathType Container)) {
+      New-Item -ItemType Directory -Path $stepSummaryParent -Force | Out-Null
+    }
+    $summaryLines -join "`n" | Out-File -FilePath $stepSummaryResolved -Append -Encoding utf8
+  }
+}
+
+if ([string]$summary.status -ne 'success') {
+  throw ("Runner label contract failed ({0}): {1}" -f [string]$summary.failureClass, [string]$summary.failureMessage)
+}
+
+Write-Output $outputJsonResolved

--- a/tools/Invoke-DockerRuntimeManager.ps1
+++ b/tools/Invoke-DockerRuntimeManager.ps1
@@ -1,12 +1,13 @@
 #Requires -Version 7.0
 <#
 .SYNOPSIS
-  Manages Docker Desktop context transitions and validates NI image manifests.
+  Manages Docker Desktop context transitions, NI image bootstrap, and runtime probes.
 
 .DESCRIPTION
   Runs on a Windows host with Docker Desktop, acquires a host lock to avoid
-  concurrent engine flips, validates Windows and Linux NI image tags, and
-  restores the desired final context for downstream jobs.
+  concurrent engine flips, validates Windows/Linux NI image manifests, ensures
+  local image availability (bootstrap pull when missing), runs lightweight
+  runtime probes, and restores the desired final context for downstream jobs.
 #>
 [CmdletBinding()]
 param(
@@ -15,6 +16,10 @@ param(
   [string]$WindowsContext = 'desktop-windows',
   [string]$LinuxContext = 'desktop-linux',
   [string]$RestoreContext = 'desktop-windows',
+  [ValidateSet('both', 'windows', 'linux')]
+  [string]$ProbeScope = 'both',
+  [bool]$BootstrapWindowsImage = $true,
+  [bool]$BootstrapLinuxImage = $true,
   [ValidateRange(30, 900)]
   [int]$SwitchTimeoutSeconds = 120,
   [ValidateRange(1, 10)]
@@ -23,6 +28,8 @@ param(
   [int]$SwitchRetryDelaySeconds = 4,
   [ValidateRange(5, 600)]
   [int]$LockWaitSeconds = 90,
+  [string]$WindowsProbeCommand = "[Console]::WriteLine('ni-runtime-probe-ok')",
+  [string]$LinuxProbeCommand = "echo ni-runtime-probe-ok",
   [string]$OutputJsonPath = 'results/fixture-drift/docker-runtime-manager.json',
   [string]$GitHubOutputPath = '',
   [string]$StepSummaryPath = ''
@@ -239,6 +246,132 @@ function Get-ImageProbeResult {
   }
 }
 
+function Get-RepoDigestForImage {
+  param(
+    [string[]]$RepoDigests,
+    [Parameter(Mandatory)][string]$Image
+  )
+
+  foreach ($entry in @($RepoDigests)) {
+    $candidate = [string]$entry
+    if ($candidate.StartsWith("$Image@", [System.StringComparison]::OrdinalIgnoreCase)) {
+      return $candidate
+    }
+  }
+  if ($RepoDigests -and @($RepoDigests).Count -gt 0) {
+    return [string]@($RepoDigests)[0]
+  }
+  return ''
+}
+
+function Ensure-LocalImageAvailability {
+  param(
+    [Parameter(Mandatory)][string]$Image,
+    [bool]$BootstrapIfMissing
+  )
+
+  $result = [ordered]@{
+    attempted = [bool]$BootstrapIfMissing
+    pulled = $false
+    imagePresent = $false
+    localImageId = ''
+    localRepoDigest = ''
+    localDigest = ''
+    pullDurationMs = 0
+    pullError = ''
+  }
+
+  $inspect = Invoke-DockerCommand -Arguments @('image', 'inspect', $Image, '--format', '{{json .}}') -IgnoreExitCode
+  if ($inspect.ExitCode -ne 0 -and $BootstrapIfMissing) {
+    $pullStart = Get-Date
+    $pull = Invoke-DockerCommand -Arguments @('pull', $Image) -IgnoreExitCode
+    $result.pullDurationMs = [int]([Math]::Round(((Get-Date) - $pullStart).TotalMilliseconds))
+    if ($pull.ExitCode -ne 0) {
+      $result.pullError = [string]$pull.Text
+      throw ("docker pull failed for '{0}' (exit={1}). Output: {2}" -f $Image, $pull.ExitCode, $pull.Text)
+    }
+    $result.pulled = $true
+    $inspect = Invoke-DockerCommand -Arguments @('image', 'inspect', $Image, '--format', '{{json .}}') -IgnoreExitCode
+  }
+
+  if ($inspect.ExitCode -ne 0) {
+    throw ("Local image inspect failed for '{0}'. Use docker pull to bootstrap and retry. Output: {1}" -f $Image, $inspect.Text)
+  }
+
+  $inspectText = $inspect.Text.Trim()
+  if ([string]::IsNullOrWhiteSpace($inspectText)) {
+    throw ("Local image inspect returned empty payload for '{0}'." -f $Image)
+  }
+
+  $inspectJson = $inspectText | ConvertFrom-Json -Depth 20
+  $repoDigests = @()
+  if ($inspectJson.PSObject.Properties['RepoDigests']) {
+    $repoDigests = @($inspectJson.RepoDigests | ForEach-Object { [string]$_ })
+  }
+  $repoDigest = Get-RepoDigestForImage -RepoDigests $repoDigests -Image $Image
+  $digest = ''
+  if ($repoDigest -match '@(?<digest>sha256:[0-9a-fA-F]+)$') {
+    $digest = [string]$Matches['digest']
+  }
+
+  $result.imagePresent = $true
+  if ($inspectJson.PSObject.Properties['Id']) {
+    $result.localImageId = [string]$inspectJson.Id
+  }
+  $result.localRepoDigest = $repoDigest
+  $result.localDigest = $digest
+
+  return $result
+}
+
+function Invoke-ContainerRuntimeProbe {
+  param(
+    [Parameter(Mandatory)][string]$Image,
+    [Parameter(Mandatory)][string]$ExpectedOs,
+    [Parameter(Mandatory)][string]$ProbeCommand
+  )
+
+  $args = @('run', '--rm')
+  if ($ExpectedOs -eq 'windows') {
+    $args += @('--entrypoint', 'powershell', $Image, '-NoLogo', '-NoProfile', '-Command', $ProbeCommand)
+  } else {
+    $args += @('--entrypoint', '/bin/sh', $Image, '-lc', $ProbeCommand)
+  }
+
+  $start = Get-Date
+  $probe = Invoke-DockerCommand -Arguments $args -IgnoreExitCode
+  $durationMs = [int]([Math]::Round(((Get-Date) - $start).TotalMilliseconds))
+  $text = [string]$probe.Text
+  if ($text.Length -gt 2000) {
+    $text = $text.Substring(0, 2000)
+  }
+
+  return [ordered]@{
+    attempted = $true
+    status = if ($probe.ExitCode -eq 0) { 'success' } else { 'failure' }
+    exitCode = [int]$probe.ExitCode
+    durationMs = $durationMs
+    output = $text
+    command = ($args -join ' ')
+    error = if ($probe.ExitCode -eq 0) { '' } else { $text }
+  }
+}
+
+function Should-IncludeLane {
+  param(
+    [Parameter(Mandatory)][string]$Scope,
+    [Parameter(Mandatory)][string]$Lane
+  )
+
+  $normalized = $Scope.Trim().ToLowerInvariant()
+  switch ($normalized) {
+    'both' { return $true }
+    'windows' { return ($Lane -eq 'windows') }
+    'linux' { return ($Lane -eq 'linux') }
+    default { return $false }
+  }
+}
+
 if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
   throw 'Docker CLI not found on host. Install Docker Desktop and ensure docker.exe is available.'
 }
@@ -249,6 +382,12 @@ if ($outputParent -and -not (Test-Path -LiteralPath $outputParent -PathType Cont
   New-Item -ItemType Directory -Path $outputParent -Force | Out-Null
 }
 
+$includeWindows = Should-IncludeLane -Scope $ProbeScope -Lane 'windows'
+$includeLinux = Should-IncludeLane -Scope $ProbeScope -Lane 'linux'
+if (-not $includeWindows -and -not $includeLinux) {
+  throw ("ProbeScope '{0}' did not resolve to any lanes." -f $ProbeScope)
+}
+
 $summary = [ordered]@{
   schema = 'docker-runtime-manager@v1'
   generatedAtUtc = (Get-Date).ToUniversalTime().ToString('o')
@@ -256,6 +395,8 @@ $summary = [ordered]@{
     machineName = $env:COMPUTERNAME
     runnerName = $env:RUNNER_NAME
     userName = $env:USERNAME
+    osVersion = [System.Environment]::OSVersion.VersionString
+    platform = [string][System.Environment]::OSVersion.Platform
   }
   settings = [ordered]@{
     windowsImage = $WindowsImage
@@ -264,6 +405,11 @@ $summary = [ordered]@{
     linuxContext = $LinuxContext
     restoreContext = $RestoreContext
     restoreExpectedOs = ''
+    probeScope = $ProbeScope
+    bootstrapWindowsImage = [bool]$BootstrapWindowsImage
+    bootstrapLinuxImage = [bool]$BootstrapLinuxImage
+    windowsProbeCommand = $WindowsProbeCommand
+    linuxProbeCommand = $LinuxProbeCommand
     switchTimeoutSeconds = [int]$SwitchTimeoutSeconds
     switchRetryCount = [int]$SwitchRetryCount
     switchRetryDelaySeconds = [int]$SwitchRetryDelaySeconds
@@ -276,11 +422,14 @@ $summary = [ordered]@{
   }
   contexts = [ordered]@{
     start = ''
+    startOsType = ''
     final = ''
+    finalOsType = ''
   }
   probes = [ordered]@{
     windows = [ordered]@{
-      status = 'pending'
+      enabled = [bool]$includeWindows
+      status = if ($includeWindows) { 'pending' } else { 'skipped' }
       context = $WindowsContext
       osType = ''
       image = $WindowsImage
@@ -288,9 +437,29 @@ $summary = [ordered]@{
       matchingPlatform = ''
       attempts = 0
       error = ''
+      bootstrap = [ordered]@{
+        attempted = $false
+        pulled = $false
+        imagePresent = $false
+        localImageId = ''
+        localRepoDigest = ''
+        localDigest = ''
+        pullDurationMs = 0
+        pullError = ''
+      }
+      probe = [ordered]@{
+        attempted = $false
+        status = 'not-run'
+        exitCode = -1
+        durationMs = 0
+        output = ''
+        command = ''
+        error = ''
+      }
     }
     linux = [ordered]@{
-      status = 'pending'
+      enabled = [bool]$includeLinux
+      status = if ($includeLinux) { 'pending' } else { 'skipped' }
       context = $LinuxContext
       osType = ''
       image = $LinuxImage
@@ -298,6 +467,25 @@ $summary = [ordered]@{
       matchingPlatform = ''
       attempts = 0
       error = ''
+      bootstrap = [ordered]@{
+        attempted = $false
+        pulled = $false
+        imagePresent = $false
+        localImageId = ''
+        localRepoDigest = ''
+        localDigest = ''
+        pullDurationMs = 0
+        pullError = ''
+      }
+      probe = [ordered]@{
+        attempted = $false
+        status = 'not-run'
+        exitCode = -1
+        durationMs = 0
+        output = ''
+        command = ''
+        error = ''
+      }
     }
   }
   status = 'failure'
@@ -329,46 +517,103 @@ try {
   if ([string]::IsNullOrWhiteSpace($contextStart)) { $contextStart = 'unknown' }
   $summary.contexts.start = $contextStart
 
-  $windowsSwitch = Set-ContextAndWait `
-    -ContextName $WindowsContext `
-    -ExpectedOsType 'windows' `
-    -TimeoutSeconds $SwitchTimeoutSeconds `
-    -RetryCount $SwitchRetryCount `
-    -RetryDelaySeconds $SwitchRetryDelaySeconds
-  $summary.probes.windows.status = 'success'
-  $summary.probes.windows.osType = [string]$windowsSwitch.OsType
-  $summary.probes.windows.attempts = [int]$windowsSwitch.Attempt
-  $windowsProbe = Get-ImageProbeResult -Image $WindowsImage -ExpectedOs 'windows'
-  $summary.probes.windows.digest = [string]$windowsProbe.digest
-  $summary.probes.windows.matchingPlatform = [string]$windowsProbe.matchingPlatform
+  try {
+    $startOsProbe = Invoke-DockerCommand -Arguments @('info', '--format', '{{.OSType}}') -IgnoreExitCode
+    if ($startOsProbe.ExitCode -eq 0) {
+      $summary.contexts.startOsType = $startOsProbe.Text.Trim().ToLowerInvariant()
+    }
+  } catch {}
 
-  $linuxSwitch = Set-ContextAndWait `
-    -ContextName $LinuxContext `
-    -ExpectedOsType 'linux' `
-    -TimeoutSeconds $SwitchTimeoutSeconds `
-    -RetryCount $SwitchRetryCount `
-    -RetryDelaySeconds $SwitchRetryDelaySeconds
-  $summary.probes.linux.status = 'success'
-  $summary.probes.linux.osType = [string]$linuxSwitch.OsType
-  $summary.probes.linux.attempts = [int]$linuxSwitch.Attempt
-  $linuxProbe = Get-ImageProbeResult -Image $LinuxImage -ExpectedOs 'linux'
-  $summary.probes.linux.digest = [string]$linuxProbe.digest
-  $summary.probes.linux.matchingPlatform = [string]$linuxProbe.matchingPlatform
+  if ($includeWindows) {
+    $windowsSwitch = Set-ContextAndWait `
+      -ContextName $WindowsContext `
+      -ExpectedOsType 'windows' `
+      -TimeoutSeconds $SwitchTimeoutSeconds `
+      -RetryCount $SwitchRetryCount `
+      -RetryDelaySeconds $SwitchRetryDelaySeconds
+
+    $summary.probes.windows.status = 'success'
+    $summary.probes.windows.osType = [string]$windowsSwitch.OsType
+    $summary.probes.windows.attempts = [int]$windowsSwitch.Attempt
+
+    $windowsManifest = Get-ImageProbeResult -Image $WindowsImage -ExpectedOs 'windows'
+    $summary.probes.windows.digest = [string]$windowsManifest.digest
+    $summary.probes.windows.matchingPlatform = [string]$windowsManifest.matchingPlatform
+
+    $windowsBootstrap = Ensure-LocalImageAvailability -Image $WindowsImage -BootstrapIfMissing:$BootstrapWindowsImage
+    $summary.probes.windows.bootstrap.attempted = [bool]$windowsBootstrap.attempted
+    $summary.probes.windows.bootstrap.pulled = [bool]$windowsBootstrap.pulled
+    $summary.probes.windows.bootstrap.imagePresent = [bool]$windowsBootstrap.imagePresent
+    $summary.probes.windows.bootstrap.localImageId = [string]$windowsBootstrap.localImageId
+    $summary.probes.windows.bootstrap.localRepoDigest = [string]$windowsBootstrap.localRepoDigest
+    $summary.probes.windows.bootstrap.localDigest = [string]$windowsBootstrap.localDigest
+    $summary.probes.windows.bootstrap.pullDurationMs = [int]$windowsBootstrap.pullDurationMs
+    $summary.probes.windows.bootstrap.pullError = [string]$windowsBootstrap.pullError
+
+    $windowsProbe = Invoke-ContainerRuntimeProbe -Image $WindowsImage -ExpectedOs 'windows' -ProbeCommand $WindowsProbeCommand
+    $summary.probes.windows.probe = $windowsProbe
+    if ([string]$windowsProbe.status -ne 'success') {
+      throw ("Runtime probe failed for Windows image '{0}' (exit={1})." -f $WindowsImage, [int]$windowsProbe.exitCode)
+    }
+  }
+
+  if ($includeLinux) {
+    $linuxSwitch = Set-ContextAndWait `
+      -ContextName $LinuxContext `
+      -ExpectedOsType 'linux' `
+      -TimeoutSeconds $SwitchTimeoutSeconds `
+      -RetryCount $SwitchRetryCount `
+      -RetryDelaySeconds $SwitchRetryDelaySeconds
+
+    $summary.probes.linux.status = 'success'
+    $summary.probes.linux.osType = [string]$linuxSwitch.OsType
+    $summary.probes.linux.attempts = [int]$linuxSwitch.Attempt
+
+    $linuxManifest = Get-ImageProbeResult -Image $LinuxImage -ExpectedOs 'linux'
+    $summary.probes.linux.digest = [string]$linuxManifest.digest
+    $summary.probes.linux.matchingPlatform = [string]$linuxManifest.matchingPlatform
+
+    $linuxBootstrap = Ensure-LocalImageAvailability -Image $LinuxImage -BootstrapIfMissing:$BootstrapLinuxImage
+    $summary.probes.linux.bootstrap.attempted = [bool]$linuxBootstrap.attempted
+    $summary.probes.linux.bootstrap.pulled = [bool]$linuxBootstrap.pulled
+    $summary.probes.linux.bootstrap.imagePresent = [bool]$linuxBootstrap.imagePresent
+    $summary.probes.linux.bootstrap.localImageId = [string]$linuxBootstrap.localImageId
+    $summary.probes.linux.bootstrap.localRepoDigest = [string]$linuxBootstrap.localRepoDigest
+    $summary.probes.linux.bootstrap.localDigest = [string]$linuxBootstrap.localDigest
+    $summary.probes.linux.bootstrap.pullDurationMs = [int]$linuxBootstrap.pullDurationMs
+    $summary.probes.linux.bootstrap.pullError = [string]$linuxBootstrap.pullError
+
+    $linuxProbe = Invoke-ContainerRuntimeProbe -Image $LinuxImage -ExpectedOs 'linux' -ProbeCommand $LinuxProbeCommand
+    $summary.probes.linux.probe = $linuxProbe
+    if ([string]$linuxProbe.status -ne 'success') {
+      throw ("Runtime probe failed for Linux image '{0}' (exit={1})." -f $LinuxImage, [int]$linuxProbe.exitCode)
+    }
+  }
 
   $summary.status = 'success'
   $summary.failureClass = 'none'
   $summary.failureMessage = ''
 } catch {
   $caught = $_
+  $message = $_.Exception.Message
   $summary.status = 'failure'
-  $summary.failureClass = 'runtime-determinism'
-  $summary.failureMessage = $_.Exception.Message
-  if ($summary.probes.windows.status -eq 'pending') {
+  if ($message -match '(?i)failed to switch docker context|did not reach expected ostype|docker engine switch|timed out waiting for docker manager lock') {
+    $summary.failureClass = 'runtime-determinism'
+  } elseif ($message -match '(?i)docker pull failed|local image inspect failed') {
+    $summary.failureClass = 'image-bootstrap'
+  } elseif ($message -match '(?i)runtime probe failed') {
+    $summary.failureClass = 'runtime-probe'
+  } else {
+    $summary.failureClass = 'preflight'
+  }
+  $summary.failureMessage = $message
+
+  if ($includeWindows -and $summary.probes.windows.status -eq 'pending') {
     $summary.probes.windows.status = 'failure'
-    $summary.probes.windows.error = $_.Exception.Message
-  } elseif ($summary.probes.linux.status -eq 'pending') {
+    $summary.probes.windows.error = $message
+  } elseif ($includeLinux -and $summary.probes.linux.status -eq 'pending') {
     $summary.probes.linux.status = 'failure'
-    $summary.probes.linux.error = $_.Exception.Message
+    $summary.probes.linux.error = $message
   }
 } finally {
   try {
@@ -379,6 +624,7 @@ try {
       -RetryCount $SwitchRetryCount `
       -RetryDelaySeconds $SwitchRetryDelaySeconds
     $summary.contexts.final = [string]$restored.Context
+    $summary.contexts.finalOsType = [string]$restored.OsType
   } catch {
     if ($summary.status -eq 'success') {
       $summary.status = 'failure'
@@ -387,6 +633,9 @@ try {
     }
     if ([string]::IsNullOrWhiteSpace([string]$summary.contexts.final)) {
       $summary.contexts.final = 'unknown'
+    }
+    if ([string]::IsNullOrWhiteSpace([string]$summary.contexts.finalOsType)) {
+      $summary.contexts.finalOsType = 'unknown'
     }
   }
 
@@ -398,28 +647,49 @@ try {
   $summary.durationMs = [int]([Math]::Round(((Get-Date) - $runStart).TotalMilliseconds))
   ($summary | ConvertTo-Json -Depth 20) | Set-Content -LiteralPath $outputJsonResolved -Encoding utf8
 
+  $windowsDigestOut = if (-not [string]::IsNullOrWhiteSpace([string]$summary.probes.windows.bootstrap.localDigest)) {
+    [string]$summary.probes.windows.bootstrap.localDigest
+  } else {
+    [string]$summary.probes.windows.digest
+  }
+  $linuxDigestOut = if (-not [string]::IsNullOrWhiteSpace([string]$summary.probes.linux.bootstrap.localDigest)) {
+    [string]$summary.probes.linux.bootstrap.localDigest
+  } else {
+    [string]$summary.probes.linux.digest
+  }
+
   Write-GitHubOutput -Key 'manager_status' -Value ([string]$summary.status) -Path $GitHubOutputPath
   Write-GitHubOutput -Key 'manager_summary_path' -Value $outputJsonResolved -Path $GitHubOutputPath
-  Write-GitHubOutput -Key 'windows_image_digest' -Value ([string]$summary.probes.windows.digest) -Path $GitHubOutputPath
-  Write-GitHubOutput -Key 'linux_image_digest' -Value ([string]$summary.probes.linux.digest) -Path $GitHubOutputPath
+  Write-GitHubOutput -Key 'windows_image_digest' -Value $windowsDigestOut -Path $GitHubOutputPath
+  Write-GitHubOutput -Key 'linux_image_digest' -Value $linuxDigestOut -Path $GitHubOutputPath
   Write-GitHubOutput -Key 'start_context' -Value ([string]$summary.contexts.start) -Path $GitHubOutputPath
   Write-GitHubOutput -Key 'final_context' -Value ([string]$summary.contexts.final) -Path $GitHubOutputPath
+  Write-GitHubOutput -Key 'windows_bootstrap_status' -Value ([string]$summary.probes.windows.bootstrap.imagePresent).ToLowerInvariant() -Path $GitHubOutputPath
+  Write-GitHubOutput -Key 'linux_bootstrap_status' -Value ([string]$summary.probes.linux.bootstrap.imagePresent).ToLowerInvariant() -Path $GitHubOutputPath
+  Write-GitHubOutput -Key 'windows_probe_status' -Value ([string]$summary.probes.windows.probe.status) -Path $GitHubOutputPath
+  Write-GitHubOutput -Key 'linux_probe_status' -Value ([string]$summary.probes.linux.probe.status) -Path $GitHubOutputPath
 
   if (-not [string]::IsNullOrWhiteSpace($StepSummaryPath)) {
     $lines = @(
       '### Docker Runtime Manager',
       '',
       ('- status: `{0}`' -f [string]$summary.status),
-      ('- start context: `{0}`' -f [string]$summary.contexts.start),
-      ('- final context: `{0}`' -f [string]$summary.contexts.final),
-      ('- windows image: `{0}` digest=`{1}`' -f [string]$summary.probes.windows.image, [string]$summary.probes.windows.digest),
-      ('- linux image: `{0}` digest=`{1}`' -f [string]$summary.probes.linux.image, [string]$summary.probes.linux.digest),
+      ('- start context: `{0}` (`{1}`)' -f [string]$summary.contexts.start, [string]$summary.contexts.startOsType),
+      ('- final context: `{0}` (`{1}`)' -f [string]$summary.contexts.final, [string]$summary.contexts.finalOsType),
+      ('- windows image: `{0}` manifestDigest=`{1}` localDigest=`{2}` pulled=`{3}` probe=`{4}`' -f [string]$summary.probes.windows.image, [string]$summary.probes.windows.digest, [string]$summary.probes.windows.bootstrap.localDigest, [bool]$summary.probes.windows.bootstrap.pulled, [string]$summary.probes.windows.probe.status),
+      ('- linux image: `{0}` manifestDigest=`{1}` localDigest=`{2}` pulled=`{3}` probe=`{4}`' -f [string]$summary.probes.linux.image, [string]$summary.probes.linux.digest, [string]$summary.probes.linux.bootstrap.localDigest, [bool]$summary.probes.linux.bootstrap.pulled, [string]$summary.probes.linux.probe.status),
       ('- summary json: `{0}`' -f $outputJsonResolved)
     )
     if ($summary.status -ne 'success' -and -not [string]::IsNullOrWhiteSpace([string]$summary.failureMessage)) {
-      $lines += ("- failure: {0}" -f [string]$summary.failureMessage)
+      $lines += ('- failure class: `{0}`' -f [string]$summary.failureClass)
+      $lines += ('- failure: {0}' -f [string]$summary.failureMessage)
     }
-    $lines -join "`n" | Out-File -FilePath (Resolve-AbsolutePath -Path $StepSummaryPath) -Append -Encoding utf8
+    $stepSummaryResolved = Resolve-AbsolutePath -Path $StepSummaryPath
+    $stepSummaryParent = Split-Path -Parent $stepSummaryResolved
+    if ($stepSummaryParent -and -not (Test-Path -LiteralPath $stepSummaryParent -PathType Container)) {
+      New-Item -ItemType Directory -Path $stepSummaryParent -Force | Out-Null
+    }
+    $lines -join "`n" | Out-File -FilePath $stepSummaryResolved -Append -Encoding utf8
   }
 }
 

--- a/tools/Test-WindowsNI2026q1HostPreflight.ps1
+++ b/tools/Test-WindowsNI2026q1HostPreflight.ps1
@@ -1,0 +1,58 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+  Deterministic host preflight for NI LabVIEW 2026 q1 Windows container image.
+
+.DESCRIPTION
+  Executes the Docker runtime manager in windows-only mode, bootstraps
+  `nationalinstruments/labview:2026q1-windows` when missing, and emits a
+  machine-readable artifact under tests/results/local-parity by default.
+#>
+[CmdletBinding()]
+param(
+  [string]$Image = 'nationalinstruments/labview:2026q1-windows',
+  [string]$ResultsDir = 'tests/results/local-parity',
+  [string]$OutputJsonPath = '',
+  [string]$GitHubOutputPath = $env:GITHUB_OUTPUT,
+  [string]$StepSummaryPath = $env:GITHUB_STEP_SUMMARY
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Resolve-AbsolutePath {
+  param([Parameter(Mandatory)][string]$Path)
+  if ([System.IO.Path]::IsPathRooted($Path)) {
+    return [System.IO.Path]::GetFullPath($Path)
+  }
+  return [System.IO.Path]::GetFullPath((Join-Path (Get-Location).Path $Path))
+}
+
+$repoRoot = Resolve-AbsolutePath -Path (Join-Path $PSScriptRoot '..')
+$managerScript = Join-Path $repoRoot 'tools' 'Invoke-DockerRuntimeManager.ps1'
+if (-not (Test-Path -LiteralPath $managerScript -PathType Leaf)) {
+  throw ("Invoke-DockerRuntimeManager.ps1 not found: {0}" -f $managerScript)
+}
+
+$resultsDirResolved = Resolve-AbsolutePath -Path $ResultsDir
+if (-not (Test-Path -LiteralPath $resultsDirResolved -PathType Container)) {
+  New-Item -ItemType Directory -Path $resultsDirResolved -Force | Out-Null
+}
+
+$jsonPathResolved = if ([string]::IsNullOrWhiteSpace($OutputJsonPath)) {
+  Join-Path $resultsDirResolved 'windows-ni-2026q1-host-preflight.json'
+} else {
+  Resolve-AbsolutePath -Path $OutputJsonPath
+}
+
+& $managerScript `
+  -ProbeScope 'windows' `
+  -WindowsImage $Image `
+  -BootstrapWindowsImage:$true `
+  -BootstrapLinuxImage:$false `
+  -RestoreContext 'desktop-windows' `
+  -OutputJsonPath $jsonPathResolved `
+  -GitHubOutputPath $GitHubOutputPath `
+  -StepSummaryPath $StepSummaryPath
+
+Write-Output $jsonPathResolved

--- a/tools/Update-FixtureDriftSessionIndex.ps1
+++ b/tools/Update-FixtureDriftSessionIndex.ps1
@@ -1,0 +1,80 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+  Attaches Docker runtime manager metadata to fixture-drift session-index.json.
+#>
+[CmdletBinding()]
+param(
+  [string]$ResultsDir = 'results/fixture-drift',
+  [string]$SessionIndexPath = '',
+  [string]$ContextPath = '',
+  [string]$RequiredLabel = 'self-hosted-docker',
+  [bool]$HasRequiredLabel = $false,
+  [string]$RunnerLabelsCsv = '',
+  [string]$ManagerStatus = '',
+  [string]$ManagerSummaryPath = '',
+  [string]$WindowsImageDigest = '',
+  [string]$LinuxImageDigest = '',
+  [string]$StartContext = '',
+  [string]$FinalContext = '',
+  [switch]$IgnoreMissingSessionIndex
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Resolve-AbsolutePath {
+  param([Parameter(Mandatory)][string]$Path)
+  if ([System.IO.Path]::IsPathRooted($Path)) {
+    return [System.IO.Path]::GetFullPath($Path)
+  }
+  return [System.IO.Path]::GetFullPath((Join-Path (Get-Location).Path $Path))
+}
+
+$resultsResolved = Resolve-AbsolutePath -Path $ResultsDir
+$sessionPathResolved = if ([string]::IsNullOrWhiteSpace($SessionIndexPath)) {
+  Join-Path $resultsResolved 'session-index.json'
+} else {
+  Resolve-AbsolutePath -Path $SessionIndexPath
+}
+$contextPathResolved = if ([string]::IsNullOrWhiteSpace($ContextPath)) {
+  Join-Path $resultsResolved 'docker-runtime-manager-context.json'
+} else {
+  Resolve-AbsolutePath -Path $ContextPath
+}
+
+if (-not (Test-Path -LiteralPath $sessionPathResolved -PathType Leaf)) {
+  if ($IgnoreMissingSessionIndex) {
+    Write-Host ("::warning::session-index.json not found at {0}; docker manager metadata was not attached." -f $sessionPathResolved)
+    return
+  }
+  throw ("session-index.json not found: {0}" -f $sessionPathResolved)
+}
+
+$labels = @()
+if (-not [string]::IsNullOrWhiteSpace($RunnerLabelsCsv)) {
+  $labels = @($RunnerLabelsCsv -split ',' | ForEach-Object { $_.Trim() } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+}
+
+$index = Get-Content -LiteralPath $sessionPathResolved -Raw | ConvertFrom-Json -Depth 30
+if (-not $index.PSObject.Properties['runContext'] -or $null -eq $index.runContext) {
+  $index | Add-Member -MemberType NoteProperty -Name 'runContext' -Value ([ordered]@{}) -Force
+}
+
+$index.runContext.dockerRuntimeManager = [ordered]@{
+  status = [string]$ManagerStatus
+  summaryPath = [string]$ManagerSummaryPath
+  windowsImageDigest = [string]$WindowsImageDigest
+  linuxImageDigest = [string]$LinuxImageDigest
+  startContext = [string]$StartContext
+  finalContext = [string]$FinalContext
+  contextArtifactPath = if (Test-Path -LiteralPath $contextPathResolved -PathType Leaf) { $contextPathResolved } else { '' }
+}
+$index.runContext.runnerLabelContract = [ordered]@{
+  requiredLabel = [string]$RequiredLabel
+  hasRequiredLabel = [bool]$HasRequiredLabel
+  labels = @($labels)
+}
+
+($index | ConvertTo-Json -Depth 30) | Set-Content -LiteralPath $sessionPathResolved -Encoding utf8
+Write-Output $sessionPathResolved

--- a/tools/Write-FixtureDriftSummary.ps1
+++ b/tools/Write-FixtureDriftSummary.ps1
@@ -33,10 +33,10 @@ function AddCounts($obj){
     $lines += ('- {0}: {1}' -f $k,$v)
   }
 }
-if ($json.summaryCounts) { AddCounts $json.summaryCounts }
-elseif ($json.counts) { AddCounts $json.counts }
+if ($json.PSObject.Properties['summaryCounts'] -and $json.summaryCounts) { AddCounts $json.summaryCounts }
+elseif ($json.PSObject.Properties['counts'] -and $json.counts) { AddCounts $json.counts }
 
-if ($json.notes) {
+if ($json.PSObject.Properties['notes'] -and $json.notes) {
   $n = $json.notes
   if ($n -is [array]) { foreach ($x in $n) { $lines += ('- Note: {0}' -f $x) } }
   else { $lines += ('- Note: {0}' -f $n) }


### PR DESCRIPTION
## Summary
- add deterministic NI Windows 2026 q1 host bootstrap preflight (`docker:ni:windows:bootstrap`)
- extend Docker runtime manager with local image bootstrap (`docker pull`), local digest capture, and runtime probe telemetry
- replace fixture-drift inline runner-label/session-index logic with reusable scripts
- add contract tests for runner-label, fixture summary docker section, session-index metadata, and runtime manager bootstrap/probe behavior
- update fixture-drift workflow to call new scripts and set Docker manager timeout to 10 minutes
- document bootstrap commands/remediation in environment + fixture drift docs

## Validation
- `Invoke-Pester -Path tests/Invoke-DockerRuntimeManager.Tests.ps1,tests/Assert-RunnerLabelContract.Tests.ps1,tests/Write-FixtureDriftSummary.Tests.ps1,tests/Update-FixtureDriftSessionIndex.Tests.ps1 -Output Detailed`
- `pwsh -NoLogo -NoProfile -File tools/PrePush-Checks.ps1 -SkipIconEditorFixtureChecks`
- `node tools/npm/run-script.mjs docker:ni:windows:bootstrap`
  - evidence: `tests/results/local-parity/windows-ni-2026q1-host-preflight.json`

Closes #117
Closes #116
