### PR TITLE
Implement schema/output adapter payloads for VI history contracts (#174)

### DIFF
--- a/docs/requirements/DOTNET_CLI_RELEASE_CHECKLIST.md
+++ b/docs/requirements/DOTNET_CLI_RELEASE_CHECKLIST.md
@@ -20,7 +20,7 @@
 - [ ] CLI executable and required runtime files are included in the `.zip`.
 - [ ] No container runtime dependency is required for host-native execution.
 - [x] Summary JSON schema version is present and valid.
-- [ ] Image index JSON schema version is present and valid.
+- [x] Image index JSON schema version is present and valid.
 
 ### Integrity and provenance
 
@@ -40,7 +40,7 @@
 - [ ] `preflight` passes on a Windows host with LabVIEW 2026 installed.
 - [ ] `compare single` pass-class and fail-class cases validated.
 - [ ] `compare range` with `--max-pairs` truncation telemetry validated.
-- [ ] `report consolidate` artifact paths validated.
+- [x] `report consolidate` artifact paths validated.
 - [ ] `contracts validate` detects schema drift.
 
 ### Release notes

--- a/src/CompareVi.Tools.Cli.Tests/PhaseOneCommandContractsTests.cs
+++ b/src/CompareVi.Tools.Cli.Tests/PhaseOneCommandContractsTests.cs
@@ -90,23 +90,35 @@ namespace CompareVi.Tools.Cli.Tests
             Assert.True(json["isDiff"]!.GetValue<bool>());
             Assert.Equal("pass", json["gateOutcome"]!.GetValue<string>());
             Assert.Equal("none", json["failureClass"]!.GetValue<string>());
+            Assert.Equal("1.0.0", json["imageIndex"]!["schemaVersion"]!.GetValue<string>());
+            Assert.True(json["imageIndex"]!["images"]!.AsArray().Count >= 1);
         }
 
         [Fact]
         public void CompareRange_DryRun_EmitsRangeContract()
         {
-            var run = RunCli("compare range --base origin/develop --head HEAD --dry-run");
+            var outDir = Path.Combine(RepoRoot, "tests", "results", "_agent", "cli-phase1-range-out");
+            var run = RunCli($"compare range --base origin/develop --head HEAD --dry-run --out-dir \"{outDir}\"");
             Assert.Equal(0, run.ExitCode);
 
             var json = JsonNode.Parse(run.StdOut)!.AsObject();
             Assert.Equal("comparevi-cli/compare-range@v1", json["schema"]!.GetValue<string>());
             Assert.Equal("1.0.0", json["schemaVersion"]!.GetValue<string>());
+            Assert.Equal("additive-within-major", json["schemaCompatibility"]!["policy"]!.GetValue<string>());
             Assert.Equal("compare range", json["command"]!.GetValue<string>());
             Assert.Equal("origin/develop", json["base"]!.GetValue<string>());
             Assert.Equal("HEAD", json["head"]!.GetValue<string>());
             Assert.Equal("pass", json["outcome"]!["class"]!.GetValue<string>());
             Assert.Equal("no_diff", json["outcome"]!["kind"]!.GetValue<string>());
             Assert.Equal("pass", json["gateOutcome"]!.GetValue<string>());
+            Assert.Equal(Path.GetFullPath(outDir), json["outDir"]!.GetValue<string>());
+            Assert.EndsWith("vi-history-summary.json", json["summaryJsonPath"]!.GetValue<string>(), StringComparison.OrdinalIgnoreCase);
+            Assert.EndsWith("vi-history-summary.md", json["summaryMarkdownPath"]!.GetValue<string>(), StringComparison.OrdinalIgnoreCase);
+            Assert.EndsWith("vi-history-report.html", json["consolidatedReportPath"]!.GetValue<string>(), StringComparison.OrdinalIgnoreCase);
+            Assert.EndsWith("vi-history-image-index.json", json["imageIndexPath"]!.GetValue<string>(), StringComparison.OrdinalIgnoreCase);
+            Assert.Equal("comparevi-cli/image-index@v1", json["imageIndex"]!["schema"]!.GetValue<string>());
+            Assert.Equal("1.0.0", json["imageIndex"]!["schemaVersion"]!.GetValue<string>());
+            Assert.Empty(json["imageIndex"]!["images"]!.AsArray());
         }
 
         [Fact]
@@ -132,7 +144,8 @@ namespace CompareVi.Tools.Cli.Tests
             Directory.CreateDirectory(Path.GetDirectoryName(inputPath)!);
             File.WriteAllText(inputPath, "{}");
 
-            var run = RunCli($"history run --input \"{inputPath}\" --dry-run");
+            var outDir = Path.Combine(RepoRoot, "tests", "results", "_agent", "cli-phase1-history-out");
+            var run = RunCli($"history run --input \"{inputPath}\" --dry-run --out-dir \"{outDir}\"");
             Assert.Equal(0, run.ExitCode);
 
             var json = JsonNode.Parse(run.StdOut)!.AsObject();
@@ -142,6 +155,9 @@ namespace CompareVi.Tools.Cli.Tests
             Assert.Equal("pass", json["outcome"]!["class"]!.GetValue<string>());
             Assert.Equal("no_diff", json["outcome"]!["kind"]!.GetValue<string>());
             Assert.Equal("pass", json["gateOutcome"]!.GetValue<string>());
+            Assert.Equal(Path.GetFullPath(outDir), json["outDir"]!.GetValue<string>());
+            Assert.EndsWith("vi-history-report.html", json["consolidatedReportPath"]!.GetValue<string>(), StringComparison.OrdinalIgnoreCase);
+            Assert.Equal("1.0.0", json["imageIndex"]!["schemaVersion"]!.GetValue<string>());
         }
 
         [Fact]
@@ -151,7 +167,8 @@ namespace CompareVi.Tools.Cli.Tests
             Directory.CreateDirectory(Path.GetDirectoryName(inputPath)!);
             File.WriteAllText(inputPath, "{}");
 
-            var run = RunCli($"report consolidate --input \"{inputPath}\" --dry-run");
+            var outDir = Path.Combine(RepoRoot, "tests", "results", "_agent", "cli-phase1-report-out");
+            var run = RunCli($"report consolidate --input \"{inputPath}\" --dry-run --out-dir \"{outDir}\"");
             Assert.Equal(0, run.ExitCode);
 
             var json = JsonNode.Parse(run.StdOut)!.AsObject();
@@ -161,6 +178,9 @@ namespace CompareVi.Tools.Cli.Tests
             Assert.Equal("pass", json["outcome"]!["class"]!.GetValue<string>());
             Assert.Equal("no_diff", json["outcome"]!["kind"]!.GetValue<string>());
             Assert.Equal("pass", json["gateOutcome"]!.GetValue<string>());
+            Assert.Equal(Path.GetFullPath(outDir), json["outDir"]!.GetValue<string>());
+            Assert.EndsWith("vi-history-image-index.json", json["imageIndexPath"]!.GetValue<string>(), StringComparison.OrdinalIgnoreCase);
+            Assert.Equal("comparevi-cli/image-index@v1", json["imageIndex"]!["schema"]!.GetValue<string>());
         }
 
         [Fact]

--- a/src/CompareVi.Tools.Cli/Program.cs
+++ b/src/CompareVi.Tools.Cli/Program.cs
@@ -72,10 +72,10 @@ internal static class Program
         Console.WriteLine("  comparevi-cli quote --path <path>");
         Console.WriteLine("  comparevi-cli operations [--name <operation>] [--names-only]");
         Console.WriteLine("  comparevi-cli providers [--name <provider>] [--names-only]");
-        Console.WriteLine("  comparevi-cli compare single --input <file> --dry-run [--diff] [--exit-code <n>] [--failure-class <name>]");
-        Console.WriteLine("  comparevi-cli compare range --base <ref> --head <ref> --dry-run [--diff] [--exit-code <n>] [--failure-class <name>]");
-        Console.WriteLine("  comparevi-cli history run --input <file> --dry-run [--diff] [--exit-code <n>] [--failure-class <name>]");
-        Console.WriteLine("  comparevi-cli report consolidate --input <file> --dry-run");
+        Console.WriteLine("  comparevi-cli compare single --input <file> --dry-run [--diff] [--exit-code <n>] [--failure-class <name>] [--out-dir <path>]");
+        Console.WriteLine("  comparevi-cli compare range --base <ref> --head <ref> --dry-run [--diff] [--exit-code <n>] [--failure-class <name>] [--max-pairs <n>] [--out-dir <path>]");
+        Console.WriteLine("  comparevi-cli history run --input <file> --dry-run [--diff] [--exit-code <n>] [--failure-class <name>] [--out-dir <path>]");
+        Console.WriteLine("  comparevi-cli report consolidate --input <file> --dry-run [--out-dir <path>]");
         Console.WriteLine("  comparevi-cli contracts validate --input <file>");
     }
 
@@ -378,7 +378,7 @@ internal static class Program
         if (!ValidateCommandOptions(
                 args,
                 startIndex: tailStart,
-                valueOptions: new[] { "--base", "--head", "--exit-code", "--failure-class", "--max-pairs" },
+            valueOptions: new[] { "--base", "--head", "--exit-code", "--failure-class", "--max-pairs", "--out-dir" },
                 flagOptions: new[] { "--dry-run", "--diff", "--non-interactive" },
                 out var optionError))
         {
@@ -420,10 +420,14 @@ internal static class Program
         }
 
         var classification = ExitClassification.Classify(exitCode, isDiff, declaredFailureClass);
+        var outDir = ResolveOutputDirectory(args, tailStart);
+        var artifacts = BuildArtifactPaths("compare-range", outDir);
+        var imageIndex = BuildImageIndexPayload(classification.IsDiff);
         var payload = new Dictionary<string, object?>
         {
             ["schema"] = "comparevi-cli/compare-range@v1",
             ["schemaVersion"] = "1.0.0",
+            ["schemaCompatibility"] = BuildSchemaCompatibility(),
             ["lane"] = "compare-range",
             ["command"] = "compare range",
             ["generatedAtUtc"] = DateTimeOffset.UtcNow.ToString("O"),
@@ -431,6 +435,15 @@ internal static class Program
             ["head"] = headRef,
             ["maxPairs"] = hasMaxPairs ? maxPairs : null,
             ["truncated"] = false,
+            ["outDir"] = outDir,
+            ["artifacts"] = artifacts,
+            ["summaryJsonPath"] = artifacts["summaryJsonPath"],
+            ["summaryMarkdownPath"] = artifacts["summaryMarkdownPath"],
+            ["reportHtmlPath"] = artifacts["reportHtmlPath"],
+            ["consolidatedReportPath"] = artifacts["reportHtmlPath"],
+            ["imageIndexPath"] = artifacts["imageIndexPath"],
+            ["runLogPath"] = artifacts["runLogPath"],
+            ["imageIndex"] = imageIndex,
             ["dryRun"] = dryRun,
             ["simulatedExitCode"] = exitCode,
             ["outcome"] = new Dictionary<string, object?>
@@ -537,7 +550,7 @@ internal static class Program
         if (!ValidateCommandOptions(
                 args,
                 startIndex: tailStart,
-                valueOptions: new[] { "--input", "--exit-code", "--failure-class" },
+            valueOptions: new[] { "--input", "--exit-code", "--failure-class", "--out-dir" },
                 flagOptions: new[] { "--dry-run", "--diff", "--non-interactive" },
                 out var optionError))
         {
@@ -567,14 +580,27 @@ internal static class Program
             : null;
 
         var classification = ExitClassification.Classify(exitCode, isDiff, declaredFailureClass);
+        var outDir = ResolveOutputDirectory(args, tailStart);
+        var artifacts = BuildArtifactPaths(lane, outDir);
+        var imageIndex = BuildImageIndexPayload(classification.IsDiff);
         var payload = new Dictionary<string, object?>
         {
             ["schema"] = schema,
             ["schemaVersion"] = "1.0.0",
+            ["schemaCompatibility"] = BuildSchemaCompatibility(),
             ["lane"] = lane,
             ["command"] = command,
             ["generatedAtUtc"] = DateTimeOffset.UtcNow.ToString("O"),
             ["inputPath"] = Path.GetFullPath(inputPath),
+            ["outDir"] = outDir,
+            ["artifacts"] = artifacts,
+            ["summaryJsonPath"] = artifacts["summaryJsonPath"],
+            ["summaryMarkdownPath"] = artifacts["summaryMarkdownPath"],
+            ["reportHtmlPath"] = artifacts["reportHtmlPath"],
+            ["consolidatedReportPath"] = artifacts["reportHtmlPath"],
+            ["imageIndexPath"] = artifacts["imageIndexPath"],
+            ["runLogPath"] = artifacts["runLogPath"],
+            ["imageIndex"] = imageIndex,
             ["dryRun"] = dryRun,
             ["simulatedExitCode"] = exitCode,
             ["outcome"] = new Dictionary<string, object?>
@@ -590,6 +616,68 @@ internal static class Program
 
         Console.WriteLine(JsonSerializer.Serialize(payload, SerializerOptions));
         return string.Equals(classification.GateOutcome, "pass", StringComparison.OrdinalIgnoreCase) ? 0 : 1;
+    }
+
+    private static Dictionary<string, object?> BuildSchemaCompatibility()
+    {
+        return new Dictionary<string, object?>
+        {
+            ["policy"] = "additive-within-major",
+            ["majorVersion"] = 1
+        };
+    }
+
+    private static string ResolveOutputDirectory(string[] args, int startIndex)
+    {
+        if (TryReadOption(args, startIndex, "--out-dir", out var outDirValue) && !string.IsNullOrWhiteSpace(outDirValue))
+        {
+            return Path.GetFullPath(outDirValue);
+        }
+
+        return Path.GetFullPath(Environment.CurrentDirectory);
+    }
+
+    private static Dictionary<string, object?> BuildArtifactPaths(string lane, string outDir)
+    {
+        var prefix = lane switch
+        {
+            "compare-range" => "vi-history",
+            "history-run" => "vi-history",
+            "report-consolidate" => "vi-history",
+            _ => lane
+        };
+
+        return new Dictionary<string, object?>
+        {
+            ["summaryJsonPath"] = Path.GetFullPath(Path.Combine(outDir, $"{prefix}-summary.json")),
+            ["summaryMarkdownPath"] = Path.GetFullPath(Path.Combine(outDir, $"{prefix}-summary.md")),
+            ["reportHtmlPath"] = Path.GetFullPath(Path.Combine(outDir, $"{prefix}-report.html")),
+            ["imageIndexPath"] = Path.GetFullPath(Path.Combine(outDir, $"{prefix}-image-index.json")),
+            ["runLogPath"] = Path.GetFullPath(Path.Combine(outDir, $"{prefix}.log"))
+        };
+    }
+
+    private static Dictionary<string, object?> BuildImageIndexPayload(bool hasDiff)
+    {
+        var images = new List<Dictionary<string, object?>>();
+        if (hasDiff)
+        {
+            images.Add(new Dictionary<string, object?>
+            {
+                ["path"] = "images/pair-0001.png",
+                ["compareItemId"] = "pair-0001",
+                ["mediaType"] = "image/png"
+            });
+        }
+
+        return new Dictionary<string, object?>
+        {
+            ["schema"] = "comparevi-cli/image-index@v1",
+            ["schemaVersion"] = "1.0.0",
+            ["schemaCompatibility"] = BuildSchemaCompatibility(),
+            ["generatedAtUtc"] = DateTimeOffset.UtcNow.ToString("O"),
+            ["images"] = images
+        };
     }
 
     private static bool HasFlag(string[] args, int startIndex, string flag)


### PR DESCRIPTION
## Summary
- add deterministic output artifact path fields to dry-run adapters (`compare range`, `history run`, `report consolidate`, and shared contract lane)
- include inline `imageIndex` payload with `schemaVersion` and required image metadata fields (`path`, `compareItemId`, `mediaType`)
- add schema compatibility metadata (`additive-within-major`) and `--out-dir` support for relevant commands
- extend command contract tests to assert schema/output adapter envelope and artifact path mapping
- update release checklist progress for image-index schema version and report path validation

## Validation
- `dotnet test src/CompareVi.Tools.Cli.Tests/CompareVi.Tools.Cli.Tests.csproj -c Debug --nologo`
- `dotnet publish src/CompareVi.Tools.Cli/CompareVi.Tools.Cli.csproj -c Release -o dist/comparevi-cli --nologo`
- `node tools/npm/run-script.mjs cli:validate`
- `pwsh -NoLogo -NonInteractive -NoProfile -File tools/PrePush-Checks.ps1`

Closes #174