### PR TITLE
Fix hook-parity windows by exporting both pre-push fixture skip env vars (#152)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -150,6 +150,7 @@ jobs:
     - name: PrePush local gates (includes watcher schema validation)
       shell: pwsh
       env:
+        PREPUSH_SKIP_ICON_EDITOR_FIXTURE_CHECKS: '1'
         PREPUSH_SKIP_LEGACY_FIXTURE_CHECKS: '1'
       run: |
         pwsh -File tools/PrePush-Checks.ps1
@@ -489,6 +490,7 @@ jobs:
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     env:
+      PREPUSH_SKIP_ICON_EDITOR_FIXTURE_CHECKS: '1'
       PREPUSH_SKIP_LEGACY_FIXTURE_CHECKS: '1'
     steps:
     - uses: actions/checkout@v5


### PR DESCRIPTION
## Summary
- fix hook-parity Windows hosted failure by exporting both pre-push fixture skip env vars in `validate.yml`
- preserve existing behavior while making parity compatible with repos that still read the legacy icon-editor skip variable name

## Change
- in `lint` and `hook-parity` jobs, set both:
  - `PREPUSH_SKIP_ICON_EDITOR_FIXTURE_CHECKS=1`
  - `PREPUSH_SKIP_LEGACY_FIXTURE_CHECKS=1`

## Why
`hook-parity (windows-latest)` was failing because pre-push checks executed icon-editor fixture freshness in some branches where only the legacy env var name was honored. This produced deterministic hook summary divergence and failed the parity gate.

## Validation
- Dispatch run (branch): https://github.com/svelderrainruiz/compare-vi-cli-action/actions/runs/22633449392
  - `hook-parity (windows-latest)`: success
  - `hook-parity (ubuntu-latest)`: success
  - overall Validate: success

Refs: #152
