### PR TITLE
Prune stale icon-editor automation from Validate scope (#147)

### DIFF
--- a/.github/workflows/ci-composite.yml
+++ b/.github/workflows/ci-composite.yml
@@ -1,225 +1,30 @@
 name: CI Pipeline (Composite)
-# Legacy icon-editor pipeline retained for manual diagnostics only.
-# Active PR/push validation is owned by Validate + fixture drift workflows.
 
 permissions:
   contents: read
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 on:
-  workflow_dispatch: # manual trigger
+  workflow_dispatch:
 
 jobs:
-  # Detect if VIPC files changed to decide whether dependencies must be installed
-  changes:
-    name: Detect VIPC changes
+  legacy-compatibility-notice:
+    name: Legacy Compatibility Notice
     runs-on: ubuntu-latest
-    outputs:
-      vipc: ${{ steps.filter.outputs.vipc }}
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - id: filter
-        uses: dorny/paths-filter@v3
-        with:
-          filters: |
-            vipc:
-              - '**/*.vipc'
-
-  apply-deps:
-    name: Apply VIPC Dependencies
-    needs: changes
-    if: needs.changes.outputs.vipc == 'true'
-    runs-on: [self-hosted, Windows, X64]
-    strategy:
-      matrix:
-        include:
-          - lv-version: "2021"
-            bitness: "32"
-          - lv-version: "2021"
-            bitness: "64"
-          - lv-version: "2025"
-            bitness: "64"
-    steps:
-      - uses: ./.github/actions/apply-vipc
-        with:
-          minimum_supported_lv_version: ${{ matrix['lv-version'] }}
-          vip_lv_version:               ${{ matrix['lv-version'] }}
-          supported_bitness:            ${{ matrix.bitness }}
-          relative_path:                ${{ github.workspace }}
-
-  version:
-    name: Compute Version
-    runs-on: [self-hosted, Windows, X64]
-    outputs:
-      VERSION:       ${{ steps.compute.outputs.VERSION }}
-      MAJOR:         ${{ steps.compute.outputs.MAJOR }}
-      MINOR:         ${{ steps.compute.outputs.MINOR }}
-      PATCH:         ${{ steps.compute.outputs.PATCH }}
-      BUILD:         ${{ steps.compute.outputs.BUILD }}
-      IS_PRERELEASE: ${{ steps.compute.outputs.IS_PRERELEASE }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - id: compute
-        uses: ./.github/actions/compute-version
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-
-  missing-in-project-check:
-    name: Test Missing-In-Project Action on Windows
-    needs: [changes, apply-deps]
-    if: ${{ needs.changes.result == 'success' && (needs.apply-deps.result == 'success' || needs.apply-deps.result == 'skipped') }}
-    runs-on: [self-hosted, Windows, X64]
-    strategy:
-      fail-fast: false
-      matrix:
-        lv-version: ["2021"]
-        bitness:    ["64","32"]
-    steps:
-      - uses: ./.github/actions/missing-in-project
-        with:
-          lv-ver:       ${{ matrix.lv-version }}
-          arch:         ${{ matrix.bitness }}
-          project-file: "vendor/icon-editor/lv_icon_editor.lvproj"
-
-  test:
-    name: Run Unit Tests
-    needs: [changes, missing-in-project-check]
-    runs-on: [self-hosted, Windows, X64]
-    strategy:
-      matrix:
-        os: [windows]
-        lv-version: ["2021"]
-        bitness: ["64","32"]
-      fail-fast: false
-    steps:
-      - uses: ./.github/actions/run-unit-tests
-        with:
-          minimum_supported_lv_version: ${{ matrix['lv-version'] }}
-          supported_bitness:            ${{ matrix.bitness }}
-          project-file:                 vendor/icon-editor/lv_icon_editor.lvproj
-
-  build-ppl:
-    name: Build ${{ matrix.bitness }}-bit Packed Library
-    needs: [test, version]
-    runs-on: [self-hosted, Windows, X64]
-    permissions:
-      contents: read
-      actions: write
-    strategy:
-      matrix:
-        bitness: [32, 64]
-        include:
-          - bitness: 32
-            suffix: x86
-          - bitness: 64
-            suffix: x64
-    steps:
-      - uses: ./.github/actions/build-lvlibp
-        with:
-          minimum_supported_lv_version: 2021
-          supported_bitness: ${{ matrix.bitness }}
-          relative_path: ${{ github.workspace }}/vendor/icon-editor
-          major: ${{ needs.version.outputs.MAJOR }}
-          minor: ${{ needs.version.outputs.MINOR }}
-          patch: ${{ needs.version.outputs.PATCH }}
-          build: ${{ needs.version.outputs.BUILD }}
-          commit: ${{ github.sha }}
-      - uses: ./.github/actions/close-labview
-        with:
-          minimum_supported_lv_version: 2021
-          supported_bitness: ${{ matrix.bitness }}
-      - uses: ./.github/actions/rename-file
-        with:
-          current_filename: ${{ github.workspace }}/vendor/icon-editor/resource/plugins/lv_icon.lvlibp
-          new_filename: ${{ github.workspace }}/vendor/icon-editor/resource/plugins/lv_icon_${{ matrix.suffix }}.lvlibp
-      - uses: actions/upload-artifact@v4
-        with:
-          name: lv_icon_${{ matrix.suffix }}.lvlibp
-          path: vendor/icon-editor/resource/plugins/lv_icon_${{ matrix.suffix }}.lvlibp
-
-  build-vi-package:
-    name: Build VI Package
-    needs: [build-ppl, version]
-    runs-on: [self-hosted, Windows, X64]
-    permissions:
-      contents: read
-      actions: read
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Generate release notes
-        uses: ./.github/actions/generate-release-notes
-        # output_path defaults to Tooling/deployment/release_notes.md
-      - uses: actions/download-artifact@v4
-        with:
-          path: resource/plugins
-          pattern: lv_icon_*.lvlibp
-          merge-multiple: true
-      - name: Generate display information JSON
-        id: display-info
-        shell: pwsh
+      - name: Emit deprecation notice
+        shell: bash
         run: |
-          $info = @{
-            "Package Version" = @{
-              "major" = ${{ needs.version.outputs.MAJOR }}
-              "minor" = ${{ needs.version.outputs.MINOR }}
-              "patch" = ${{ needs.version.outputs.PATCH }}
-              "build" = ${{ needs.version.outputs.BUILD }}
-            }
-            "Product Name" = ""
-            "Company Name" = "${{ github.repository_owner }}"
-            "Author Name (Person or Company)" = "${{ github.event.repository.name }}"
-            "Product Homepage (URL)" = ""
-            "Legal Copyright" = ""
-            "License Agreement Name" = ""
-            "Product Description Summary" = ""
-            "Product Description" = ""
-            "Release Notes - Change Log" = ""
-          }
-          $json = $info | ConvertTo-Json -Depth 5 -Compress
-          "json=$json" >> $Env:GITHUB_OUTPUT
-      - uses: ./.github/actions/modify-vipb-display-info
-        with:
-          supported_bitness: 64
-          relative_path: ${{ github.workspace }}
-          vipb_path: .github/actions/build-vi-package/NI Icon editor.vipb
-          minimum_supported_lv_version: 2025
-          labview_minor_revision: 3
-          major: ${{ needs.version.outputs.MAJOR }}
-          minor: ${{ needs.version.outputs.MINOR }}
-          patch: ${{ needs.version.outputs.PATCH }}
-          build: ${{ needs.version.outputs.BUILD }}
-          commit: ${{ github.sha }}
-          release_notes_file: ${{ github.workspace }}/Tooling/deployment/release_notes.md
-          display_information_json: ${{ steps.display-info.outputs.json }}
-      - uses: ./.github/actions/build-vi-package
-        with:
-          supported_bitness: 64
-          minimum_supported_lv_version: 2025
-          labview_minor_revision: 3
-          major: ${{ needs.version.outputs.MAJOR }}
-          minor: ${{ needs.version.outputs.MINOR }}
-          patch: ${{ needs.version.outputs.PATCH }}
-          build: ${{ needs.version.outputs.BUILD }}
-          commit: ${{ github.sha }}
-          release_notes_file: ${{ github.workspace }}/Tooling/deployment/release_notes.md
-          display_information_json: ${{ steps.display-info.outputs.json }}
-      - uses: ./.github/actions/close-labview
-        with:
-          minimum_supported_lv_version: 2025
-          supported_bitness: 64
-      - name: Upload VI Package
-        uses: actions/upload-artifact@v4
-        with:
-          name: vi-package
-          path: builds/VI Package/*.vip
+          echo "::notice::ci-composite.yml is a manual compatibility stub."
+          echo "::notice::Use Validate + Fixture Drift Validation for active CI gates."
 
-
+      - name: Append summary
+        shell: bash
+        run: |
+          {
+            echo "### CI Pipeline (Composite) Status"
+            echo ""
+            echo "- This workflow is intentionally reduced to a manual compatibility stub."
+            echo "- Active branch-protection and standing-priority validation runs in:"
+            echo "  - \`Validate\`"
+            echo "  - \`Fixture Drift Validation\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -140,7 +140,7 @@ jobs:
     - name: PrePush local gates (includes watcher schema validation)
       shell: pwsh
       env:
-        PREPUSH_SKIP_ICON_EDITOR_FIXTURE_CHECKS: '1'
+        PREPUSH_SKIP_LEGACY_FIXTURE_CHECKS: '1'
       run: |
         pwsh -File tools/PrePush-Checks.ps1
 
@@ -226,8 +226,8 @@ jobs:
           Where-Object {
             $path = $_.FullName -replace '\\','/'
             return $path -notmatch '/node_modules/' `
-              -and $path -notmatch '/vendor/icon-editor/' `
-              -and $path -notmatch '/tmp/icon-editor/'
+              -and $path -notmatch '/vendor/' `
+              -and $path -notmatch '/tmp/'
           }
         $errors = @()
         foreach ($file in $mdFiles) {
@@ -479,7 +479,7 @@ jobs:
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     env:
-      PREPUSH_SKIP_ICON_EDITOR_FIXTURE_CHECKS: '1'
+      PREPUSH_SKIP_LEGACY_FIXTURE_CHECKS: '1'
     steps:
     - uses: actions/checkout@v5
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,9 +22,10 @@ line buffers).
   - Operate inside this repository unless the human asks otherwise.
   - Keep workflows deterministic and green.
   - Reference the current standing-priority issue (e.g., `#<standing-number>`) in commit and PR descriptions.
-  - Treat icon-editor CI/package automation as legacy/manual-only. Do not expand
-    `ci-composite.yml` or icon-editor fixture freshness checks into required PR
-    gates unless a standing-priority issue explicitly re-enables that scope.
+  - Treat icon-editor CI/package automation as legacy/manual-only.
+    `ci-composite.yml` is now a manual compatibility stub; do not reintroduce
+    icon-editor fixture freshness checks into required PR gates unless a
+    standing-priority issue explicitly re-enables that scope.
 - First actions in a session:
   1. `pwsh -NoLogo -NoProfile -File tools/priority/bootstrap.ps1` to run hook preflight, refresh the standing-priority
      snapshot/router artifacts, and auto-anchor the workspace to `develop`. When PowerShell + Node aren't available on
@@ -343,4 +344,3 @@ Guidance:
 - For markdownlint, try `Resolve-MarkdownlintCli2Path`; only fall back to `npx --no-install` when necessary.
 - For LVCompare, continue to enforce the canonical path; pass `-lvpath` to LVCompare and never launch `LabVIEW.exe`.
 - Do not lint or link-check vendor documentation under `bin/`; scope link checks to `docs/` or ignore `bin/**`.
-

--- a/docs/ICON_EDITOR_PACKAGE.md
+++ b/docs/ICON_EDITOR_PACKAGE.md
@@ -378,8 +378,9 @@ carries the actual LabVIEW payload.
 
 ## Local replay for CI build failures
 
-When the `Build VI Package` job fails late in `ci-composite.yml`, you can replay that
-stage locally without re-running the whole pipeline:
+When a historical `Build VI Package` job fails in the legacy
+`ci-composite.yml` workflow, you can replay that stage locally without
+re-running the full legacy pipeline:
 
 ```powershell
 pwsh tools/icon-editor/Replay-BuildVipJob.ps1 -RunId <workflow-run-id>

--- a/tools/PrePush-Checks.ps1
+++ b/tools/PrePush-Checks.ps1
@@ -128,12 +128,15 @@ Write-Host '[pre-push] actionlint OK' -ForegroundColor Green
 
 $updateReportScript = Join-Path $root 'tools' 'icon-editor' 'Update-IconEditorFixtureReport.ps1'
 if (Test-Path -LiteralPath $updateReportScript -PathType Leaf) {
-  if ($SkipIconEditorFixtureChecks -or ($env:PREPUSH_SKIP_ICON_EDITOR_FIXTURE_CHECKS -eq '1')) {
-    Write-Host '[pre-push] Skipping icon-editor fixture freshness checks by request' -ForegroundColor Yellow
+  $skipLegacyFixtureChecks = $SkipIconEditorFixtureChecks `
+    -or ($env:PREPUSH_SKIP_ICON_EDITOR_FIXTURE_CHECKS -match '^(1|true|yes|on)$') `
+    -or ($env:PREPUSH_SKIP_LEGACY_FIXTURE_CHECKS -match '^(1|true|yes|on)$')
+  if ($skipLegacyFixtureChecks) {
+    Write-Host '[pre-push] Skipping legacy fixture freshness checks by request' -ForegroundColor Yellow
     return
   }
   if (-not $IsWindows) {
-    Write-Host '[pre-push] Skipping icon-editor fixture freshness checks on non-Windows host' -ForegroundColor Yellow
+    Write-Host '[pre-push] Skipping legacy fixture freshness checks on non-Windows host' -ForegroundColor Yellow
     return
   }
   $refUpdateLines = @()
@@ -145,7 +148,8 @@ if (Test-Path -LiteralPath $updateReportScript -PathType Leaf) {
       }
     }
   } catch {}
-  $forceIconEditorChecks = ($env:PREPUSH_FORCE_ICON_EDITOR_FIXTURE_CHECKS -match '^(1|true|yes|on)$')
+  $forceIconEditorChecks = ($env:PREPUSH_FORCE_ICON_EDITOR_FIXTURE_CHECKS -match '^(1|true|yes|on)$') `
+    -or ($env:PREPUSH_FORCE_LEGACY_FIXTURE_CHECKS -match '^(1|true|yes|on)$')
   $changedPaths = Get-PrePushChangedPaths -RepoRoot $root -RefUpdateLines $refUpdateLines
   $shouldRunIconEditorChecks = Test-IconEditorFixtureCheckRequired -ChangedPaths $changedPaths -Force:$forceIconEditorChecks
   if (-not $shouldRunIconEditorChecks) {


### PR DESCRIPTION
## Summary
- reduce `.github/workflows/ci-composite.yml` to a manual compatibility stub (remove legacy icon-editor execution graph)
- update `Validate` pre-push env wiring to use legacy-neutral skip toggles
- remove icon-editor-specific markdown link-check path assumptions in `Validate`
- support additive legacy-neutral skip/force env aliases in `tools/PrePush-Checks.ps1`

## Testing
- `pwsh -NoLogo -NoProfile -File tools/PrePush-Checks.ps1 -SkipIconEditorFixtureChecks`
- `node tools/npm/run-script.mjs lint:md:changed`

Closes #147
