### PR TITLE
Add deterministic origin/upstream parity reporter for standing-priority hygiene

### DIFF
--- a/.github/workflows/standing-priority-hygiene.yml
+++ b/.github/workflows/standing-priority-hygiene.yml
@@ -24,6 +24,22 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      - name: Fetch parity refs
+        shell: bash
+        run: |
+          git remote add upstream https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action.git 2>/dev/null || true
+          git fetch --no-tags --prune --depth=1 origin develop
+          git fetch --no-tags --prune --depth=1 upstream develop
+
+      - name: Report origin/upstream parity
+        run: |
+          node tools/priority/report-origin-upstream-parity.mjs \
+            --base-ref "upstream/develop" \
+            --head-ref "origin/develop" \
+            --sample-limit 20 \
+            --github-output "$GITHUB_OUTPUT" \
+            --step-summary "$GITHUB_STEP_SUMMARY"
+
       - name: Resolve issue number
         id: issue
         shell: bash
@@ -41,4 +57,3 @@ jobs:
           node tools/priority/standing-priority-hygiene.mjs \
             --issue "${{ steps.issue.outputs.number }}" \
             --label "standing-priority"
-

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,9 @@ line buffers).
      the working tree is on `develop` before creating a feature branch.
   2. Review `.agent_priority_cache.json` / `tests/results/_agent/issue/` for tasks, acceptance, and
      linked PRs on the standing issue.
-  3. Create or sync a working branch (`issue/<standing-number>-<slug>`), push minimal changes,
+  3. Run `node tools/priority/report-origin-upstream-parity.mjs --base-ref upstream/develop --head-ref origin/develop`
+     and use `tipDiff.fileCount` as the primary origin/upstream alignment KPI (`0` means branch-tip content parity).
+  4. Create or sync a working branch (`issue/<standing-number>-<slug>`), push minimal changes,
      dispatch CI, update the PR (reference `#<standing-number>`), monitor to green, merge when
      acceptance is met.
 

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -266,6 +266,9 @@ For Docker/Desktop VI history validation, run fast-loop lanes explicitly:
   - `release-<tag>-finalize.json` records the fast-forward results and the GitHub release draft.
 - `priority:sync` surfaces the most recent artifact in the standing-priority step summary and exposes it to downstream
   automation via `snapshot.releaseArtifacts`.
+- `priority:parity` reports origin/upstream parity using two metrics:
+  - `tipDiff.fileCount` from `git diff --name-only upstream/develop origin/develop` (primary KPI; `0` means tip parity)
+  - commit divergence from `git rev-list --left-right --count upstream/develop...origin/develop` (telemetry only)
 - The release router now suggests `npm run release:finalize -- <version>` automatically when the latest branch artifact
   lacks a matching finalize record.
 
@@ -391,4 +394,3 @@ pwsh -File scripts/CompareVI.ps1 `
   `-KeepBranch` preserves the branch/PR after the staging and history dispatches complete for manual inspection.
 - When testing fork scenarios locally, use the composite `.github/actions/fetch-pr-head` action to simulate
   `pull/<id>/head` checkouts before invoking the staging or history helpers.
-

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "priority:handoff-tests": "node tools/priority/run-handoff-tests.mjs",
     "priority:merge-sync": "node tools/priority/merge-sync-pr.mjs",
     "priority:policy": "node tools/priority/check-policy.mjs",
+    "priority:parity": "node tools/priority/report-origin-upstream-parity.mjs",
     "priority:pr": "node tools/priority/create-pr.mjs",
     "priority:release": "pwsh -NoLogo -NoProfile -File tools/priority/Simulate-Release.ps1",
     "priority:schema": "npm run schema:validate -- --schema docs/schemas/standing-priority-issue-v1.schema.json --data tests/results/_agent/issue/[0-9]*.json --optional",

--- a/tools/priority/__tests__/report-origin-upstream-parity.test.mjs
+++ b/tools/priority/__tests__/report-origin-upstream-parity.test.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  collectParity,
+  parseCliArgs,
+  parseFileList,
+  parseRevListCounts,
+  renderSummaryMarkdown
+} from '../report-origin-upstream-parity.mjs';
+
+test('parseRevListCounts parses left/right counters', () => {
+  assert.deepEqual(parseRevListCounts('3\t12\n'), { baseOnly: 3, headOnly: 12 });
+  assert.deepEqual(parseRevListCounts('0 0'), { baseOnly: 0, headOnly: 0 });
+});
+
+test('parseRevListCounts rejects invalid payloads', () => {
+  assert.throws(() => parseRevListCounts(''), /Invalid rev-list count output/);
+  assert.throws(() => parseRevListCounts('abc\t2'), /Invalid rev-list count output/);
+});
+
+test('parseFileList removes blanks and trims entries', () => {
+  assert.deepEqual(parseFileList('\n a.txt \r\n\r\nb.txt\n'), ['a.txt', 'b.txt']);
+});
+
+test('parseCliArgs accepts parity options', () => {
+  const parsed = parseCliArgs([
+    '--base-ref',
+    'upstream/develop',
+    '--head-ref',
+    'origin/develop',
+    '--sample-limit',
+    '5',
+    '--strict'
+  ]);
+  assert.equal(parsed.baseRef, 'upstream/develop');
+  assert.equal(parsed.headRef, 'origin/develop');
+  assert.equal(parsed.sampleLimit, 5);
+  assert.equal(parsed.strict, true);
+});
+
+test('collectParity returns ok payload when git commands succeed', () => {
+  const calls = [];
+  const fakeRunner = (_cmd, args) => {
+    calls.push(args.join(' '));
+    if (args[0] === 'rev-list') {
+      return { status: 0, stdout: '2\t5\n', stderr: '' };
+    }
+    if (args[0] === 'diff') {
+      return { status: 0, stdout: 'a.ps1\nb.ps1\n', stderr: '' };
+    }
+    return { status: 1, stdout: '', stderr: 'unexpected command' };
+  };
+
+  const report = collectParity(
+    {
+      baseRef: 'upstream/develop',
+      headRef: 'origin/develop',
+      sampleLimit: 1
+    },
+    fakeRunner
+  );
+
+  assert.equal(report.status, 'ok');
+  assert.equal(report.tipDiff.fileCount, 2);
+  assert.deepEqual(report.tipDiff.sample, ['a.ps1']);
+  assert.deepEqual(report.commitDivergence, { baseOnly: 2, headOnly: 5 });
+  assert.equal(calls.length, 2);
+});
+
+test('collectParity returns unavailable payload when refs are missing (non-strict)', () => {
+  const fakeRunner = (_cmd, args) => {
+    if (args[0] === 'rev-list') {
+      return {
+        status: 128,
+        stdout: '',
+        stderr: 'fatal: ambiguous argument upstream/develop...origin/develop'
+      };
+    }
+    return { status: 0, stdout: '', stderr: '' };
+  };
+
+  const report = collectParity(
+    {
+      baseRef: 'upstream/develop',
+      headRef: 'origin/develop'
+    },
+    fakeRunner
+  );
+
+  assert.equal(report.status, 'unavailable');
+  assert.match(report.reason, /git rev-list --left-right --count/);
+});
+
+test('collectParity throws in strict mode when git fails', () => {
+  const fakeRunner = () => ({ status: 1, stdout: '', stderr: 'boom' });
+  assert.throws(
+    () =>
+      collectParity(
+        {
+          baseRef: 'upstream/develop',
+          headRef: 'origin/develop',
+          strict: true
+        },
+        fakeRunner
+      ),
+    /git rev-list --left-right --count/
+  );
+});
+
+test('renderSummaryMarkdown includes parity metrics for ok status', () => {
+  const markdown = renderSummaryMarkdown({
+    status: 'ok',
+    baseRef: 'upstream/develop',
+    headRef: 'origin/develop',
+    tipDiff: { fileCount: 3, sample: ['a.txt'], sampleLimit: 20 },
+    commitDivergence: { baseOnly: 1, headOnly: 4 }
+  });
+  assert.match(markdown, /Tip Diff File Count \| 3/);
+  assert.match(markdown, /Commit Divergence \(base-only\/head-only\) \| 1\/4/);
+  assert.match(markdown, /`a.txt`/);
+});
+

--- a/tools/priority/report-origin-upstream-parity.mjs
+++ b/tools/priority/report-origin-upstream-parity.mjs
@@ -1,0 +1,301 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+function sh(cmd, args, opts = {}) {
+  return spawnSync(cmd, args, { encoding: 'utf8', shell: false, ...opts });
+}
+
+function ensureCommand(result, cmd) {
+  if (result?.error?.code === 'ENOENT') {
+    const err = new Error(`Command not found: ${cmd}`);
+    err.code = 'ENOENT';
+    throw err;
+  }
+  return result;
+}
+
+function trimText(value) {
+  return String(value ?? '').trim();
+}
+
+function makeErrorMessage(args, result) {
+  const details = trimText(result?.stderr) || trimText(result?.stdout) || 'unknown error';
+  return `git ${args.join(' ')} failed: ${details}`;
+}
+
+function runGit(args, runner = sh) {
+  const result = ensureCommand(runner('git', args), 'git');
+  if (result.status !== 0) {
+    const err = new Error(makeErrorMessage(args, result));
+    err.status = result.status;
+    err.stderr = result.stderr;
+    err.stdout = result.stdout;
+    err.args = args;
+    throw err;
+  }
+  return result.stdout || '';
+}
+
+export function parseRevListCounts(stdout) {
+  const text = trimText(stdout);
+  const parts = text.split(/\s+/).filter(Boolean);
+  if (parts.length < 2) {
+    throw new Error(`Invalid rev-list count output: ${text || '(empty)'}`);
+  }
+
+  const baseOnly = Number(parts[0]);
+  const headOnly = Number(parts[1]);
+  if (!Number.isInteger(baseOnly) || !Number.isInteger(headOnly)) {
+    throw new Error(`Invalid rev-list count output: ${text || '(empty)'}`);
+  }
+
+  return { baseOnly, headOnly };
+}
+
+export function parseFileList(stdout) {
+  return String(stdout || '')
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function toPositiveInt(value, fallback) {
+  if (value == null || value === '') return fallback;
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`Invalid non-negative integer: ${value}`);
+  }
+  return parsed;
+}
+
+export function parseCliArgs(argv = process.argv.slice(2)) {
+  const args = Array.from(argv || []);
+  const options = {
+    baseRef: 'upstream/develop',
+    headRef: 'origin/develop',
+    sampleLimit: 20,
+    outputPath: null,
+    githubOutputPath: null,
+    stepSummaryPath: null,
+    strict: false
+  };
+
+  for (let i = 0; i < args.length; i += 1) {
+    const token = args[i];
+    if (token === '--base-ref') {
+      const value = args[++i];
+      if (!value) throw new Error('Missing value for --base-ref');
+      options.baseRef = value;
+      continue;
+    }
+    if (token === '--head-ref') {
+      const value = args[++i];
+      if (!value) throw new Error('Missing value for --head-ref');
+      options.headRef = value;
+      continue;
+    }
+    if (token === '--sample-limit') {
+      const value = args[++i];
+      if (value == null) throw new Error('Missing value for --sample-limit');
+      options.sampleLimit = toPositiveInt(value, 20);
+      continue;
+    }
+    if (token === '--output-path') {
+      const value = args[++i];
+      if (!value) throw new Error('Missing value for --output-path');
+      options.outputPath = value;
+      continue;
+    }
+    if (token === '--github-output') {
+      const value = args[++i];
+      if (!value) throw new Error('Missing value for --github-output');
+      options.githubOutputPath = value;
+      continue;
+    }
+    if (token === '--step-summary') {
+      const value = args[++i];
+      if (!value) throw new Error('Missing value for --step-summary');
+      options.stepSummaryPath = value;
+      continue;
+    }
+    if (token === '--strict') {
+      options.strict = true;
+      continue;
+    }
+    if (token === '--help' || token === '-h') {
+      options.help = true;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${token}`);
+  }
+
+  return options;
+}
+
+export function collectParity(options = {}, runner = sh) {
+  const baseRef = options.baseRef || 'upstream/develop';
+  const headRef = options.headRef || 'origin/develop';
+  const sampleLimit = toPositiveInt(options.sampleLimit, 20);
+  const strict = Boolean(options.strict);
+  const now = new Date().toISOString();
+
+  try {
+    const countsText = runGit(['rev-list', '--left-right', '--count', `${baseRef}...${headRef}`], runner);
+    const counts = parseRevListCounts(countsText);
+    const filesText = runGit(['diff', '--name-only', baseRef, headRef], runner);
+    const files = parseFileList(filesText);
+    const sample = sampleLimit > 0 ? files.slice(0, sampleLimit) : [];
+
+    return {
+      schema: 'origin-upstream-parity@v1',
+      status: 'ok',
+      generatedAt: now,
+      baseRef,
+      headRef,
+      tipDiff: {
+        fileCount: files.length,
+        sampleLimit,
+        sample
+      },
+      commitDivergence: {
+        baseOnly: counts.baseOnly,
+        headOnly: counts.headOnly
+      }
+    };
+  } catch (err) {
+    if (strict) throw err;
+    return {
+      schema: 'origin-upstream-parity@v1',
+      status: 'unavailable',
+      generatedAt: now,
+      baseRef,
+      headRef,
+      reason: err.message
+    };
+  }
+}
+
+function writeJson(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(value, null, 2) + '\n', 'utf8');
+}
+
+function appendGitHubOutput(filePath, name, value) {
+  if (!filePath) return;
+  fs.appendFileSync(filePath, `${name}=${String(value ?? '')}\n`, 'utf8');
+}
+
+export function renderSummaryMarkdown(report) {
+  if (!report || report.status !== 'ok') {
+    return [
+      '### Origin/Upstream Parity',
+      '',
+      '| Metric | Value |',
+      '| --- | --- |',
+      `| Status | unavailable |`,
+      `| Base Ref | ${report?.baseRef || '(none)'} |`,
+      `| Head Ref | ${report?.headRef || '(none)'} |`,
+      `| Reason | ${report?.reason || 'unknown'} |`,
+      ''
+    ].join('\n');
+  }
+
+  const lines = [
+    '### Origin/Upstream Parity',
+    '',
+    '| Metric | Value |',
+    '| --- | --- |',
+    `| Status | ok |`,
+    `| Base Ref | ${report.baseRef} |`,
+    `| Head Ref | ${report.headRef} |`,
+    `| Tip Diff File Count | ${report.tipDiff.fileCount} |`,
+    `| Commit Divergence (base-only/head-only) | ${report.commitDivergence.baseOnly}/${report.commitDivergence.headOnly} |`
+  ];
+
+  if (Array.isArray(report.tipDiff.sample) && report.tipDiff.sample.length > 0) {
+    lines.push('', 'Tip-diff sample:');
+    for (const file of report.tipDiff.sample) {
+      lines.push(`- \`${file}\``);
+    }
+  }
+
+  lines.push('');
+  return lines.join('\n');
+}
+
+function printHelp() {
+  console.log(`Usage:
+  node tools/priority/report-origin-upstream-parity.mjs [options]
+
+Options:
+  --base-ref <ref>          Base ref (default: upstream/develop)
+  --head-ref <ref>          Head ref (default: origin/develop)
+  --sample-limit <n>        Max sample files in output (default: 20)
+  --output-path <file>      JSON output file path
+  --github-output <file>    Append GitHub output variables
+  --step-summary <file>     Append markdown summary
+  --strict                  Fail on git/ref errors instead of reporting unavailable
+  --help, -h                Show help`);
+}
+
+async function main() {
+  const options = parseCliArgs(process.argv.slice(2));
+  if (options.help) {
+    printHelp();
+    process.exitCode = 0;
+    return;
+  }
+
+  const outputPath =
+    options.outputPath ||
+    path.join(process.cwd(), 'tests', 'results', '_agent', 'issue', 'origin-upstream-parity.json');
+  const report = collectParity(options);
+  writeJson(outputPath, report);
+
+  appendGitHubOutput(options.githubOutputPath, 'parity_status', report.status);
+  appendGitHubOutput(
+    options.githubOutputPath,
+    'parity_tip_diff_count',
+    report.status === 'ok' ? report.tipDiff.fileCount : ''
+  );
+  appendGitHubOutput(
+    options.githubOutputPath,
+    'parity_base_only_commits',
+    report.status === 'ok' ? report.commitDivergence.baseOnly : ''
+  );
+  appendGitHubOutput(
+    options.githubOutputPath,
+    'parity_head_only_commits',
+    report.status === 'ok' ? report.commitDivergence.headOnly : ''
+  );
+  appendGitHubOutput(options.githubOutputPath, 'parity_report_path', outputPath);
+
+  if (options.stepSummaryPath) {
+    const summary = renderSummaryMarkdown(report);
+    fs.appendFileSync(options.stepSummaryPath, `${summary}\n`, 'utf8');
+  }
+
+  console.log(`[parity] status=${report.status} base=${report.baseRef} head=${report.headRef}`);
+  if (report.status === 'ok') {
+    console.log(
+      `[parity] tipDiff=${report.tipDiff.fileCount} commits=${report.commitDivergence.baseOnly}/${report.commitDivergence.headOnly}`
+    );
+  } else {
+    console.log(`[parity] reason=${report.reason}`);
+  }
+  console.log(`[parity] report=${outputPath}`);
+}
+
+const modulePath = path.resolve(fileURLToPath(import.meta.url));
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : null;
+if (invokedPath && invokedPath === modulePath) {
+  main().catch((err) => {
+    console.error(`[parity] ${err.message}`);
+    process.exitCode = 1;
+  });
+}
+


### PR DESCRIPTION
## Summary
- add `tools/priority/report-origin-upstream-parity.mjs` to emit a deterministic parity envelope
- add `tools/priority/__tests__/report-origin-upstream-parity.test.mjs`
- wire parity reporting into `.github/workflows/standing-priority-hygiene.yml`
- expose npm entrypoint `priority:parity`
- document `tipDiff.fileCount` as the primary alignment KPI in `AGENTS.md`

## Contract
Reporter schema output:
- `schema: origin-upstream-parity@v1`
- `status: ok | unavailable`
- `baseRef`, `headRef`
- `tipDiff.fileCount`, `tipDiff.sample[]`
- `commitDivergence.baseOnly/headOnly`

## Validation
- `node --test tools/priority/__tests__/report-origin-upstream-parity.test.mjs`
- `node tools/npm/run-script.mjs priority:test`
- `pwsh -NoLogo -NoProfile -File tools/PrePush-Checks.ps1 -SkipIconEditorFixtureChecks`
- `node tools/priority/report-origin-upstream-parity.mjs --base-ref upstream/develop --head-ref origin/develop --sample-limit 5`

Refs #159.