### PR TITLE
Add gh-auth token fallback for priority REST sync (#139)

### DIFF
--- a/tools/priority/__tests__/token-resolution.test.mjs
+++ b/tools/priority/__tests__/token-resolution.test.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  resolveGitHubToken,
+  resetPrioritySyncTokenStateForTests,
+  warnNoGitHubTokenForRestOnce
+} from '../sync-standing-priority.mjs';
+
+test('resolveGitHubToken prefers GH_TOKEN over GITHUB_TOKEN and gh fallback', () => {
+  const token = resolveGitHubToken({
+    env: { GH_TOKEN: ' gh-token ', GITHUB_TOKEN: ' github-token ' },
+    authTokenProvider: () => 'gh-auth-token'
+  });
+  assert.equal(token, 'gh-token');
+});
+
+test('resolveGitHubToken falls back to GITHUB_TOKEN when GH_TOKEN missing', () => {
+  const token = resolveGitHubToken({
+    env: { GITHUB_TOKEN: ' github-token ' },
+    authTokenProvider: () => 'gh-auth-token'
+  });
+  assert.equal(token, 'github-token');
+});
+
+test('resolveGitHubToken uses gh auth token provider when env tokens are missing', () => {
+  const token = resolveGitHubToken({
+    env: {},
+    authTokenProvider: () => ' gh-auth-token '
+  });
+  assert.equal(token, 'gh-auth-token');
+});
+
+test('resolveGitHubToken returns null when no token source is available', () => {
+  const token = resolveGitHubToken({
+    env: {},
+    authTokenProvider: () => null
+  });
+  assert.equal(token, null);
+});
+
+test('warnNoGitHubTokenForRestOnce emits only one warning per process state', () => {
+  resetPrioritySyncTokenStateForTests();
+  const seen = [];
+  const originalWarn = console.warn;
+  console.warn = (message) => {
+    seen.push(message);
+  };
+
+  try {
+    warnNoGitHubTokenForRestOnce();
+    warnNoGitHubTokenForRestOnce();
+  } finally {
+    console.warn = originalWarn;
+    resetPrioritySyncTokenStateForTests();
+  }
+
+  assert.equal(seen.length, 1);
+  assert.equal(
+    seen[0],
+    '[priority] No GitHub token available for REST fallback; attempting unauthenticated request'
+  );
+});
+

--- a/tools/priority/sync-standing-priority.mjs
+++ b/tools/priority/sync-standing-priority.mjs
@@ -9,6 +9,8 @@ import { ProxyAgent } from 'undici';
 
 const USER_AGENT = 'compare-vi-cli-action/priority-sync';
 const PROXY_AGENT_CACHE = new Map();
+let GH_AUTH_TOKEN_CACHE;
+let WARNED_NO_GITHUB_TOKEN_FOR_REST = false;
 
 function toUrl(input) {
   if (!input) return null;
@@ -464,9 +466,53 @@ function resolveRepositorySlug(repoRoot) {
   return null;
 }
 
-function resolveGitHubToken() {
-  const token = process.env.GH_TOKEN || process.env.GITHUB_TOKEN;
-  return token ? token.trim() : null;
+function normalizeTokenValue(value) {
+  const normalized = typeof value === 'string' ? value.trim() : '';
+  return normalized || null;
+}
+
+function resolveGitHubTokenViaGh() {
+  if (GH_AUTH_TOKEN_CACHE !== undefined) {
+    return GH_AUTH_TOKEN_CACHE;
+  }
+
+  try {
+    const auth = ensureCommand(sh('gh', ['auth', 'token']), 'gh');
+    if (auth.status === 0) {
+      GH_AUTH_TOKEN_CACHE = normalizeTokenValue(auth.stdout);
+      return GH_AUTH_TOKEN_CACHE;
+    }
+    GH_AUTH_TOKEN_CACHE = null;
+    return null;
+  } catch {
+    GH_AUTH_TOKEN_CACHE = null;
+    return null;
+  }
+}
+
+export function resolveGitHubToken(options = {}) {
+  const env = options.env ?? process.env;
+  const tokenFromEnv = normalizeTokenValue(env.GH_TOKEN) || normalizeTokenValue(env.GITHUB_TOKEN);
+  if (tokenFromEnv) {
+    return tokenFromEnv;
+  }
+
+  if (typeof options.authTokenProvider === 'function') {
+    return normalizeTokenValue(options.authTokenProvider());
+  }
+
+  return resolveGitHubTokenViaGh();
+}
+
+export function warnNoGitHubTokenForRestOnce() {
+  if (WARNED_NO_GITHUB_TOKEN_FOR_REST) return;
+  WARNED_NO_GITHUB_TOKEN_FOR_REST = true;
+  console.warn('[priority] No GitHub token available for REST fallback; attempting unauthenticated request');
+}
+
+export function resetPrioritySyncTokenStateForTests() {
+  GH_AUTH_TOKEN_CACHE = undefined;
+  WARNED_NO_GITHUB_TOKEN_FOR_REST = false;
 }
 
 async function requestGitHubJson(url, token) {
@@ -499,7 +545,7 @@ async function fetchStandingPriorityNumberViaRest(repoRoot, slug) {
 
   const token = resolveGitHubToken();
   if (!token) {
-    console.warn('[priority] No GitHub token available for REST fallback; attempting unauthenticated request');
+    warnNoGitHubTokenForRestOnce();
   }
 
     const url = new URL(`https://api.github.com/repos/${resolvedSlug}/issues`);
@@ -593,7 +639,7 @@ async function fetchIssueViaRest(repoRoot, number, slug) {
 
   const token = resolveGitHubToken();
   if (!token) {
-    console.warn('[priority] No GitHub token available for REST fallback; attempting unauthenticated request');
+    warnNoGitHubTokenForRestOnce();
   }
 
   try {


### PR DESCRIPTION
## Summary
- add token source fallback order for priority REST sync: `GH_TOKEN` -> `GITHUB_TOKEN` -> `gh auth token`
- cache gh auth token resolution to avoid repeated shell calls
- emit unauthenticated REST warning only once per process when no token source exists
- add test coverage for token precedence and warning de-dup behavior

## Issue
- Closes #139

## Testing
- `node tools/npm/run-script.mjs priority:test`
- `node tools/npm/run-script.mjs hooks:multi`
- `node tools/npm/run-script.mjs hooks:schema`