### PR TITLE
fix(#149): remove self-hosted dual-lane churn from Validate

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -866,7 +866,7 @@ jobs:
     defaults:
       run:
         shell: pwsh
-    timeout-minutes: 10
+    timeout-minutes: 1
     steps:
       - uses: actions/checkout@v5
 


### PR DESCRIPTION
## Summary
- stop unconditional `-SwitchWindowsEngine` in the self-hosted Windows VI history lane bootstrap
- reduce Windows lane timeout and preflight engine-ready timeout for faster failure
- run self-hosted Docker fast-loop as explicit Windows-only lane (Linux remains hosted)

## Why
- avoids unnecessary engine churn on shared self-hosted Docker Desktop hosts
- reduces perceived deadlock/stall behavior from redundant engine switching
- aligns with policy that Linux coverage is hosted (`ubuntu-latest`) rather than self-hosted Docker Desktop

## Validation
- `pwsh -NoLogo -NoProfile -File tools/PrePush-Checks.ps1`
- `pwsh -NoLogo -NoProfile -File .\\Invoke-PesterTests.ps1 -TestsPath tests -IncludePatterns ''Assert-DockerRuntimeDeterminism.Tests.ps1''`
- `pwsh -NoLogo -NoProfile -File .\\Invoke-PesterTests.ps1 -TestsPath tests -IncludePatterns ''Test-DockerDesktopFastLoop.Tests.ps1''`

Closes #149
