### PR TITLE
Scope icon-editor pre-push checks by changed paths (#143)

### DIFF
--- a/tests/PrePush-IconEditorScope.Tests.ps1
+++ b/tests/PrePush-IconEditorScope.Tests.ps1
@@ -1,0 +1,32 @@
+Describe 'PrePush-IconEditorScope' {
+  BeforeAll {
+    $modulePath = Join-Path (Get-Location) 'tools' 'PrePush-IconEditorScope.psm1'
+    Import-Module $modulePath -Force
+  }
+
+  It 'requires fixture checks when icon-editor paths are changed' {
+    $changedPaths = @(
+      'tools/icon-editor/Update-IconEditorFixtureReport.ps1',
+      'README.md'
+    )
+
+    $shouldRun = Test-IconEditorFixtureCheckRequired -ChangedPaths $changedPaths
+    $shouldRun | Should -BeTrue
+  }
+
+  It 'skips fixture checks when no icon-editor scoped paths are changed' {
+    $changedPaths = @(
+      'tools/priority/sync-standing-priority.mjs',
+      'docs/INTEGRATION_RUNBOOK.md'
+    )
+
+    $shouldRun = Test-IconEditorFixtureCheckRequired -ChangedPaths $changedPaths
+    $shouldRun | Should -BeFalse
+  }
+
+  It 'allows explicit force override' {
+    $shouldRun = Test-IconEditorFixtureCheckRequired -ChangedPaths @() -Force
+    $shouldRun | Should -BeTrue
+  }
+}
+

--- a/tools/PrePush-Checks.ps1
+++ b/tools/PrePush-Checks.ps1
@@ -19,6 +19,7 @@ param(
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 Import-Module (Join-Path (Split-Path -Parent $PSCommandPath) 'VendorTools.psm1') -Force
+Import-Module (Join-Path (Split-Path -Parent $PSCommandPath) 'PrePush-IconEditorScope.psm1') -Force
 
 function Write-Info([string]$msg){ Write-Host $msg -ForegroundColor DarkGray }
 
@@ -133,6 +134,13 @@ if (Test-Path -LiteralPath $updateReportScript -PathType Leaf) {
   }
   if (-not $IsWindows) {
     Write-Host '[pre-push] Skipping icon-editor fixture freshness checks on non-Windows host' -ForegroundColor Yellow
+    return
+  }
+  $forceIconEditorChecks = ($env:PREPUSH_FORCE_ICON_EDITOR_FIXTURE_CHECKS -match '^(1|true|yes|on)$')
+  $changedPaths = Get-PrePushChangedPaths -RepoRoot $root
+  $shouldRunIconEditorChecks = Test-IconEditorFixtureCheckRequired -ChangedPaths $changedPaths -Force:$forceIconEditorChecks
+  if (-not $shouldRunIconEditorChecks) {
+    Write-Host '[pre-push] Skipping icon-editor fixture freshness checks (no icon-editor scoped paths changed)' -ForegroundColor Yellow
     return
   }
   Write-Host '[pre-push] Verifying icon-editor fixture report freshness' -ForegroundColor Cyan

--- a/tools/PrePush-IconEditorScope.psm1
+++ b/tools/PrePush-IconEditorScope.psm1
@@ -1,0 +1,80 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$script:IconEditorPathPrefixes = @(
+  '.github/actions/apply-vipc/',
+  'docs/icon_editor_package.md',
+  'fixtures/icon-editor-history/',
+  'tests/fixtures/icon-editor/',
+  'tools/icon-editor/',
+  'vendor/icon-editor/'
+)
+
+function Normalize-ChangedPath {
+  param([string]$Path)
+  if ([string]::IsNullOrWhiteSpace($Path)) {
+    return $null
+  }
+  return ($Path.Trim() -replace '\\', '/').ToLowerInvariant()
+}
+
+function Get-PrePushChangedPaths {
+  [CmdletBinding()]
+  param([Parameter(Mandatory = $true)][string]$RepoRoot)
+
+  $paths = New-Object System.Collections.Generic.List[string]
+
+  $upstreamResult = & git -C $RepoRoot rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>$null
+  if ($LASTEXITCODE -eq 0 -and $upstreamResult) {
+    $upstream = ($upstreamResult | Select-Object -First 1).Trim()
+    if ($upstream) {
+      $rangePaths = & git -C $RepoRoot diff --name-only --diff-filter=ACMRTUXB "$upstream...HEAD" 2>$null
+      if ($LASTEXITCODE -eq 0 -and $rangePaths) {
+        foreach ($candidate in $rangePaths) {
+          $normalized = Normalize-ChangedPath -Path $candidate
+          if ($normalized) { $paths.Add($normalized) }
+        }
+      }
+    }
+  }
+
+  $statusLines = & git -C $RepoRoot status --porcelain 2>$null
+  if ($LASTEXITCODE -eq 0 -and $statusLines) {
+    foreach ($line in $statusLines) {
+      $text = "$line"
+      if ($text.Length -lt 4) { continue }
+      $pathPart = $text.Substring(3).Trim()
+      if ($pathPart -match ' -> ') {
+        $pathPart = ($pathPart -split ' -> ')[-1]
+      }
+      $normalized = Normalize-ChangedPath -Path $pathPart
+      if ($normalized) { $paths.Add($normalized) }
+    }
+  }
+
+  $deduped = $paths | Sort-Object -Unique
+  return @($deduped)
+}
+
+function Test-IconEditorFixtureCheckRequired {
+  [CmdletBinding()]
+  param(
+    [string[]]$ChangedPaths = @(),
+    [switch]$Force
+  )
+
+  if ($Force) { return $true }
+  foreach ($path in $ChangedPaths) {
+    $normalized = Normalize-ChangedPath -Path $path
+    if (-not $normalized) { continue }
+    foreach ($prefix in $script:IconEditorPathPrefixes) {
+      if ($normalized.StartsWith($prefix)) {
+        return $true
+      }
+    }
+  }
+  return $false
+}
+
+Export-ModuleMember -Function Get-PrePushChangedPaths, Test-IconEditorFixtureCheckRequired
+


### PR DESCRIPTION
## Summary
- add `tools/PrePush-IconEditorScope.psm1` to compute changed-path scope and determine whether icon-editor fixture checks are required
- update `tools/PrePush-Checks.ps1` to run icon-editor fixture checks only when icon-editor scoped paths changed (or when `PREPUSH_FORCE_ICON_EDITOR_FIXTURE_CHECKS` is set)
- keep explicit skip behavior (`-SkipIconEditorFixtureChecks` / `PREPUSH_SKIP_ICON_EDITOR_FIXTURE_CHECKS=1`)
- add Pester tests for the new scope decision logic

## Issue
- Closes #143

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Path 'tests/PrePush-IconEditorScope.Tests.ps1' -CI"`
- `node tools/npm/run-script.mjs priority:test`