### PR TITLE
Harden markdown lint determinism for single-file and temp drafts (#131)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,6 +130,11 @@ line buffers).
   - Full dual-lane validation:
     - `pwsh -NoLogo -NoProfile -File tools/Test-DockerDesktopFastLoop.ps1 -LaneScope both -StepTimeoutSeconds 600`
   - `-ManageDockerEngine` is only allowed with `-LaneScope both`.
+- Markdown lint changed-file contract:
+  - `tools/Lint-Markdown.ps1` and `tools/lint-markdown.mjs` suppress temporary
+    draft files (`.tmp-*.md`, `pr-*-body.md`) during changed-file runs.
+  - Tracked markdown is still linted; temp-file suppression is only for
+    untracked local drafts.
 - Optional hook workflow:
   1. `git config core.hooksPath tools/hooks`
   2. Copy `tools/hooks/pre-push.sample` to `tools/hooks/pre-push`

--- a/tests/Lint-Markdown.Tests.ps1
+++ b/tests/Lint-Markdown.Tests.ps1
@@ -1,0 +1,99 @@
+Set-StrictMode -Version Latest
+
+Describe 'Lint-Markdown.ps1' {
+  BeforeAll {
+    $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+    $script:LintScriptSource = Join-Path $script:RepoRoot 'tools' 'Lint-Markdown.ps1'
+    if (-not (Test-Path -LiteralPath $script:LintScriptSource -PathType Leaf)) {
+      throw "Lint script not found at $script:LintScriptSource"
+    }
+  }
+
+  It 'handles a single changed markdown file without scalar count errors' {
+    $repoPath = Join-Path $TestDrive 'single-file'
+    $toolsPath = Join-Path $repoPath 'tools'
+    New-Item -ItemType Directory -Path $toolsPath -Force | Out-Null
+    Copy-Item -LiteralPath $script:LintScriptSource -Destination (Join-Path $toolsPath 'Lint-Markdown.ps1') -Force
+
+    @'
+function Resolve-MarkdownlintCli2Path {
+  return (Join-Path $PSScriptRoot 'fake-markdownlint.ps1')
+}
+
+Export-ModuleMember -Function Resolve-MarkdownlintCli2Path
+'@ | Set-Content -LiteralPath (Join-Path $toolsPath 'VendorTools.psm1') -Encoding UTF8
+
+    @'
+param([Parameter(ValueFromRemainingArguments=$true)][string[]]$Args)
+exit 0
+'@ | Set-Content -LiteralPath (Join-Path $toolsPath 'fake-markdownlint.ps1') -Encoding UTF8
+
+    Set-Content -LiteralPath (Join-Path $repoPath '.markdownlint.jsonc') -Encoding UTF8 -Value '{"default":true,"MD013":false}'
+    Set-Content -LiteralPath (Join-Path $repoPath '.markdownlintignore') -Encoding UTF8 -Value ''
+    Set-Content -LiteralPath (Join-Path $repoPath 'README.md') -Encoding UTF8 -Value "# Seed`n"
+    Set-Content -LiteralPath (Join-Path $repoPath 'single.md') -Encoding UTF8 -Value "# Single`n"
+
+    Push-Location $repoPath
+    try {
+      git init | Out-Null
+      git config user.email lint-tests@example.com
+      git config user.name lint-tests
+      git add README.md .markdownlint.jsonc .markdownlintignore tools
+      git commit -m 'init' | Out-Null
+
+      $output = & pwsh -NoLogo -NoProfile -File (Join-Path $repoPath 'tools' 'Lint-Markdown.ps1') 2>&1
+      $exitCode = $LASTEXITCODE
+    } finally {
+      Pop-Location
+    }
+
+    $joined = @($output | ForEach-Object { [string]$_ }) -join "`n"
+    $exitCode | Should -Be 0
+    $joined | Should -Match 'Linting 1 Markdown file\(s\)\.'
+    $joined | Should -Not -Match "property 'Count' cannot be found"
+  }
+
+  It 'suppresses temporary markdown drafts from changed-file lint selection' {
+    $repoPath = Join-Path $TestDrive 'suppressed-temp'
+    $toolsPath = Join-Path $repoPath 'tools'
+    New-Item -ItemType Directory -Path $toolsPath -Force | Out-Null
+    Copy-Item -LiteralPath $script:LintScriptSource -Destination (Join-Path $toolsPath 'Lint-Markdown.ps1') -Force
+
+    @'
+function Resolve-MarkdownlintCli2Path {
+  return (Join-Path $PSScriptRoot 'fake-markdownlint.ps1')
+}
+
+Export-ModuleMember -Function Resolve-MarkdownlintCli2Path
+'@ | Set-Content -LiteralPath (Join-Path $toolsPath 'VendorTools.psm1') -Encoding UTF8
+
+    @'
+param([Parameter(ValueFromRemainingArguments=$true)][string[]]$Args)
+exit 0
+'@ | Set-Content -LiteralPath (Join-Path $toolsPath 'fake-markdownlint.ps1') -Encoding UTF8
+
+    Set-Content -LiteralPath (Join-Path $repoPath '.markdownlint.jsonc') -Encoding UTF8 -Value '{"default":true,"MD013":false}'
+    Set-Content -LiteralPath (Join-Path $repoPath '.markdownlintignore') -Encoding UTF8 -Value ''
+    Set-Content -LiteralPath (Join-Path $repoPath 'README.md') -Encoding UTF8 -Value "# Seed`n"
+    Set-Content -LiteralPath (Join-Path $repoPath '.tmp-scratch.md') -Encoding UTF8 -Value 'draft'
+    Set-Content -LiteralPath (Join-Path $repoPath 'pr-123-body.md') -Encoding UTF8 -Value 'draft'
+
+    Push-Location $repoPath
+    try {
+      git init | Out-Null
+      git config user.email lint-tests@example.com
+      git config user.name lint-tests
+      git add README.md .markdownlint.jsonc .markdownlintignore tools
+      git commit -m 'init' | Out-Null
+
+      $output = & pwsh -NoLogo -NoProfile -File (Join-Path $repoPath 'tools' 'Lint-Markdown.ps1') 2>&1
+      $exitCode = $LASTEXITCODE
+    } finally {
+      Pop-Location
+    }
+
+    $joined = @($output | ForEach-Object { [string]$_ }) -join "`n"
+    $exitCode | Should -Be 0
+    $joined | Should -Match 'No Markdown files to lint\.'
+  }
+}

--- a/tools/Lint-Markdown.ps1
+++ b/tools/Lint-Markdown.ps1
@@ -205,22 +205,39 @@ try {
       Get-ChangedMarkdownFiles -Base $mergeBase
     }
   )
+  $markdownFiles = @($markdownFiles | Where-Object { $_ })
 
-  if ($markdownFiles) {
-    $markdownFiles = $markdownFiles | Where-Object { -not (Test-MarkdownlintIgnored -Path $_ -Matchers $ignoreMatchers) }
+  if ($markdownFiles.Count -gt 0) {
+    $markdownFiles = @(
+      $markdownFiles | Where-Object { -not (Test-MarkdownlintIgnored -Path $_ -Matchers $ignoreMatchers) }
+    )
   }
 
-  if (-not $markdownFiles -or $markdownFiles.Count -eq 0) {
+  if ($markdownFiles.Count -eq 0) {
     Write-Host 'No Markdown files to lint.'
     exit 0
   }
 
   # Scoped suppressions for known large/generated files until backlog is addressed
-  $suppressed = @(
+  $suppressedExact = @(
     'CHANGELOG.md',
     'fixture-summary.md'
   )
-  $filesToLint = @($markdownFiles | Where-Object { $suppressed -notcontains $_ })
+  $suppressedNamePatterns = @(
+    '^\.tmp-.*\.md$',
+    '^pr-.*-body\.md$'
+  )
+  $filesToLint = @(
+    $markdownFiles | Where-Object {
+      $path = $_.Replace('\', '/')
+      $leaf = Split-Path -Path $path -Leaf
+      if ($suppressedExact -contains $path) { return $false }
+      foreach ($pattern in $suppressedNamePatterns) {
+        if ($leaf -match $pattern) { return $false }
+      }
+      return $true
+    }
+  )
 
   if (-not $filesToLint -or $filesToLint.Count -eq 0) {
     Write-Host 'No Markdown files to lint.'

--- a/tools/__tests__/lint-markdown.test.mjs
+++ b/tools/__tests__/lint-markdown.test.mjs
@@ -1,0 +1,20 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { isSuppressedMarkdownPath } from '../lint-markdown.mjs';
+
+test('suppresses known generated markdown names', () => {
+  assert.equal(isSuppressedMarkdownPath('CHANGELOG.md'), true);
+  assert.equal(isSuppressedMarkdownPath('fixture-summary.md'), true);
+});
+
+test('suppresses temporary draft markdown names', () => {
+  assert.equal(isSuppressedMarkdownPath('.tmp-pr-body.md'), true);
+  assert.equal(isSuppressedMarkdownPath('notes/pr-576-body.md'), true);
+  assert.equal(isSuppressedMarkdownPath('notes\\pr-999-body.md'), true);
+});
+
+test('does not suppress normal docs', () => {
+  assert.equal(isSuppressedMarkdownPath('README.md'), false);
+  assert.equal(isSuppressedMarkdownPath('docs/DEVELOPER_GUIDE.md'), false);
+});

--- a/tools/lint-markdown.mjs
+++ b/tools/lint-markdown.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
-import { dirname, join } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
 import { existsSync } from 'node:fs';
 
 function parseArgs(argv) {
@@ -153,6 +153,20 @@ function extractRules(output) {
   return Array.from(matches);
 }
 
+export function isSuppressedMarkdownPath(file) {
+  if (!file) {
+    return true;
+  }
+  const normalized = file.replace(/\\/g, '/');
+  const leaf = normalized.split('/').pop() || normalized;
+  const suppressedExact = new Set(['CHANGELOG.md', 'fixture-summary.md']);
+  if (suppressedExact.has(normalized)) {
+    return true;
+  }
+  const suppressedNamePatterns = [/^\.tmp-.*\.md$/i, /^pr-.*-body\.md$/i];
+  return suppressedNamePatterns.some((pattern) => pattern.test(leaf));
+}
+
 function main() {
   const { all, baseRef } = parseArgs(process.argv);
   const repoRoot = resolveRepoRoot();
@@ -177,8 +191,7 @@ function main() {
     return 0;
   }
 
-  const suppressed = new Set(['CHANGELOG.md', 'fixture-summary.md']);
-  const filesToLint = markdownFiles.filter((file) => !suppressed.has(file));
+  const filesToLint = markdownFiles.filter((file) => !isSuppressedMarkdownPath(file));
   if (filesToLint.length === 0) {
     console.log('No Markdown files to lint.');
     return 0;
@@ -211,10 +224,15 @@ function main() {
   return typeof result.status === 'number' ? result.status : 1;
 }
 
-try {
-  const exitCode = main();
-  process.exitCode = exitCode;
-} catch (error) {
-  console.error(error instanceof Error ? error.message : String(error));
-  process.exitCode = 1;
+const invokedPath = process.argv[1] ? resolve(process.argv[1]) : '';
+const modulePath = fileURLToPath(import.meta.url);
+
+if (invokedPath === modulePath) {
+  try {
+    const exitCode = main();
+    process.exitCode = exitCode;
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
 }


### PR DESCRIPTION
## Summary
- fix `tools/Lint-Markdown.ps1` single-file changed-set handling (no scalar `.Count` failure)
- suppress local temp markdown drafts in changed-file mode (`.tmp-*.md`, `pr-*-body.md`) in both PowerShell and Node lint paths
- make `tools/lint-markdown.mjs` import-safe by gating `main()` to direct execution only
- add regression tests for PowerShell changed-file behavior and Node suppression rules

## Standing Priority
- addresses #131

## Validation
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Path 'tests/Lint-Markdown.Tests.ps1' -CI"`
- `node --test tools/__tests__/lint-markdown.test.mjs`
- `pwsh -NoLogo -NoProfile -File tools/PrePush-Checks.ps1 -SkipIconEditorFixtureChecks`
