### PR TITLE
Add post-merge requirements verification gate workflow (#182)

### DIFF
--- a/.github/workflows/verification.yml
+++ b/.github/workflows/verification.yml
@@ -1,0 +1,47 @@
+name: Requirements Verification
+
+on:
+  push:
+    branches: [develop]
+  workflow_dispatch:
+    inputs:
+      sample_id:
+        description: 'Optional run sample identifier for provenance'
+        required: false
+        default: ''
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.inputs.sample_id || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verification:
+    name: requirements-verification
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Run requirements verification gate
+        id: gate
+        shell: pwsh
+        run: |
+          pwsh -NoLogo -NonInteractive -NoProfile -File tools/Verify-RequirementsGate.ps1 `
+            -TestsPath tests `
+            -ResultsRoot tests/results `
+            -OutDir tests/results/_agent/verification `
+            -BaselinePolicyPath tools/policy/requirements-verification-baseline.json `
+            -GitHubOutputPath $env:GITHUB_OUTPUT `
+            -StepSummaryPath $env:GITHUB_STEP_SUMMARY
+
+      - name: Upload verification artifacts
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: requirements-verification-${{ github.run_id }}
+          path: |
+            tests/results/_agent/verification/trace-matrix.json
+            tests/results/_agent/verification/trace-matrix.html
+            tests/results/_agent/verification/verification-summary.json
+          if-no-files-found: error

--- a/tools/Verify-RequirementsGate.ps1
+++ b/tools/Verify-RequirementsGate.ps1
@@ -1,0 +1,108 @@
+[CmdletBinding()]
+param(
+  [string]$TestsPath = 'tests',
+  [string]$ResultsRoot = 'tests/results',
+  [string]$OutDir = 'tests/results/_agent/verification',
+  [string]$BaselinePolicyPath = 'tools/policy/requirements-verification-baseline.json',
+  [string]$GitHubOutputPath = $env:GITHUB_OUTPUT,
+  [string]$StepSummaryPath = $env:GITHUB_STEP_SUMMARY
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path '.').Path
+if (-not (Test-Path -LiteralPath $OutDir -PathType Container)) {
+  New-Item -ItemType Directory -Path $OutDir -Force | Out-Null
+}
+
+$traceScript = Join-Path $repoRoot 'tools/Traceability-Matrix.ps1'
+if (-not (Test-Path -LiteralPath $traceScript -PathType Leaf)) {
+  throw "Traceability matrix script not found: $traceScript"
+}
+
+pwsh -NoLogo -NoProfile -File $traceScript -TestsPath $TestsPath -ResultsRoot $ResultsRoot -OutDir $OutDir -RenderHtml | Out-Host
+
+$tracePath = Join-Path $OutDir 'trace-matrix.json'
+if (-not (Test-Path -LiteralPath $tracePath -PathType Leaf)) {
+  throw "Traceability matrix output missing: $tracePath"
+}
+
+$trace = Get-Content -LiteralPath $tracePath -Raw | ConvertFrom-Json -Depth 20
+$baseline = Get-Content -LiteralPath $BaselinePolicyPath -Raw | ConvertFrom-Json -Depth 10
+
+$allowedUnknown = @($baseline.allowlist.unknownRequirementIds | ForEach-Object { [string]$_ })
+$allowedUncovered = @($baseline.allowlist.uncoveredRequirementIds | ForEach-Object { [string]$_ })
+$currentUnknown = @($trace.gaps.unknownRequirementIds | ForEach-Object { [string]$_ } | Sort-Object -Unique)
+$currentUncovered = @($trace.gaps.requirementsWithoutTests | ForEach-Object { [string]$_ } | Sort-Object -Unique)
+
+$newUnknown = @($currentUnknown | Where-Object { $_ -notin $allowedUnknown })
+$newUncovered = @($currentUncovered | Where-Object { $_ -notin $allowedUncovered })
+
+$gateStatus = if ($newUnknown.Count -eq 0 -and $newUncovered.Count -eq 0) { 'pass' } else { 'fail' }
+$gateKind = if ($gateStatus -eq 'pass') { 'requirements_coverage_ok' } else { 'requirements_coverage_regression' }
+
+$summary = [ordered]@{
+  schema = 'requirements-verification/v1'
+  schemaVersion = '1.0.0'
+  generatedAtUtc = (Get-Date).ToUniversalTime().ToString('o')
+  traceMatrixPath = [IO.Path]::GetRelativePath($repoRoot, (Resolve-Path -LiteralPath $tracePath).Path).Replace('\\', '/')
+  baselinePolicyPath = [IO.Path]::GetRelativePath($repoRoot, (Resolve-Path -LiteralPath $BaselinePolicyPath).Path).Replace('\\', '/')
+  metrics = [ordered]@{
+    requirementTotal = [int]$trace.summary.requirements.total
+    requirementCovered = [int]$trace.summary.requirements.covered
+    requirementUncovered = [int]$trace.summary.requirements.uncovered
+    unknownRequirementIds = @($currentUnknown)
+  }
+  deltas = [ordered]@{
+    newUnknownRequirementIds = @($newUnknown)
+    newUncoveredRequirementIds = @($newUncovered)
+  }
+  outcome = [ordered]@{
+    status = $gateStatus
+    kind = $gateKind
+  }
+}
+
+$summaryPath = Join-Path $OutDir 'verification-summary.json'
+$summary | ConvertTo-Json -Depth 12 | Set-Content -LiteralPath $summaryPath -Encoding utf8
+
+if ($GitHubOutputPath) {
+  "verification-summary-path=$summaryPath" | Out-File -FilePath $GitHubOutputPath -Encoding utf8 -Append
+  "verification-status=$gateStatus" | Out-File -FilePath $GitHubOutputPath -Encoding utf8 -Append
+}
+
+if ($StepSummaryPath) {
+  $lines = @(
+    '## Requirements Verification Gate',
+    '',
+    "- Status: **$gateStatus**",
+    "- Kind: $gateKind",
+    "- Summary: $([IO.Path]::GetRelativePath($repoRoot, $summaryPath).Replace('\\', '/'))",
+    "- Trace Matrix: $($summary.traceMatrixPath)",
+    "- Requirements covered: $($summary.metrics.requirementCovered)/$($summary.metrics.requirementTotal)",
+    "- Unknown requirement IDs: $($currentUnknown.Count)",
+    "- New unknown requirement IDs: $($newUnknown.Count)",
+    "- New uncovered requirement IDs: $($newUncovered.Count)"
+  )
+
+  if ($newUnknown.Count -gt 0) {
+    $lines += ''
+    $lines += '### New Unknown Requirement IDs'
+    foreach ($id in $newUnknown) { $lines += "- $id" }
+  }
+
+  if ($newUncovered.Count -gt 0) {
+    $lines += ''
+    $lines += '### New Uncovered Requirement IDs'
+    foreach ($id in $newUncovered) { $lines += "- $id" }
+  }
+
+  ($lines -join "`n") | Out-File -FilePath $StepSummaryPath -Encoding utf8 -Append
+}
+
+Write-Host "[verification] status=$gateStatus summary=$summaryPath" -ForegroundColor Cyan
+if ($gateStatus -ne 'pass') {
+  Write-Error '[verification] requirements verification gate failed due to regression.'
+  exit 1
+}

--- a/tools/policy/requirements-verification-baseline.json
+++ b/tools/policy/requirements-verification-baseline.json
@@ -1,0 +1,21 @@
+{
+  "schema": "requirements-verification-baseline/v1",
+  "schemaVersion": "1.0.0",
+  "allowlist": {
+    "unknownRequirementIds": [
+      "REQ_ONE",
+      "REQ_UNKNOWN"
+    ],
+    "uncoveredRequirementIds": [
+      "DOTNET_CLI_POWERSHELL_MAPPING",
+      "DOTNET_CLI_RELEASE_ASSET",
+      "DOTNET_CLI_RELEASE_CHECKLIST",
+      "INDEX",
+      "PESTER_SINGLE_INVOKER",
+      "SINGLE_INVOKER_SYSTEM_DEFINITION",
+      "WATCH_AND_QUEUE",
+      "WATCHER_BUSY_LOOP",
+      "WATCHER_LIVE_FEED"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add new post-merge workflow `.github/workflows/verification.yml` triggered on push to `develop`
- add `tools/Verify-RequirementsGate.ps1` to run traceability matrix generation and enforce a deterministic requirements-verification gate
- emit machine-readable gate output (`tests/results/_agent/verification/verification-summary.json`) with schema/version and explicit pass/fail outcome
- upload verification artifacts (`trace-matrix.json`, `trace-matrix.html`, `verification-summary.json`) for every run
- add baseline policy allowlist (`tools/policy/requirements-verification-baseline.json`) so gate fails on regressions (new unknown or newly uncovered requirement IDs)

## Validation
- `pwsh -NoLogo -NonInteractive -NoProfile -File tools/Verify-RequirementsGate.ps1 -TestsPath tests -ResultsRoot tests/results -OutDir tests/results/_agent/verification -BaselinePolicyPath tools/policy/requirements-verification-baseline.json`
- `pwsh -NoLogo -NonInteractive -NoProfile -File tools/PrePush-Checks.ps1`

Closes #182