### PR TITLE
Automate standing-priority label cleanup on close (#141)

### DIFF
--- a/.github/workflows/standing-priority-hygiene.yml
+++ b/.github/workflows/standing-priority-hygiene.yml
@@ -1,0 +1,44 @@
+name: Standing Priority Hygiene
+
+on:
+  issues:
+    types:
+      - closed
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: "Issue number to evaluate"
+        required: true
+        type: number
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  remove-closed-standing-priority-label:
+    name: Remove Closed Standing-Priority Label
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Resolve issue number
+        id: issue
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "number=${{ inputs.issue_number }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "number=${{ github.event.issue.number }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Remove standing-priority label if issue is closed
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          node tools/priority/standing-priority-hygiene.mjs \
+            --issue "${{ steps.issue.outputs.number }}" \
+            --label "standing-priority"
+

--- a/tools/priority/__tests__/standing-priority-hygiene.test.mjs
+++ b/tools/priority/__tests__/standing-priority-hygiene.test.mjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  issueHasLabel,
+  parseCliArgs,
+  shouldRemoveStandingPriorityLabel
+} from '../standing-priority-hygiene.mjs';
+
+test('issueHasLabel matches label names across string/object labels', () => {
+  assert.equal(issueHasLabel({ labels: ['standing-priority'] }), true);
+  assert.equal(issueHasLabel({ labels: [{ name: 'standing-priority' }] }), true);
+  assert.equal(issueHasLabel({ labels: [{ name: 'enhancement' }] }), false);
+});
+
+test('shouldRemoveStandingPriorityLabel requires closed state and standing label', () => {
+  assert.equal(
+    shouldRemoveStandingPriorityLabel({
+      state: 'closed',
+      labels: [{ name: 'standing-priority' }]
+    }),
+    true
+  );
+  assert.equal(
+    shouldRemoveStandingPriorityLabel({
+      state: 'open',
+      labels: [{ name: 'standing-priority' }]
+    }),
+    false
+  );
+  assert.equal(
+    shouldRemoveStandingPriorityLabel({
+      state: 'closed',
+      labels: [{ name: 'enhancement' }]
+    }),
+    false
+  );
+});
+
+test('parseCliArgs reads issue, label and dry-run options', () => {
+  const parsed = parseCliArgs(['--issue', '141', '--label', 'standing-priority', '--dry-run']);
+  assert.equal(parsed.issue, 141);
+  assert.equal(parsed.label, 'standing-priority');
+  assert.equal(parsed.dryRun, true);
+});
+
+test('parseCliArgs rejects missing issue', () => {
+  assert.throws(() => parseCliArgs([]), /Missing required --issue/);
+});
+

--- a/tools/priority/standing-priority-hygiene.mjs
+++ b/tools/priority/standing-priority-hygiene.mjs
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+function sh(cmd, args, opts = {}) {
+  return spawnSync(cmd, args, { encoding: 'utf8', shell: false, ...opts });
+}
+
+function ensureCommand(result, cmd) {
+  if (result?.error?.code === 'ENOENT') {
+    const err = new Error(`Command not found: ${cmd}`);
+    err.code = 'ENOENT';
+    throw err;
+  }
+  return result;
+}
+
+export function issueHasLabel(issue, label = 'standing-priority') {
+  if (!issue || !Array.isArray(issue.labels)) return false;
+  const normalized = String(label || '')
+    .trim()
+    .toLowerCase();
+  if (!normalized) return false;
+  return issue.labels.some((entry) => {
+    const name = typeof entry === 'string' ? entry : entry?.name;
+    return String(name || '')
+      .trim()
+      .toLowerCase() === normalized;
+  });
+}
+
+export function shouldRemoveStandingPriorityLabel(issue, label = 'standing-priority') {
+  const state = String(issue?.state || '')
+    .trim()
+    .toUpperCase();
+  return state === 'CLOSED' && issueHasLabel(issue, label);
+}
+
+export function parseCliArgs(argv = process.argv.slice(2)) {
+  const args = Array.from(argv || []);
+  const options = {
+    issue: null,
+    label: 'standing-priority',
+    dryRun: false
+  };
+
+  for (let i = 0; i < args.length; i += 1) {
+    const token = args[i];
+    if (token === '--issue') {
+      const value = args[++i];
+      if (!value) throw new Error('Missing value for --issue');
+      const parsed = Number(value);
+      if (!Number.isInteger(parsed) || parsed <= 0) {
+        throw new Error(`Invalid issue number: ${value}`);
+      }
+      options.issue = parsed;
+      continue;
+    }
+    if (token === '--label') {
+      const value = args[++i];
+      if (!value) throw new Error('Missing value for --label');
+      options.label = value;
+      continue;
+    }
+    if (token === '--dry-run') {
+      options.dryRun = true;
+      continue;
+    }
+    if (token === '--help' || token === '-h') {
+      options.help = true;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${token}`);
+  }
+
+  if (!options.help && !options.issue) {
+    throw new Error('Missing required --issue <number>');
+  }
+  return options;
+}
+
+function printHelp() {
+  console.log(`Usage:
+  node tools/priority/standing-priority-hygiene.mjs --issue <number> [--label <name>] [--dry-run]
+
+Removes the standing-priority label from a closed issue when present.`);
+}
+
+export async function runHygiene(options = {}) {
+  const issueNumber = options.issue;
+  const label = options.label || 'standing-priority';
+  const dryRun = Boolean(options.dryRun);
+
+  const viewResult = ensureCommand(
+    sh('gh', ['issue', 'view', String(issueNumber), '--json', 'number,state,labels,url']),
+    'gh'
+  );
+  if (viewResult.status !== 0) {
+    const details = viewResult.stderr?.trim() || viewResult.stdout?.trim() || 'unknown error';
+    throw new Error(`Failed to inspect issue #${issueNumber}: ${details}`);
+  }
+
+  const issue = JSON.parse(viewResult.stdout || '{}');
+  if (!shouldRemoveStandingPriorityLabel(issue, label)) {
+    console.log(
+      `[standing-hygiene] No cleanup needed for issue #${issue.number ?? issueNumber} (state=${issue.state || 'unknown'}).`
+    );
+    return { removed: false, issue };
+  }
+
+  if (dryRun) {
+    console.log(
+      `[standing-hygiene] Dry-run: would remove label '${label}' from closed issue #${issue.number}.`
+    );
+    return { removed: false, issue, dryRun: true };
+  }
+
+  const editResult = ensureCommand(
+    sh('gh', ['issue', 'edit', String(issue.number), '--remove-label', label]),
+    'gh'
+  );
+  if (editResult.status !== 0) {
+    const details = editResult.stderr?.trim() || editResult.stdout?.trim() || 'unknown error';
+    throw new Error(
+      `Failed to remove label '${label}' from issue #${issue.number}: ${details}`
+    );
+  }
+
+  console.log(`[standing-hygiene] Removed label '${label}' from issue #${issue.number}.`);
+  return { removed: true, issue };
+}
+
+const modulePath = path.resolve(fileURLToPath(import.meta.url));
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : null;
+if (invokedPath && invokedPath === modulePath) {
+  (async () => {
+    try {
+      const options = parseCliArgs(process.argv.slice(2));
+      if (options.help) {
+        printHelp();
+        process.exitCode = 0;
+        return;
+      }
+      await runHygiene(options);
+      process.exitCode = 0;
+    } catch (err) {
+      console.error(`[standing-hygiene] ${err.message}`);
+      process.exitCode = 1;
+    }
+  })();
+}
+


### PR DESCRIPTION
## Summary
- add a new workflow `.github/workflows/standing-priority-hygiene.yml` triggered on issue close (and manual dispatch)
- add `tools/priority/standing-priority-hygiene.mjs` to inspect issue state/labels and remove `standing-priority` from closed issues
- add unit tests for label detection, close-state cleanup decision, and CLI argument parsing

## Issue
- Closes #141

## Testing
- `node tools/npm/run-script.mjs priority:test`
- `bin/actionlint.exe -color`