### PR TITLE
feat: fork-standing-priority routing for priority sync (#169)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,8 +7,12 @@ line buffers).
 
 ## Primary directive
 
-- The standing priority is whichever issue carries the `standing-priority`
-  label. Use the sanitized wrappers (`node tools/npm/cli.mjs <command>` /
+- The standing priority is whichever issue carries the active standing-priority
+  label for the current repository context:
+  - canonical/upstream: `standing-priority`
+  - fork repos: `fork-standing-priority` (with fallback to
+    `standing-priority` for compatibility)
+  Use the sanitized wrappers (`node tools/npm/cli.mjs <command>` /
   `node tools/npm/run-script.mjs <script>`) instead of raw `npm` invocations
   (the container exports `npm_config_http_proxy`, which triggers warnings in
   recent npm builds). Run `pwsh -NoLogo -NoProfile -File

--- a/tools/priority/__tests__/standing-priority-resolution.test.mjs
+++ b/tools/priority/__tests__/standing-priority-resolution.test.mjs
@@ -6,10 +6,11 @@ import {
   buildNoStandingPriorityState,
   determinePrioritySyncExitCode,
   isStandingPriorityCacheCandidate,
+  resolveStandingPriorityLabels,
   resolveStandingPriorityFromSources
 } from '../sync-standing-priority.mjs';
 
-test('isStandingPriorityCacheCandidate requires OPEN state and standing-priority label', () => {
+test('isStandingPriorityCacheCandidate requires OPEN state and matching standing label', () => {
   assert.equal(
     isStandingPriorityCacheCandidate({
       number: 42,
@@ -42,6 +43,7 @@ test('resolveStandingPriorityFromSources uses cache only when lookups are unavai
   const number = resolveStandingPriorityFromSources({
     ghOutcome: { status: 'unavailable', error: 'gh missing' },
     restOutcome: { status: 'error', error: 'network timeout' },
+    standingPriorityLabels: ['fork-standing-priority', 'standing-priority'],
     cache: {
       number: 99,
       state: 'OPEN',
@@ -57,6 +59,7 @@ test('resolveStandingPriorityFromSources rejects stale cache when gh reports emp
       resolveStandingPriorityFromSources({
         ghOutcome: { status: 'empty' },
         restOutcome: { status: 'error', error: 'network timeout' },
+        standingPriorityLabels: ['fork-standing-priority', 'standing-priority'],
         cache: {
           number: 1,
           state: 'OPEN',
@@ -73,6 +76,7 @@ test('resolveStandingPriorityFromSources rejects stale cache when rest reports e
       resolveStandingPriorityFromSources({
         ghOutcome: { status: 'error', error: 'gh unavailable' },
         restOutcome: { status: 'empty' },
+        standingPriorityLabels: ['fork-standing-priority', 'standing-priority'],
         cache: {
           number: 1,
           state: 'OPEN',
@@ -89,6 +93,7 @@ test('resolveStandingPriorityFromSources fails when only invalid cache remains',
       resolveStandingPriorityFromSources({
         ghOutcome: { status: 'unavailable', error: 'gh missing' },
         restOutcome: { status: 'error', error: 'network timeout' },
+        standingPriorityLabels: ['fork-standing-priority', 'standing-priority'],
         cache: {
           number: 1,
           state: 'CLOSED',
@@ -107,8 +112,9 @@ test('buildNoStandingPriorityState clears router/cache deterministically', () =>
       state: 'OPEN',
       labels: ['standing-priority']
     },
-    "No open issue with label 'standing-priority' found.",
-    '2026-03-03T03:10:00.000Z'
+    'No open issue found with labels: `fork-standing-priority`, `standing-priority`.',
+    '2026-03-03T03:10:00.000Z',
+    ['fork-standing-priority', 'standing-priority']
   );
 
   assert.equal(state.clearedRouter.issue, null);
@@ -117,9 +123,25 @@ test('buildNoStandingPriorityState clears router/cache deterministically', () =>
   assert.equal(state.clearedCache.state, 'NONE');
   assert.equal(
     state.clearedCache.lastFetchError,
-    "No open issue with label 'standing-priority' found."
+    'No open issue found with labels: `fork-standing-priority`, `standing-priority`.'
   );
   assert.equal(state.result.fetchSource, 'none');
+});
+
+test('resolveStandingPriorityLabels prefers fork-standing-priority for non-canonical owners', () => {
+  const labels = resolveStandingPriorityLabels(
+    '/tmp/repo',
+    'svelderrainruiz/compare-vi-cli-action',
+    {}
+  );
+  assert.deepEqual(labels, ['fork-standing-priority', 'standing-priority']);
+});
+
+test('resolveStandingPriorityLabels honors explicit env override order', () => {
+  const labels = resolveStandingPriorityLabels('/tmp/repo', null, {
+    AGENT_STANDING_PRIORITY_LABELS: 'custom-one, custom-two, custom-one'
+  });
+  assert.deepEqual(labels, ['custom-one', 'custom-two']);
 });
 
 test('determinePrioritySyncExitCode maps no-standing to success and real errors to failure', () => {
@@ -127,4 +149,3 @@ test('determinePrioritySyncExitCode maps no-standing to success and real errors 
   assert.equal(determinePrioritySyncExitCode({ code: 'NO_STANDING_PRIORITY' }), 0);
   assert.equal(determinePrioritySyncExitCode(new Error('boom')), 1);
 });
-

--- a/tools/priority/sync-standing-priority.mjs
+++ b/tools/priority/sync-standing-priority.mjs
@@ -11,6 +11,26 @@ const USER_AGENT = 'compare-vi-cli-action/priority-sync';
 const PROXY_AGENT_CACHE = new Map();
 let GH_AUTH_TOKEN_CACHE;
 let WARNED_NO_GITHUB_TOKEN_FOR_REST = false;
+const DEFAULT_STANDING_PRIORITY_LABEL = 'standing-priority';
+const FORK_STANDING_PRIORITY_LABEL = 'fork-standing-priority';
+const CANONICAL_PRIORITY_OWNER = 'labview-community-ci-cd';
+
+function normalizeStandingPriorityLabels(values) {
+  const seen = new Set();
+  const labels = [];
+  for (const value of values || []) {
+    if (value == null) continue;
+    const label = String(value).trim().toLowerCase();
+    if (!label || seen.has(label)) continue;
+    seen.add(label);
+    labels.push(label);
+  }
+  return labels;
+}
+
+function formatStandingPriorityLabels(labels) {
+  return (labels || []).map((label) => `\`${label}\``).join(', ');
+}
 
 function toUrl(input) {
   if (!input) return null;
@@ -466,6 +486,28 @@ function resolveRepositorySlug(repoRoot) {
   return null;
 }
 
+export function resolveStandingPriorityLabels(repoRoot, slug, env = process.env) {
+  const explicit = env.AGENT_STANDING_PRIORITY_LABELS || env.AGENT_PRIORITY_LABELS;
+  const explicitLabels = normalizeStandingPriorityLabels(
+    explicit
+      ? String(explicit)
+          .split(',')
+          .map((label) => label.trim())
+      : []
+  );
+  if (explicitLabels.length > 0) {
+    return explicitLabels;
+  }
+
+  const resolvedSlug = (slug || resolveRepositorySlug(repoRoot) || '').toLowerCase();
+  const owner = resolvedSlug.includes('/') ? resolvedSlug.split('/')[0] : '';
+  if (owner && owner !== CANONICAL_PRIORITY_OWNER) {
+    return [FORK_STANDING_PRIORITY_LABEL, DEFAULT_STANDING_PRIORITY_LABEL];
+  }
+
+  return [DEFAULT_STANDING_PRIORITY_LABEL];
+}
+
 function normalizeTokenValue(value) {
   const normalized = typeof value === 'string' ? value.trim() : '';
   return normalized || null;
@@ -536,7 +578,7 @@ async function requestGitHubJson(url, token) {
   return response.json();
 }
 
-async function fetchStandingPriorityNumberViaRest(repoRoot, slug) {
+async function fetchStandingPriorityNumberViaRest(repoRoot, slug, standingPriorityLabels = [DEFAULT_STANDING_PRIORITY_LABEL]) {
   const resolvedSlug = slug ?? resolveRepositorySlug(repoRoot);
   if (!resolvedSlug) {
     console.warn('[priority] Unable to resolve repository slug for REST fallback');
@@ -548,38 +590,48 @@ async function fetchStandingPriorityNumberViaRest(repoRoot, slug) {
     warnNoGitHubTokenForRestOnce();
   }
 
+  const errors = [];
+  for (const label of standingPriorityLabels) {
     const url = new URL(`https://api.github.com/repos/${resolvedSlug}/issues`);
-    url.searchParams.set('labels', 'standing-priority');
+    url.searchParams.set('labels', label);
     url.searchParams.set('state', 'open');
     url.searchParams.set('per_page', '25');
     url.searchParams.set('sort', 'updated');
     url.searchParams.set('direction', 'desc');
 
-  try {
-    const data = await requestGitHubJson(url.toString(), token);
-    if (Array.isArray(data)) {
-      if (data.length > 1) {
-        const ids = data.map((item) => item?.number).filter(Boolean);
-        console.warn(
-          `[priority] Multiple open items carry the standing-priority label (candidates: ${ids.join(', ')}) – selecting the most recently updated entry.`
-        );
+    try {
+      const data = await requestGitHubJson(url.toString(), token);
+      if (Array.isArray(data)) {
+        if (data.length > 1) {
+          const ids = data.map((item) => item?.number).filter(Boolean);
+          console.warn(
+            `[priority] Multiple open items carry label '${label}' (candidates: ${ids.join(', ')}) – selecting the most recently updated entry.`
+          );
+        }
+        const first = data.find((item) => item?.number != null);
+        if (first) return { status: 'found', number: Number(first.number), label };
+        continue;
       }
-      const first = data.find((item) => item?.number != null);
-      if (first) return { status: 'found', number: Number(first.number) };
-      return { status: 'empty' };
+      if (data?.number != null) {
+        return { status: 'found', number: Number(data.number), label };
+      }
+    } catch (err) {
+      errors.push(`${label}: ${err.message}`);
     }
-    if (data?.number != null) {
-      return { status: 'found', number: Number(data.number) };
-    }
-    return { status: 'empty' };
-  } catch (err) {
-    console.warn(`[priority] REST fallback failed: ${err.message}`);
-    return { status: 'error', error: err.message };
   }
+
+  if (errors.length > 0) {
+    const message = errors.join(' | ');
+    console.warn(`[priority] REST fallback failed: ${message}`);
+    return { status: 'error', error: message };
+  }
+
+  return { status: 'empty' };
 }
 
-function createNoStandingPriorityError(message) {
-  const err = new Error(message || "No open issue with label 'standing-priority' found.");
+function createNoStandingPriorityError(message, standingPriorityLabels = [DEFAULT_STANDING_PRIORITY_LABEL]) {
+  const labelText = formatStandingPriorityLabels(standingPriorityLabels);
+  const err = new Error(message || `No open issue found with labels: ${labelText}.`);
   err.code = 'NO_STANDING_PRIORITY';
   return err;
 }
@@ -592,19 +644,25 @@ function isUnavailableOutcome(outcome) {
   return !outcome || outcome.status === 'error' || outcome.status === 'unavailable';
 }
 
-export function isStandingPriorityCacheCandidate(cache) {
+export function isStandingPriorityCacheCandidate(cache, standingPriorityLabels = [DEFAULT_STANDING_PRIORITY_LABEL]) {
   if (!cache || cache.number == null) return false;
   const labels = normalizeList(cache.labels || []);
+  const requiredLabels = normalizeStandingPriorityLabels(standingPriorityLabels);
   const state = String(cache.state || '').trim().toUpperCase();
-  return state === 'OPEN' && labels.includes('standing-priority');
+  return state === 'OPEN' && requiredLabels.some((label) => labels.includes(label));
 }
 
-export function resolveStandingPriorityFromSources({ ghOutcome, restOutcome, cache }) {
+export function resolveStandingPriorityFromSources({
+  ghOutcome,
+  restOutcome,
+  cache,
+  standingPriorityLabels = [DEFAULT_STANDING_PRIORITY_LABEL]
+}) {
   if (isNoStandingOutcome(ghOutcome) || isNoStandingOutcome(restOutcome)) {
-    throw createNoStandingPriorityError();
+    throw createNoStandingPriorityError(undefined, standingPriorityLabels);
   }
 
-  if (isStandingPriorityCacheCandidate(cache)) {
+  if (isStandingPriorityCacheCandidate(cache, standingPriorityLabels)) {
     return Number(cache.number);
   }
 
@@ -620,7 +678,7 @@ export function resolveStandingPriorityFromSources({ ghOutcome, restOutcome, cac
     reasons.push(`rest: ${restOutcome.error}`);
   }
   if (cache?.number != null) {
-    reasons.push('cache invalid (must be OPEN and include standing-priority label)');
+    reasons.push(`cache invalid (must be OPEN and include one of: ${standingPriorityLabels.join(', ')})`);
   }
 
   throw new Error(
@@ -651,7 +709,7 @@ async function fetchIssueViaRest(repoRoot, number, slug) {
   }
 }
 
-async function resolveStandingPriorityNumber(repoRoot, slug) {
+async function resolveStandingPriorityNumber(repoRoot, slug, standingPriorityLabels = [DEFAULT_STANDING_PRIORITY_LABEL]) {
   const override = process.env.AGENT_PRIORITY_OVERRIDE;
   if (override) {
     try {
@@ -667,19 +725,28 @@ async function resolveStandingPriorityNumber(repoRoot, slug) {
 
   let ghOutcome = { status: 'error', error: 'unknown' };
   try {
-    const query = ensureCommand(
-      sh('gh', ['issue', 'list', '--label', 'standing-priority', '--state', 'open', '--limit', '1', '--json', 'number']),
-      'gh'
-    );
-    if (query.status === 0) {
-      const parsed = query.stdout.trim() ? JSON.parse(query.stdout) : [];
-      const first = Array.isArray(parsed) ? parsed[0] : parsed;
-      if (first?.number) return Number(first.number);
+    let ghHasEmpty = false;
+    const ghErrors = [];
+    for (const label of standingPriorityLabels) {
+      const query = ensureCommand(
+        sh('gh', ['issue', 'list', '--label', label, '--state', 'open', '--limit', '1', '--json', 'number']),
+        'gh'
+      );
+      if (query.status === 0) {
+        const parsed = query.stdout.trim() ? JSON.parse(query.stdout) : [];
+        const first = Array.isArray(parsed) ? parsed[0] : parsed;
+        if (first?.number) return Number(first.number);
+        ghHasEmpty = true;
+      } else {
+        ghErrors.push(`${label}: ${query.stderr?.trim() || `gh exited with status ${query.status}`}`);
+      }
+    }
+    if (ghHasEmpty) {
       ghOutcome = { status: 'empty' };
     } else {
       ghOutcome = {
         status: 'error',
-        error: query.stderr?.trim() || `gh exited with status ${query.status}`
+        error: ghErrors.join(' | ') || 'gh issue list failed'
       };
     }
   } catch (err) {
@@ -691,11 +758,11 @@ async function resolveStandingPriorityNumber(repoRoot, slug) {
     }
   }
 
-  const restOutcome = await fetchStandingPriorityNumberViaRest(repoRoot, slug);
+  const restOutcome = await fetchStandingPriorityNumberViaRest(repoRoot, slug, standingPriorityLabels);
   if (restOutcome?.status === 'found') return restOutcome.number;
 
   const cache = readJson(path.join(repoRoot, '.agent_priority_cache.json'));
-  return resolveStandingPriorityFromSources({ ghOutcome, restOutcome, cache });
+  return resolveStandingPriorityFromSources({ ghOutcome, restOutcome, cache, standingPriorityLabels });
 }
 
 function normalizeIssueResult(result) {
@@ -790,7 +857,12 @@ function stepSummaryAppend(lines) {
   fs.appendFileSync(file, lines.join('\n') + '\n');
 }
 
-export function buildNoStandingPriorityState(cache, message, clearedAt = new Date().toISOString()) {
+export function buildNoStandingPriorityState(
+  cache,
+  message,
+  clearedAt = new Date().toISOString(),
+  standingPriorityLabels = [DEFAULT_STANDING_PRIORITY_LABEL]
+) {
   const clearedRouter = {
     schema: 'agent/priority-router@v1',
     issue: null,
@@ -816,7 +888,7 @@ export function buildNoStandingPriorityState(cache, message, clearedAt = new Dat
   };
   const summaryLines = [
     '### Standing Priority Snapshot',
-    "- Issue: none found (`standing-priority` label on open issues)",
+    `- Issue: none found (labels checked: ${formatStandingPriorityLabels(standingPriorityLabels)})`,
     `- Status: ${message}`,
     '- Top actions: n/a'
   ];
@@ -833,6 +905,7 @@ export function buildNoStandingPriorityState(cache, message, clearedAt = new Dat
 export async function main() {
   const repoRoot = gitRoot();
   const slug = resolveRepositorySlug(repoRoot);
+  const standingPriorityLabels = resolveStandingPriorityLabels(repoRoot, slug);
   const cachePath = path.join(repoRoot, '.agent_priority_cache.json');
   const cache = readJson(cachePath) || {};
   const resultsDir = path.join(repoRoot, 'tests', 'results', '_agent', 'issue');
@@ -840,12 +913,14 @@ export async function main() {
 
   let number;
   try {
-    number = await resolveStandingPriorityNumber(repoRoot, slug);
+    number = await resolveStandingPriorityNumber(repoRoot, slug, standingPriorityLabels);
   } catch (err) {
     if (err?.code === 'NO_STANDING_PRIORITY') {
       const { clearedRouter, clearedCache, summaryLines, result } = buildNoStandingPriorityState(
         cache,
-        err.message
+        err.message,
+        undefined,
+        standingPriorityLabels
       );
       writeJson(path.join(resultsDir, 'router.json'), clearedRouter);
 
@@ -1008,4 +1083,3 @@ if (invokedPath && invokedPath === modulePath) {
     process.exitCode = exitCode;
   })();
 }
-


### PR DESCRIPTION
## Summary
- add fork-aware standing-priority label resolution in `sync-standing-priority.mjs`
- for non-canonical repo owners, prioritize `fork-standing-priority` and fall back to `standing-priority`
- keep explicit label override via env and improve no-standing diagnostics
- update standing-priority resolution tests and AGENTS guidance

## Validation
- `node --test tools/priority/__tests__/standing-priority-resolution.test.mjs`
- `pwsh -NoLogo -NoProfile -File tools/PrePush-Checks.ps1`

Refs #169