### PR TITLE
Harvest PR27 harness timing + multi-VI smoke scenario (#121)

### DIFF
--- a/tests/Invoke-PRVIHistory.Tests.ps1
+++ b/tests/Invoke-PRVIHistory.Tests.ps1
@@ -113,10 +113,14 @@ Describe 'Invoke-PRVIHistory.ps1' {
         $target.status | Should -Be 'completed'
         $target.stats.processed | Should -Be 3
         $target.stats.diffs | Should -Be 1
+        $target.stats.durationSeconds | Should -Be 0
+        $target.stats.durationSamples | Should -Be 0
         $target.reportImages.status | Should -Be 'completed'
         $target.reportImages.exportedImageCount | Should -Be 1
         $target.reportImages.sourceImageCount | Should -Be 1
         Test-Path -LiteralPath $target.reportImages.indexPath -PathType Leaf | Should -BeTrue
+        $result.totals.durationSeconds | Should -Be 0
+        $result.totals.durationSamples | Should -Be 0
 
         Test-Path -LiteralPath $result.resultsRoot -PathType Container | Should -BeTrue
         Test-Path -LiteralPath $result.targets[0].manifest -PathType Leaf | Should -BeTrue
@@ -201,6 +205,8 @@ Describe 'Invoke-PRVIHistory.ps1' {
         $result.targets | Should -Not -BeNullOrEmpty
         $result.targets[0].status | Should -Be 'completed'
         $result.targets[0].stats.processed | Should -Be 2
+        $result.targets[0].stats.durationSeconds | Should -Be 0
+        $result.targets[0].stats.durationSamples | Should -Be 0
         $result.targets[0].reportImages.status | Should -Be 'no-html-report'
         $result.targets[0].reportImages.exportedImageCount | Should -Be 0
 
@@ -406,7 +412,12 @@ Describe 'Invoke-PRVIHistory.ps1' {
         $result.targets[0].commitPairs[1].classification | Should -Be 'noise-masscompile'
         $result.targets[0].timing.totalSeconds | Should -Be 4
         $result.targets[0].timing.medianSeconds | Should -Be 2
+        $result.targets[0].stats.durationSeconds | Should -Be 4
+        $result.targets[0].stats.durationSamples | Should -Be 2
+        $result.targets[0].stats.durationAvgSeconds | Should -Be 2
         $result.totals.timing.totalSeconds | Should -Be 4
+        $result.totals.durationSeconds | Should -Be 4
+        $result.totals.durationSamples | Should -Be 2
         $result.estimatedCompareTime.seconds | Should -Be 2
         $result.kpi.signalRecall | Should -Be 0.5
         $result.kpi.noisePrecisionMasscompile | Should -Be 1

--- a/tests/Summarize-PRVIHistory.Tests.ps1
+++ b/tests/Summarize-PRVIHistory.Tests.ps1
@@ -85,8 +85,11 @@ Describe 'Summarize-PRVIHistory.ps1' {
                     status      = 'completed'
                     changeTypes = @('modified','renamed')
                     stats       = [ordered]@{
-                        processed = 4
-                        diffs     = 2
+                        processed          = 4
+                        diffs              = 2
+                        durationSeconds    = 12.5
+                        durationSamples    = 4
+                        durationAvgSeconds = 3.125
                     }
                     reportMd   = $reportMd
                     reportHtml = $reportHtml
@@ -124,6 +127,8 @@ Describe 'Summarize-PRVIHistory.ps1' {
         $result.totals.diffPairRows | Should -Be 1
         $result.totals.previewImages | Should -Be 1
         $result.totals.markdownTruncated | Should -BeFalse
+        $result.totals.durationSeconds | Should -Be 12.5
+        $result.totals.durationSamples | Should -Be 4
         $result.totals.timing.totalSeconds | Should -Be 3.75
         $result.kpi.signalRecall | Should -Be 1
         $result.kpi.noisePrecisionMasscompile | Should -BeNullOrEmpty
@@ -143,6 +148,7 @@ Describe 'Summarize-PRVIHistory.ps1' {
         $result.markdown | Should -Match 'Timing'
         $result.markdown | Should -Match '\[signal\]'
         $result.markdown | Should -Match '\[fast 1\.5s\]'
+        $result.markdown | Should -Match 'time: 12\.50s total'
         $result.markdown | Should -Match '### Mobile Preview'
         $result.markdown | Should -Match 'history-image-000.png'
 

--- a/tools/Invoke-PRVIHistory.ps1
+++ b/tools/Invoke-PRVIHistory.ps1
@@ -987,6 +987,8 @@ $pairDurations = [System.Collections.Generic.List[double]]::new()
 $reportImageTargetCount = 0
 $reportImageExportedCount = 0
 $reportImageExtractionErrors = 0
+$totalDurationSeconds = 0.0
+$totalDurationSamples = 0
 
 for ($i = 0; $i -lt $targets.Count; $i++) {
     $target = $targets[$i]
@@ -1245,6 +1247,21 @@ for ($i = 0; $i -lt $targets.Count; $i++) {
     $targetPairs = @($targetTimeline.Pairs)
     $targetDurations = @($targetTimeline.Durations)
     $targetTiming = New-TimingSummary -DurationsSeconds $targetDurations
+    $targetDurationSeconds = if ($targetTiming -and $targetTiming.PSObject.Properties['totalSeconds'] -and $null -ne $targetTiming.totalSeconds) {
+        [double]$targetTiming.totalSeconds
+    } else {
+        0.0
+    }
+    $targetDurationSamples = if ($targetTiming -and $targetTiming.PSObject.Properties['comparisonCount']) {
+        [int]$targetTiming.comparisonCount
+    } else {
+        0
+    }
+    $targetDurationAvgSeconds = if ($targetDurationSamples -gt 0) {
+        [Math]::Round(($targetDurationSeconds / [double]$targetDurationSamples), 6)
+    } else {
+        $null
+    }
 
     $totalPairRows += $targetPairs.Count
     foreach ($pairRow in $targetPairs) {
@@ -1260,6 +1277,8 @@ for ($i = 0; $i -lt $targets.Count; $i++) {
         if ($candidateDuration -lt 0) { continue }
         $pairDurations.Add([double]$candidateDuration) | Out-Null
     }
+    $totalDurationSeconds += $targetDurationSeconds
+    $totalDurationSamples += $targetDurationSamples
 
     [void]$summaryTargets.Add([pscustomobject]@{
         repoPath    = $repoPath
@@ -1276,9 +1295,12 @@ for ($i = 0; $i -lt $targets.Count; $i++) {
         timing      = $targetTiming
         estimatedCompareTime = $targetTiming.estimatedCompareTime
         stats       = [pscustomobject]@{
-            processed = $processed
-            diffs     = $diffs
-            missing   = $missing
+            processed          = $processed
+            diffs              = $diffs
+            missing            = $missing
+            durationSeconds    = [Math]::Round($targetDurationSeconds, 6)
+            durationSamples    = $targetDurationSamples
+            durationAvgSeconds = $targetDurationAvgSeconds
         }
     }) | Out-Null
 }
@@ -1322,6 +1344,8 @@ $summary = [pscustomobject]@{
         imageErrors      = $reportImageExtractionErrors
         pairRows         = $totalPairRows
         diffPairRows     = $diffPairRows
+        durationSeconds  = [Math]::Round($totalDurationSeconds, 6)
+        durationSamples  = $totalDurationSamples
         timing           = $overallTiming
         estimatedCompareTime = $overallTiming.estimatedCompareTime
     }

--- a/tools/Summarize-PRVIHistory.ps1
+++ b/tools/Summarize-PRVIHistory.ps1
@@ -338,6 +338,8 @@ $rows.Add('| --- | --- | --- | --- | --- | --- |') | Out-Null
 $diffTotal = 0
 $comparisonTotal = 0
 $completed = 0
+$durationTotalSeconds = 0.0
+$durationSampleTotal = 0
 
 foreach ($target in $targets) {
     $repoPath = if ($target.PSObject.Properties['repoPath']) { [string]$target.repoPath } else { '(unknown)' }
@@ -355,6 +357,9 @@ foreach ($target in $targets) {
     $comparisons = '0'
     $diffs = '0'
     $reportNote = '_n/a_'
+    $durationSecondsValue = $null
+    $durationSamplesValue = 0
+    $durationAvgSecondsValue = $null
 
     if ($target.PSObject.Properties['stats'] -and $target.stats) {
         $stats = $target.stats
@@ -367,6 +372,27 @@ foreach ($target in $targets) {
             $diffValue = [int]$stats.diffs
             $diffTotal += $diffValue
             $diffs = $diffValue.ToString()
+        }
+        if ($stats.PSObject.Properties['durationSeconds']) {
+            $parsedDuration = 0.0
+            if ([double]::TryParse([string]$stats.durationSeconds, [ref]$parsedDuration)) {
+                $durationSecondsValue = $parsedDuration
+                $durationTotalSeconds += $parsedDuration
+            }
+        }
+        if ($stats.PSObject.Properties['durationSamples']) {
+            try {
+                $durationSamplesValue = [int]$stats.durationSamples
+                if ($durationSamplesValue -gt 0) {
+                    $durationSampleTotal += $durationSamplesValue
+                }
+            } catch {}
+        }
+        if ($stats.PSObject.Properties['durationAvgSeconds']) {
+            $parsedAvg = 0.0
+            if ([double]::TryParse([string]$stats.durationAvgSeconds, [ref]$parsedAvg)) {
+                $durationAvgSecondsValue = $parsedAvg
+            }
         }
     }
 
@@ -389,6 +415,24 @@ foreach ($target in $targets) {
         $reportNote = [string]::Join('<br />', $reportPaths)
     } elseif ($message) {
         $reportNote = $message
+    }
+
+    $timingNote = $null
+    if ($durationSecondsValue -ne $null -and $durationSamplesValue -gt 0) {
+        $timingNote = ("time: {0:N2}s total ({1} compare{2}" -f $durationSecondsValue, $durationSamplesValue, $(if ($durationSamplesValue -eq 1) { '' } else { 's' }))
+        if ($durationAvgSecondsValue -ne $null) {
+            $timingNote += (", avg {0:N2}s" -f $durationAvgSecondsValue)
+        }
+        $timingNote += ')'
+    } elseif ($durationSecondsValue -ne $null) {
+        $timingNote = ("time: {0:N2}s total" -f $durationSecondsValue)
+    }
+    if ($timingNote) {
+        if ($reportNote -eq '_n/a_') {
+            $reportNote = $timingNote
+        } else {
+            $reportNote = ($reportNote + '<br />' + $timingNote)
+        }
     }
 
     $statusLabel = switch ($status) {
@@ -627,6 +671,8 @@ $result = [pscustomobject]@{
         diffPairRows= $diffPairRows
         previewImages = $previewEntries.Count
         markdownTruncated = $markdownTruncated
+        durationSeconds = [Math]::Round($durationTotalSeconds, 6)
+        durationSamples = $durationSampleTotal
         timing      = $timingSummary
     }
     targets  = $targets

--- a/tools/Test-PRVIHistorySmoke.ps1
+++ b/tools/Test-PRVIHistorySmoke.ps1
@@ -22,6 +22,8 @@ Emit the planned steps without executing them.
 .PARAMETER Scenario
 Selects which synthetic change set to exercise. Use `attribute` for the legacy
 single-commit attr diff, `sequential` to replay multiple fixture commits, or
+`sequential-multi-vi` to replay the same sequential fixture with two VI targets
+mutated in each commit, or
 `mixed-same-commit` to mutate two VI targets in a single commit (strict signal
 plus non-strict metadata-noise coverage), or `sequential-masscompile` to replay
 masscompile-only commits around a mixed signal+noise commit.
@@ -48,7 +50,7 @@ param(
     [string]$BaseBranch = 'develop',
     [switch]$KeepBranch,
     [switch]$DryRun,
-    [ValidateSet('attribute', 'sequential', 'mixed-same-commit', 'sequential-masscompile')]
+    [ValidateSet('attribute', 'sequential', 'sequential-multi-vi', 'mixed-same-commit', 'sequential-masscompile')]
     [string]$Scenario = 'attribute',
     [int]$MaxPairs = 6,
     [int]$WorkflowTimeoutMinutes = 10,
@@ -764,6 +766,73 @@ function Invoke-SequentialHistoryCommits {
     return $commits.ToArray()
 }
 
+function Invoke-SequentialMultiViHistoryCommits {
+    param(
+        [Parameter(Mandatory)]
+        [string[]]$TargetVis
+    )
+
+    if (-not $TargetVis -or $TargetVis.Count -lt 2) {
+        throw 'Sequential multi-VI scenario requires at least two target VI paths.'
+    }
+
+    $fixture = Get-SequentialHistorySequence
+    Write-Verbose ("Sequential fixture loaded from {0}" -f $fixture.path)
+
+    $targetDetails = New-Object System.Collections.Generic.List[pscustomobject]
+    foreach ($targetVi in ($TargetVis | Select-Object -Unique)) {
+        $targetResolved = if ([System.IO.Path]::IsPathRooted($targetVi)) {
+            $targetVi
+        } else {
+            Join-Path $fixture.repoRoot $targetVi
+        }
+        if (-not (Test-Path -LiteralPath $targetResolved -PathType Leaf)) {
+            throw ("Sequential multi-VI target not found: {0}" -f $targetVi)
+        }
+        $targetRelative = if ([System.IO.Path]::IsPathRooted($targetVi)) {
+            [System.IO.Path]::GetRelativePath($fixture.repoRoot, $targetResolved)
+        } else {
+            $targetVi
+        }
+        $targetDetails.Add([pscustomobject]@{
+            relativePath = $targetRelative
+            resolvedPath = $targetResolved
+        }) | Out-Null
+    }
+
+    $commits = New-Object System.Collections.Generic.List[pscustomobject]
+    for ($index = 0; $index -lt $fixture.steps.Count; $index++) {
+        $step = $fixture.steps[$index]
+        $stepNumber = $index + 1
+        $displaySource = if ($step.source) { $step.source } else { $step.resolvedSource }
+
+        foreach ($target in $targetDetails) {
+            Write-Host ("Applying sequential multi-VI step {0}: {1} <= {2}" -f $stepNumber, $target.relativePath, $displaySource)
+            Copy-VIContent -Source $step.resolvedSource -Destination $target.resolvedPath
+            $statusAfterStep = @(Invoke-Git -Arguments @('status', '--porcelain', '--', $target.relativePath))
+            Write-Host ("Post-step status for {0}: {1}" -f $target.relativePath, ($statusAfterStep -join ' '))
+            if ($statusAfterStep.Count -eq 0) {
+                throw ("Sequential multi-VI step {0} produced no delta for target '{1}'." -f $stepNumber, $target.relativePath)
+            }
+            Invoke-Git -Arguments @('add', '-f', $target.relativePath) | Out-Null
+        }
+
+        $commitMessage = if ([string]::IsNullOrWhiteSpace($step.message)) {
+            "chore: sequential multi-VI history step $stepNumber"
+        } else {
+            $step.message
+        }
+        Invoke-Git -Arguments @('commit', '-m', $commitMessage) | Out-Null
+        $commits.Add([pscustomobject]@{
+            Title   = if ($step.title) { "$($step.title) (multi-VI)" } else { "Step $stepNumber (multi-VI)" }
+            Source  = $displaySource
+            Message = $commitMessage
+        }) | Out-Null
+    }
+
+    return $commits.ToArray()
+}
+
 function Invoke-SequentialMasscompileHistoryCommits {
     $fixture = Get-SequentialMasscompileFixture
     Write-Verbose ("Sequential masscompile fixture loaded from {0}" -f $fixture.path)
@@ -875,6 +944,14 @@ switch ($scenarioKey) {
         $scenarioNeedsArtifactValidation = $true
         $scenarioRequiresMobilePreview = $true
     }
+    'sequential-multi-vi' {
+        $scenarioBranchSuffix = 'sequential-multi-vi'
+        $scenarioDescription  = 'sequential multi-category history (two VIs per commit)'
+        $scenarioExpectation  = '`/vi-history` workflow reports per-target rows for two sequentially changed VIs'
+        $scenarioPlanHint     = '- Apply sequential fixture commits to fixtures/vi-attr/Head.vi and fixtures/vi-attr/Base.vi in each commit'
+        $scenarioNeedsArtifactValidation = $true
+        $scenarioRequiresMobilePreview = $true
+    }
     'mixed-same-commit' {
         $scenarioBranchSuffix = 'mixed'
         $scenarioDescription  = 'mixed same-commit two-target history'
@@ -902,6 +979,9 @@ switch ($scenarioKey) {
     'sequential' {
         Get-SequentialHistorySequence | Out-Null
     }
+    'sequential-multi-vi' {
+        Get-SequentialHistorySequence | Out-Null
+    }
     'mixed-same-commit' {
         Get-MixedSameCommitFixture | Out-Null
     }
@@ -914,6 +994,12 @@ $effectiveMaxPairs = $MaxPairs
 if (-not $PSBoundParameters.ContainsKey('MaxPairs')) {
     switch ($scenarioKey) {
         'sequential' {
+            $sequentialFixture = Get-SequentialHistorySequence
+            if ($null -ne $sequentialFixture.maxPairs) {
+                $effectiveMaxPairs = [int]$sequentialFixture.maxPairs
+            }
+        }
+        'sequential-multi-vi' {
             $sequentialFixture = Get-SequentialHistorySequence
             if ($null -ne $sequentialFixture.maxPairs) {
                 $effectiveMaxPairs = [int]$sequentialFixture.maxPairs
@@ -1088,6 +1174,28 @@ try {
             $expectedTargets = @(
                 [pscustomobject]@{
                     repoPath          = $targetVi
+                    requireDiff       = $true
+                    minDiffs          = 1
+                    classificationHint= 'signal'
+                }
+            )
+        }
+        'sequential-multi-vi' {
+            $targetVis = @('fixtures/vi-attr/Head.vi', 'fixtures/vi-attr/Base.vi')
+            foreach ($targetVi in $targetVis) {
+                Enable-HistoryTracking -Path $targetVi
+                $trackedHistoryPaths.Add($targetVi) | Out-Null
+            }
+            $commitSummaries = Invoke-SequentialMultiViHistoryCommits -TargetVis $targetVis
+            $expectedTargets = @(
+                [pscustomobject]@{
+                    repoPath          = 'fixtures/vi-attr/Head.vi'
+                    requireDiff       = $true
+                    minDiffs          = 1
+                    classificationHint= 'signal'
+                },
+                [pscustomobject]@{
+                    repoPath          = 'fixtures/vi-attr/Base.vi'
                     requireDiff       = $true
                     minDiffs          = 1
                     classificationHint= 'signal'
@@ -1346,17 +1454,23 @@ try {
     $scratchContext.Diffs = $totalDiffs
 
     if ($scenarioNeedsArtifactValidation) {
-        if ($scenarioKey -eq 'sequential') {
+        if ($scenarioKey -in @('sequential', 'sequential-multi-vi')) {
             $expectedSequentialComparisons = [Math]::Max(1, $commitSummaries.Count)
             if ($effectiveMaxPairs -gt 0) {
                 $expectedSequentialComparisons = [Math]::Max(1, [Math]::Min($expectedSequentialComparisons, $effectiveMaxPairs))
             }
-            $sequentialTarget = $targetValidations | Where-Object { $_.repoPath -eq 'fixtures/vi-attr/Head.vi' } | Select-Object -First 1
-            if (-not $sequentialTarget) {
-                $sequentialTarget = $targetValidations | Select-Object -First 1
+            $sequentialTargets = @($expectedTargets | Where-Object { $_.requireDiff })
+            if ($sequentialTargets.Count -eq 0) {
+                $sequentialTargets = @($expectedTargets)
             }
-            if ($sequentialTarget.comparisons -lt $expectedSequentialComparisons) {
-                throw ("Expected at least {0} comparisons for sequential scenario, but comment reported {1}." -f $expectedSequentialComparisons, $sequentialTarget.comparisons)
+            foreach ($sequentialTargetExpectation in $sequentialTargets) {
+                $sequentialTarget = $targetValidations | Where-Object { $_.repoPath -eq $sequentialTargetExpectation.repoPath } | Select-Object -First 1
+                if (-not $sequentialTarget) {
+                    throw ("Expected sequential target row was not parsed: {0}" -f $sequentialTargetExpectation.repoPath)
+                }
+                if ($sequentialTarget.comparisons -lt $expectedSequentialComparisons) {
+                    throw ("Expected at least {0} comparisons for {1}, but comment reported {2}." -f $expectedSequentialComparisons, $sequentialTargetExpectation.repoPath, $sequentialTarget.comparisons)
+                }
             }
         }
         $artifactDir = Join-Path $summaryDir ("artifact-$timestamp")
@@ -1441,13 +1555,13 @@ try {
                 $targetValidation.artifactPolicyReason = [string]$artifactDecision.reasonMessage
             }
 
-            if ($scenarioKey -eq 'sequential' -and $summaryTarget -and $summaryTarget.repoPath -eq 'fixtures/vi-attr/Head.vi') {
+            if ($scenarioKey -in @('sequential', 'sequential-multi-vi') -and $summaryTarget) {
                 $expectedSequentialComparisons = [Math]::Max(1, $commitSummaries.Count)
                 if ($effectiveMaxPairs -gt 0) {
                     $expectedSequentialComparisons = [Math]::Max(1, [Math]::Min($expectedSequentialComparisons, $effectiveMaxPairs))
                 }
                 if ($artifactComparisons -lt $expectedSequentialComparisons) {
-                    throw ("Summary JSON reported {0} comparisons for sequential target; expected at least {1}." -f $artifactComparisons, $expectedSequentialComparisons)
+                    throw ("Summary JSON reported {0} comparisons for {1}; expected at least {2}." -f $artifactComparisons, $summaryTarget.repoPath, $expectedSequentialComparisons)
                 }
             }
         }


### PR DESCRIPTION
## Summary
Harvests targeted harness/timing deltas from PR #27 into `develop` without pulling in broader cross-branch or masscompile expansions.

## What was ported
1. Added additive timing fields to `pr-vi-history-summary@v1`:
- Per target: `stats.durationSeconds`, `stats.durationSamples`, `stats.durationAvgSeconds`
- Totals: `totals.durationSeconds`, `totals.durationSamples`
2. Updated summary renderer to surface per-target timing notes in the `Report / Notes` column.
3. Added `sequential-multi-vi` scenario support in `tools/Test-PRVIHistorySmoke.ps1`:
- Replays sequential fixture steps while mutating two target VIs in each commit.
- Reuses existing strict policy/comment/artifact validation paths.
4. Extended tests for timing fields in both invoke and summarize contracts.

## Explicitly out of scope in this PR
- Cross-branch dispatch window controls from PR #27.
- Masscompile-provider/path behavior changes from PR #27.
- Breaking workflow interfaces.

## Validation
- `Invoke-Pester -Path tests/Invoke-PRVIHistory.Tests.ps1,tests/Summarize-PRVIHistory.Tests.ps1 -CI`
- `pwsh -NoLogo -NoProfile -File tools/Test-PRVIHistorySmoke.ps1 -Scenario sequential-multi-vi -DryRun`
- `pwsh -NoLogo -NoProfile -File tools/PrePush-Checks.ps1 -SkipIconEditorFixtureChecks`

Closes #121