### PR TITLE
feat(#165): add deterministic dual-remote parity contract

### DIFF
--- a/tests/Update-SessionIndexParity.Tests.ps1
+++ b/tests/Update-SessionIndexParity.Tests.ps1
@@ -34,6 +34,18 @@ Describe 'Update-SessionIndexParity.ps1' -Tag 'Unit' {
       tipDiff = [ordered]@{
         fileCount = 0
       }
+      treeParity = [ordered]@{
+        equal = $true
+        status = 'equal'
+      }
+      historyParity = [ordered]@{
+        equal = $false
+        status = 'diverged'
+      }
+      recommendation = [ordered]@{
+        code = 'history-diverged-tree-equal'
+        summary = 'Tree aligned, history diverged.'
+      }
       commitDivergence = [ordered]@{
         baseOnly = 33
         headOnly = 126
@@ -54,14 +66,20 @@ Describe 'Update-SessionIndexParity.ps1' -Tag 'Unit' {
     $updated = Get-Content -LiteralPath $sessionIndexPath -Raw | ConvertFrom-Json -Depth 30
     $updated.runContext.parity.status | Should -Be 'ok'
     $updated.runContext.parity.tipDiff.fileCount | Should -Be 0
+    $updated.runContext.parity.treeParity.status | Should -Be 'equal'
+    $updated.runContext.parity.historyParity.status | Should -Be 'diverged'
+    $updated.runContext.parity.recommendation.code | Should -Be 'history-diverged-tree-equal'
     $updated.runContext.parity.commitDivergence.baseOnly | Should -Be 33
     $updated.runContext.parity.commitDivergence.headOnly | Should -Be 126
     $updated.runContext.parity.reportPath | Should -Be $parityPath
 
     $summary = Get-Content -LiteralPath $summaryPath -Raw
     $summary | Should -Match 'Origin/Upstream Parity Telemetry'
+    $summary | Should -Match 'Tree Parity \| equal'
+    $summary | Should -Match 'History Parity \| diverged'
     $summary | Should -Match 'Tip Diff File Count \| 0'
     $summary | Should -Match 'Commit Divergence \(base-only/head-only\) \| 33/126'
+    $summary | Should -Match 'Recommendation \| history-diverged-tree-equal'
   }
 
   It 'writes unavailable parity telemetry when report is missing' {
@@ -91,4 +109,3 @@ Describe 'Update-SessionIndexParity.ps1' -Tag 'Unit' {
     } | Should -Not -Throw
   }
 }
-

--- a/tools/Update-SessionIndexParity.ps1
+++ b/tools/Update-SessionIndexParity.ps1
@@ -39,6 +39,18 @@ function New-UnavailableParityPayload {
     tipDiff     = [ordered]@{
       fileCount = $null
     }
+    treeParity = [ordered]@{
+      equal = $null
+      status = 'unknown'
+    }
+    historyParity = [ordered]@{
+      equal = $null
+      status = 'unknown'
+    }
+    recommendation = [ordered]@{
+      code = ''
+      summary = ''
+    }
     commitDivergence = [ordered]@{
       baseOnly = $null
       headOnly = $null
@@ -77,6 +89,38 @@ function Convert-ToParityTelemetry {
   $tipDiff = Get-ChildValue -Object $ParityReport -Name 'tipDiff'
   if ($null -ne $tipDiff) { $tipDiffCount = Get-ChildValue -Object $tipDiff -Name 'fileCount' }
 
+  $treeParity = Get-ChildValue -Object $ParityReport -Name 'treeParity'
+  $treeParityEqual = $null
+  $treeParityStatus = 'unknown'
+  if ($null -ne $treeParity) {
+    $treeParityEqual = Get-ChildValue -Object $treeParity -Name 'equal'
+    $candidate = Get-ChildValue -Object $treeParity -Name 'status'
+    if ($null -ne $candidate -and -not [string]::IsNullOrWhiteSpace([string]$candidate)) {
+      $treeParityStatus = [string]$candidate
+    }
+  }
+
+  $historyParity = Get-ChildValue -Object $ParityReport -Name 'historyParity'
+  $historyParityEqual = $null
+  $historyParityStatus = 'unknown'
+  if ($null -ne $historyParity) {
+    $historyParityEqual = Get-ChildValue -Object $historyParity -Name 'equal'
+    $candidate = Get-ChildValue -Object $historyParity -Name 'status'
+    if ($null -ne $candidate -and -not [string]::IsNullOrWhiteSpace([string]$candidate)) {
+      $historyParityStatus = [string]$candidate
+    }
+  }
+
+  $recommendationNode = Get-ChildValue -Object $ParityReport -Name 'recommendation'
+  $recommendationCode = ''
+  $recommendationSummary = ''
+  if ($null -ne $recommendationNode) {
+    $candidate = Get-ChildValue -Object $recommendationNode -Name 'code'
+    if ($null -ne $candidate) { $recommendationCode = [string]$candidate }
+    $candidate = Get-ChildValue -Object $recommendationNode -Name 'summary'
+    if ($null -ne $candidate) { $recommendationSummary = [string]$candidate }
+  }
+
   $baseOnly = $null
   $headOnly = $null
   $commitDivergence = Get-ChildValue -Object $ParityReport -Name 'commitDivergence'
@@ -96,6 +140,18 @@ function Convert-ToParityTelemetry {
     tipDiff     = [ordered]@{
       fileCount = $tipDiffCount
     }
+    treeParity = [ordered]@{
+      equal = $treeParityEqual
+      status = $treeParityStatus
+    }
+    historyParity = [ordered]@{
+      equal = $historyParityEqual
+      status = $historyParityStatus
+    }
+    recommendation = [ordered]@{
+      code = $recommendationCode
+      summary = $recommendationSummary
+    }
     commitDivergence = [ordered]@{
       baseOnly = $baseOnly
       headOnly = $headOnly
@@ -111,11 +167,17 @@ function Write-ParityStepSummary {
   $tipDiffCount = Get-ChildValue -Object (Get-ChildValue -Object $Parity -Name 'tipDiff') -Name 'fileCount'
   $baseOnly = Get-ChildValue -Object (Get-ChildValue -Object $Parity -Name 'commitDivergence') -Name 'baseOnly'
   $headOnly = Get-ChildValue -Object (Get-ChildValue -Object $Parity -Name 'commitDivergence') -Name 'headOnly'
+  $treeParityStatus = Get-ChildValue -Object (Get-ChildValue -Object $Parity -Name 'treeParity') -Name 'status'
+  $historyParityStatus = Get-ChildValue -Object (Get-ChildValue -Object $Parity -Name 'historyParity') -Name 'status'
+  $recommendationCode = Get-ChildValue -Object (Get-ChildValue -Object $Parity -Name 'recommendation') -Name 'code'
 
   $statusValue = if ($Parity.status) { [string]$Parity.status } else { 'unavailable' }
   $reasonValue = if ($Parity.reason) { [string]$Parity.reason } else { '' }
   $tipDiffValue = if ($null -ne $tipDiffCount -and "$tipDiffCount".Trim() -ne '') { [string]$tipDiffCount } else { 'n/a' }
   $divergenceValue = if (($null -ne $baseOnly -and "$baseOnly".Trim() -ne '') -and ($null -ne $headOnly -and "$headOnly".Trim() -ne '')) { ('{0}/{1}' -f $baseOnly, $headOnly) } else { 'n/a' }
+  $treeParityValue = if ($null -ne $treeParityStatus -and -not [string]::IsNullOrWhiteSpace([string]$treeParityStatus)) { [string]$treeParityStatus } else { 'n/a' }
+  $historyParityValue = if ($null -ne $historyParityStatus -and -not [string]::IsNullOrWhiteSpace([string]$historyParityStatus)) { [string]$historyParityStatus } else { 'n/a' }
+  $recommendationValue = if ($null -ne $recommendationCode -and -not [string]::IsNullOrWhiteSpace([string]$recommendationCode)) { [string]$recommendationCode } else { 'n/a' }
 
   $lines = @(
     '### Origin/Upstream Parity Telemetry',
@@ -123,8 +185,11 @@ function Write-ParityStepSummary {
     '| Metric | Value |',
     '| --- | --- |',
     ('| Status | {0} |' -f $statusValue),
+    ('| Tree Parity | {0} |' -f $treeParityValue),
+    ('| History Parity | {0} |' -f $historyParityValue),
     ('| Tip Diff File Count | {0} |' -f $tipDiffValue),
-    ('| Commit Divergence (base-only/head-only) | {0} |' -f $divergenceValue)
+    ('| Commit Divergence (base-only/head-only) | {0} |' -f $divergenceValue),
+    ('| Recommendation | {0} |' -f $recommendationValue)
   )
   if (-not [string]::IsNullOrWhiteSpace($reasonValue)) {
     $lines += ('| Reason | {0} |' -f $reasonValue.Replace('|', '\|'))

--- a/tools/priority/__tests__/report-origin-upstream-parity.test.mjs
+++ b/tools/priority/__tests__/report-origin-upstream-parity.test.mjs
@@ -32,23 +32,34 @@ test('parseCliArgs accepts parity options', () => {
     'origin/develop',
     '--sample-limit',
     '5',
-    '--strict'
+    '--strict',
+    '--fail-on-tree-diff'
   ]);
   assert.equal(parsed.baseRef, 'upstream/develop');
   assert.equal(parsed.headRef, 'origin/develop');
   assert.equal(parsed.sampleLimit, 5);
   assert.equal(parsed.strict, true);
+  assert.equal(parsed.failOnTreeDiff, true);
 });
 
 test('collectParity returns ok payload when git commands succeed', () => {
   const calls = [];
   const fakeRunner = (_cmd, args) => {
     calls.push(args.join(' '));
+    if (args[0] === 'rev-parse' && args[1] === '--verify') {
+      return { status: 0, stdout: `${args[2]}-commit\n`, stderr: '' };
+    }
+    if (args[0] === 'rev-parse' && String(args[1]).endsWith('^{tree}')) {
+      return { status: 0, stdout: 'tree-shared\n', stderr: '' };
+    }
     if (args[0] === 'rev-list') {
       return { status: 0, stdout: '2\t5\n', stderr: '' };
     }
     if (args[0] === 'diff') {
       return { status: 0, stdout: 'a.ps1\nb.ps1\n', stderr: '' };
+    }
+    if (args[0] === 'remote' && args[1] === 'get-url') {
+      return { status: 0, stdout: `https://example/${args.at(-1)}.git\n`, stderr: '' };
     }
     return { status: 1, stdout: '', stderr: 'unexpected command' };
   };
@@ -66,11 +77,24 @@ test('collectParity returns ok payload when git commands succeed', () => {
   assert.equal(report.tipDiff.fileCount, 2);
   assert.deepEqual(report.tipDiff.sample, ['a.ps1']);
   assert.deepEqual(report.commitDivergence, { baseOnly: 2, headOnly: 5 });
-  assert.equal(calls.length, 2);
+  assert.equal(report.treeParity.status, 'equal');
+  assert.equal(report.treeParity.equal, true);
+  assert.equal(report.historyParity.status, 'diverged');
+  assert.equal(report.recommendation.code, 'history-diverged-tree-equal');
+  assert.equal(report.remoteManagement.baseRemote, 'upstream');
+  assert.equal(report.remoteManagement.headRemote, 'origin');
+  assert.equal(calls.length >= 6, true);
 });
 
 test('collectParity returns unavailable payload when refs are missing (non-strict)', () => {
   const fakeRunner = (_cmd, args) => {
+    if (args[0] === 'rev-parse') {
+      return {
+        status: 128,
+        stdout: '',
+        stderr: 'fatal: bad revision'
+      };
+    }
     if (args[0] === 'rev-list') {
       return {
         status: 128,
@@ -90,7 +114,7 @@ test('collectParity returns unavailable payload when refs are missing (non-stric
   );
 
   assert.equal(report.status, 'unavailable');
-  assert.match(report.reason, /git rev-list --left-right --count/);
+  assert.match(report.reason, /git rev-parse --verify/);
 });
 
 test('collectParity throws in strict mode when git fails', () => {
@@ -105,7 +129,7 @@ test('collectParity throws in strict mode when git fails', () => {
         },
         fakeRunner
       ),
-    /git rev-list --left-right --count/
+    /git rev-parse --verify/
   );
 });
 
@@ -114,11 +138,20 @@ test('renderSummaryMarkdown includes parity metrics for ok status', () => {
     status: 'ok',
     baseRef: 'upstream/develop',
     headRef: 'origin/develop',
+    treeParity: { status: 'equal', equal: true },
+    historyParity: { status: 'diverged', equal: false },
     tipDiff: { fileCount: 3, sample: ['a.txt'], sampleLimit: 20 },
-    commitDivergence: { baseOnly: 1, headOnly: 4 }
+    commitDivergence: { baseOnly: 1, headOnly: 4 },
+    recommendation: {
+      code: 'history-diverged-tree-equal',
+      summary: 'Tree is aligned but history diverges.',
+      nextActions: ['No code sync required.']
+    }
   });
+  assert.match(markdown, /Tree Parity \| equal/);
+  assert.match(markdown, /History Parity \| diverged/);
   assert.match(markdown, /Tip Diff File Count \| 3/);
   assert.match(markdown, /Commit Divergence \(base-only\/head-only\) \| 1\/4/);
+  assert.match(markdown, /Recommendation \| history-diverged-tree-equal/);
   assert.match(markdown, /`a.txt`/);
 });
-

--- a/tools/priority/report-origin-upstream-parity.mjs
+++ b/tools/priority/report-origin-upstream-parity.mjs
@@ -81,7 +81,8 @@ export function parseCliArgs(argv = process.argv.slice(2)) {
     outputPath: null,
     githubOutputPath: null,
     stepSummaryPath: null,
-    strict: false
+    strict: false,
+    failOnTreeDiff: false
   };
 
   for (let i = 0; i < args.length; i += 1) {
@@ -126,6 +127,10 @@ export function parseCliArgs(argv = process.argv.slice(2)) {
       options.strict = true;
       continue;
     }
+    if (token === '--fail-on-tree-diff') {
+      options.failOnTreeDiff = true;
+      continue;
+    }
     if (token === '--help' || token === '-h') {
       options.help = true;
       continue;
@@ -136,6 +141,99 @@ export function parseCliArgs(argv = process.argv.slice(2)) {
   return options;
 }
 
+function parseRemoteFromRef(ref) {
+  const text = trimText(ref);
+  if (!text.includes('/')) return null;
+  const [candidate] = text.split('/');
+  if (!candidate) return null;
+  if (!/^[A-Za-z0-9._-]+$/.test(candidate)) return null;
+  return candidate;
+}
+
+function runGitOptional(args, runner = sh) {
+  const result = ensureCommand(runner('git', args), 'git');
+  if (result.status !== 0) return null;
+  return trimText(result.stdout);
+}
+
+function collectRemoteDetails(remoteName, runner = sh) {
+  if (!remoteName) {
+    return {
+      name: null,
+      present: false,
+      fetchUrl: null,
+      pushUrl: null
+    };
+  }
+
+  const fetchUrl = runGitOptional(['remote', 'get-url', remoteName], runner);
+  const pushUrl = runGitOptional(['remote', 'get-url', '--push', remoteName], runner);
+  return {
+    name: remoteName,
+    present: Boolean(fetchUrl || pushUrl),
+    fetchUrl: fetchUrl || null,
+    pushUrl: pushUrl || null
+  };
+}
+
+function buildParityRecommendation({
+  baseRef,
+  headRef,
+  treeEqual,
+  baseOnly,
+  headOnly,
+  tipDiffCount
+}) {
+  if (treeEqual && baseOnly === 0 && headOnly === 0) {
+    return {
+      code: 'aligned',
+      summary: 'Tree and history are aligned.',
+      nextActions: []
+    };
+  }
+
+  if (treeEqual) {
+    return {
+      code: 'history-diverged-tree-equal',
+      summary: 'Tree is aligned but commit history diverges (typically due to squash/merge style).',
+      nextActions: [
+        `No code sync required; optional history normalization can be handled with policy-approved merge strategy between ${baseRef} and ${headRef}.`
+      ]
+    };
+  }
+
+  if (headOnly > 0 && baseOnly === 0) {
+    return {
+      code: 'sync-base-from-head',
+      summary: `${headRef} is ahead with tree drift; sync ${baseRef} from ${headRef}.`,
+      nextActions: [
+        `Open a sync PR from ${headRef} into ${baseRef} or apply a tip-diff file sync from ${headRef}.`,
+        `Validate required checks before merging into ${baseRef}.`
+      ]
+    };
+  }
+
+  if (baseOnly > 0 && headOnly === 0) {
+    return {
+      code: 'sync-head-from-base',
+      summary: `${baseRef} is ahead with tree drift; sync ${headRef} from ${baseRef}.`,
+      nextActions: [
+        `Open a sync PR from ${baseRef} into ${headRef} or apply a tip-diff file sync from ${baseRef}.`,
+        `Validate required checks before merging into ${headRef}.`
+      ]
+    };
+  }
+
+  return {
+    code: 'bidirectional-drift',
+    summary: `Both ${baseRef} and ${headRef} diverged with tree drift; manual parity branch required.`,
+    nextActions: [
+      `Create a dedicated parity branch from ${baseRef}, cherry-pick or file-sync intended deltas from ${headRef}.`,
+      'Run full validation and merge with admin policy as needed.'
+    ]
+  };
+}
+
 export function collectParity(options = {}, runner = sh) {
   const baseRef = options.baseRef || 'upstream/develop';
   const headRef = options.headRef || 'origin/develop';
@@ -144,11 +242,32 @@ export function collectParity(options = {}, runner = sh) {
   const now = new Date().toISOString();
 
   try {
+    const baseCommit = trimText(runGit(['rev-parse', '--verify', baseRef], runner));
+    const headCommit = trimText(runGit(['rev-parse', '--verify', headRef], runner));
+    const baseTree = trimText(runGit(['rev-parse', `${baseRef}^{tree}`], runner));
+    const headTree = trimText(runGit(['rev-parse', `${headRef}^{tree}`], runner));
     const countsText = runGit(['rev-list', '--left-right', '--count', `${baseRef}...${headRef}`], runner);
     const counts = parseRevListCounts(countsText);
     const filesText = runGit(['diff', '--name-only', baseRef, headRef], runner);
     const files = parseFileList(filesText);
     const sample = sampleLimit > 0 ? files.slice(0, sampleLimit) : [];
+    const treeEqual = baseTree === headTree;
+    const historyEqual = counts.baseOnly === 0 && counts.headOnly === 0;
+    const baseRemote = parseRemoteFromRef(baseRef);
+    const headRemote = parseRemoteFromRef(headRef);
+    const recommendation = buildParityRecommendation({
+      baseRef,
+      headRef,
+      treeEqual,
+      baseOnly: counts.baseOnly,
+      headOnly: counts.headOnly,
+      tipDiffCount: files.length
+    });
+    const baseRemoteDetails = collectRemoteDetails(baseRemote, runner);
+    const headRemoteDetails = collectRemoteDetails(headRemote, runner);
+    const remotes = {};
+    if (baseRemoteDetails.name) remotes[baseRemoteDetails.name] = baseRemoteDetails;
+    if (headRemoteDetails.name) remotes[headRemoteDetails.name] = headRemoteDetails;
 
     return {
       schema: 'origin-upstream-parity@v1',
@@ -156,10 +275,41 @@ export function collectParity(options = {}, runner = sh) {
       generatedAt: now,
       baseRef,
       headRef,
+      refs: {
+        base: {
+          ref: baseRef,
+          commit: baseCommit,
+          tree: baseTree
+        },
+        head: {
+          ref: headRef,
+          commit: headCommit,
+          tree: headTree
+        }
+      },
+      treeParity: {
+        equal: treeEqual,
+        status: treeEqual ? 'equal' : 'different',
+        baseTree,
+        headTree
+      },
+      historyParity: {
+        equal: historyEqual,
+        status: historyEqual ? 'equal' : 'diverged',
+        baseOnly: counts.baseOnly,
+        headOnly: counts.headOnly
+      },
+      recommendation,
+      remoteManagement: {
+        baseRemote,
+        headRemote,
+        remotes
+      },
       tipDiff: {
         fileCount: files.length,
         sampleLimit,
-        sample
+        sample,
+        treeConsistent: treeEqual ? files.length === 0 : true
       },
       commitDivergence: {
         baseOnly: counts.baseOnly,
@@ -212,14 +362,26 @@ export function renderSummaryMarkdown(report) {
     `| Status | ok |`,
     `| Base Ref | ${report.baseRef} |`,
     `| Head Ref | ${report.headRef} |`,
+    `| Tree Parity | ${report.treeParity?.status || 'unknown'} |`,
+    `| History Parity | ${report.historyParity?.status || 'unknown'} |`,
     `| Tip Diff File Count | ${report.tipDiff.fileCount} |`,
-    `| Commit Divergence (base-only/head-only) | ${report.commitDivergence.baseOnly}/${report.commitDivergence.headOnly} |`
+    `| Commit Divergence (base-only/head-only) | ${report.commitDivergence.baseOnly}/${report.commitDivergence.headOnly} |`,
+    `| Recommendation | ${report.recommendation?.code || 'n/a'} |`
   ];
 
   if (Array.isArray(report.tipDiff.sample) && report.tipDiff.sample.length > 0) {
     lines.push('', 'Tip-diff sample:');
     for (const file of report.tipDiff.sample) {
       lines.push(`- \`${file}\``);
+    }
+  }
+  if (report.recommendation?.summary) {
+    lines.push('', `Recommendation summary: ${report.recommendation.summary}`);
+  }
+  if (Array.isArray(report.recommendation?.nextActions) && report.recommendation.nextActions.length > 0) {
+    lines.push('', 'Next actions:');
+    for (const action of report.recommendation.nextActions) {
+      lines.push(`- ${action}`);
     }
   }
 
@@ -239,6 +401,7 @@ Options:
   --github-output <file>    Append GitHub output variables
   --step-summary <file>     Append markdown summary
   --strict                  Fail on git/ref errors instead of reporting unavailable
+  --fail-on-tree-diff       Exit non-zero when tree parity is different
   --help, -h                Show help`);
 }
 
@@ -272,6 +435,21 @@ async function main() {
     'parity_head_only_commits',
     report.status === 'ok' ? report.commitDivergence.headOnly : ''
   );
+  appendGitHubOutput(
+    options.githubOutputPath,
+    'parity_tree_equal',
+    report.status === 'ok' ? report.treeParity?.equal : ''
+  );
+  appendGitHubOutput(
+    options.githubOutputPath,
+    'parity_history_equal',
+    report.status === 'ok' ? report.historyParity?.equal : ''
+  );
+  appendGitHubOutput(
+    options.githubOutputPath,
+    'parity_recommendation_code',
+    report.status === 'ok' ? report.recommendation?.code : ''
+  );
   appendGitHubOutput(options.githubOutputPath, 'parity_report_path', outputPath);
 
   if (options.stepSummaryPath) {
@@ -284,10 +462,24 @@ async function main() {
     console.log(
       `[parity] tipDiff=${report.tipDiff.fileCount} commits=${report.commitDivergence.baseOnly}/${report.commitDivergence.headOnly}`
     );
+    console.log(
+      `[parity] tree=${report.treeParity?.status || 'unknown'} history=${report.historyParity?.status || 'unknown'} recommendation=${report.recommendation?.code || 'n/a'}`
+    );
   } else {
     console.log(`[parity] reason=${report.reason}`);
   }
   console.log(`[parity] report=${outputPath}`);
+
+  if (options.failOnTreeDiff) {
+    if (report.status !== 'ok') {
+      throw new Error('Unable to evaluate tree parity because parity status is unavailable.');
+    }
+    if (!report.treeParity?.equal) {
+      throw new Error(
+        `Tree parity mismatch for ${report.baseRef} vs ${report.headRef} (${report.refs?.base?.tree || '<unknown>'} != ${report.refs?.head?.tree || '<unknown>'}).`
+      );
+    }
+  }
 }
 
 const modulePath = path.resolve(fileURLToPath(import.meta.url));
@@ -298,4 +490,3 @@ if (invokedPath && invokedPath === modulePath) {
     process.exitCode = 1;
   });
 }
-


### PR DESCRIPTION
## Summary
- extend `tools/priority/report-origin-upstream-parity.mjs` to manage dual-remote parity explicitly (`origin` + `upstream`)
- add additive parity contract nodes:
  - `refs` (base/head commit + tree)
  - `treeParity`
  - `historyParity`
  - `recommendation`
  - `remoteManagement`
- keep existing fields (`tipDiff`, `commitDivergence`) for compatibility
- enrich session-index parity injection and step summary with tree/history parity + recommendation code

## Why
Tree parity and commit-history divergence are different signals. This change makes deterministic alignment decisions explicit and machine-readable across both remotes.

## Validation
- `node --test tools/priority/__tests__/report-origin-upstream-parity.test.mjs`
- `pwsh -NoLogo -NoProfile -File .\\Invoke-PesterTests.ps1 -TestsPath tests -IncludePatterns 'Update-SessionIndexParity.Tests.ps1'`
- `pwsh -NoLogo -NoProfile -File tools/PrePush-Checks.ps1`
- `node tools/priority/report-origin-upstream-parity.mjs --base-ref upstream/develop --head-ref origin/develop --sample-limit 5`

Closes #165
