### PR TITLE
Add regression coverage and hardening for requirements verification gate (#186)

### DIFF
--- a/docs/knowledgebase/FEATURE_BRANCH_POLICY.md
+++ b/docs/knowledgebase/FEATURE_BRANCH_POLICY.md
@@ -83,6 +83,24 @@ checked into `tools/priority/policy.json` so `priority:policy` stays authoritati
 - **Admin bypass**: leave disabled; administrators should only intervene when `priority:policy` confirms parity.
 - **Reapply**: Use `node tools/npm/run-script.mjs priority:policy -- --apply` to push the manifest configuration when drift is detected.
 
+#### Requirements verification gate (local runbook)
+
+- Generate and evaluate the gate summary locally:
+
+  ```powershell
+  pwsh -NoLogo -NonInteractive -NoProfile -File tools/Verify-RequirementsGate.ps1 \
+    -TestsPath tests \
+    -ResultsRoot tests/results \
+    -OutDir tests/results/_agent/verification \
+    -BaselinePolicyPath tools/policy/requirements-verification-baseline.json
+  ```
+
+- Run focused regression tests for baseline pass/fail logic:
+
+  ```powershell
+  ./Invoke-PesterTests.ps1 -IncludePatterns 'RequirementsVerificationGate.Tests.ps1'
+  ```
+
 ### `main`
 - **Ruleset**: `8614140` (repository ruleset, scope `refs/heads/main`).
 - **Allowed merges**: queue-managed squash enforced by the `merge_queue` rule (`merge_method=SQUASH`); direct merges and

--- a/tests/RequirementsVerificationGate.Tests.ps1
+++ b/tests/RequirementsVerificationGate.Tests.ps1
@@ -1,0 +1,152 @@
+Describe 'Requirements verification gate' {
+  BeforeAll {
+    $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+    $scriptPath = Join-Path $repoRoot 'tools/Verify-RequirementsGate.ps1'
+
+    function Invoke-GateScript {
+      param(
+        [Parameter(Mandatory)] [string]$TracePath,
+        [Parameter(Mandatory)] [string]$BaselinePath,
+        [Parameter(Mandatory)] [string]$OutDir,
+        [Parameter(Mandatory)] [string]$GhOut,
+        [Parameter(Mandatory)] [string]$StepSummary
+      )
+
+      $psi = [System.Diagnostics.ProcessStartInfo]::new()
+      $psi.FileName = 'pwsh'
+      $psi.Arguments = ('-NoLogo -NoProfile -NonInteractive -File "{0}" -TraceMatrixPath "{1}" -BaselinePolicyPath "{2}" -OutDir "{3}" -GitHubOutputPath "{4}" -StepSummaryPath "{5}"' -f $scriptPath, $TracePath, $BaselinePath, $OutDir, $GhOut, $StepSummary)
+      $psi.WorkingDirectory = $repoRoot
+      $psi.RedirectStandardOutput = $true
+      $psi.RedirectStandardError = $true
+      $psi.UseShellExecute = $false
+      $psi.CreateNoWindow = $true
+
+      $proc = [System.Diagnostics.Process]::Start($psi)
+      $stdout = $proc.StandardOutput.ReadToEnd()
+      $stderr = $proc.StandardError.ReadToEnd()
+      $proc.WaitForExit()
+
+      return [pscustomobject]@{
+        ExitCode = $proc.ExitCode
+        StdOut = $stdout
+        StdErr = $stderr
+      }
+    }
+
+    function Write-JsonFile {
+      param(
+        [Parameter(Mandatory)] [string]$Path,
+        [Parameter(Mandatory)] [object]$Data
+      )
+      $Data | ConvertTo-Json -Depth 12 | Set-Content -LiteralPath $Path -Encoding utf8
+    }
+  }
+
+  It 'passes when trace matrix matches allowlist baseline' {
+    $outDir = Join-Path $TestDrive 'out-pass'
+    New-Item -ItemType Directory -Path $outDir -Force | Out-Null
+
+    $tracePath = Join-Path $TestDrive 'trace-pass.json'
+    $baselinePath = Join-Path $TestDrive 'baseline-pass.json'
+    $ghOut = Join-Path $TestDrive 'gh-output-pass.txt'
+    $stepSummary = Join-Path $TestDrive 'summary-pass.md'
+
+    Write-JsonFile -Path $tracePath -Data @{
+      summary = @{ requirements = @{ total = 3; covered = 2; uncovered = 1 } }
+      gaps = @{
+        unknownRequirementIds = @('REQ_ONE')
+        requirementsWithoutTests = @('DOTNET_CLI_RELEASE_ASSET')
+      }
+    }
+
+    Write-JsonFile -Path $baselinePath -Data @{
+      schema = 'requirements-verification-baseline/v1'
+      schemaVersion = '1.0.0'
+      allowlist = @{
+        unknownRequirementIds = @('REQ_ONE')
+        uncoveredRequirementIds = @('DOTNET_CLI_RELEASE_ASSET')
+      }
+    }
+
+    $run = Invoke-GateScript -TracePath $tracePath -BaselinePath $baselinePath -OutDir $outDir -GhOut $ghOut -StepSummary $stepSummary
+    $run.ExitCode | Should -Be 0
+
+    $summaryPath = Join-Path $outDir 'verification-summary.json'
+    Test-Path -LiteralPath $summaryPath | Should -BeTrue
+    $summary = Get-Content -LiteralPath $summaryPath -Raw | ConvertFrom-Json
+    $summary.outcome.status | Should -Be 'pass'
+    $summary.traceSource | Should -Be 'provided'
+    $summary.deltas.newUnknownRequirementIds.Count | Should -Be 0
+    $summary.deltas.newUncoveredRequirementIds.Count | Should -Be 0
+
+    (Get-Content -LiteralPath $ghOut -Raw) | Should -Match 'verification-status=pass'
+  }
+
+  It 'fails when new unknown requirement IDs are introduced' {
+    $outDir = Join-Path $TestDrive 'out-new-unknown'
+    New-Item -ItemType Directory -Path $outDir -Force | Out-Null
+
+    $tracePath = Join-Path $TestDrive 'trace-new-unknown.json'
+    $baselinePath = Join-Path $TestDrive 'baseline-new-unknown.json'
+    $ghOut = Join-Path $TestDrive 'gh-output-new-unknown.txt'
+    $stepSummary = Join-Path $TestDrive 'summary-new-unknown.md'
+
+    Write-JsonFile -Path $tracePath -Data @{
+      summary = @{ requirements = @{ total = 2; covered = 2; uncovered = 0 } }
+      gaps = @{
+        unknownRequirementIds = @('REQ_NEW')
+        requirementsWithoutTests = @()
+      }
+    }
+
+    Write-JsonFile -Path $baselinePath -Data @{
+      schema = 'requirements-verification-baseline/v1'
+      schemaVersion = '1.0.0'
+      allowlist = @{
+        unknownRequirementIds = @('REQ_ONE')
+        uncoveredRequirementIds = @()
+      }
+    }
+
+    $run = Invoke-GateScript -TracePath $tracePath -BaselinePath $baselinePath -OutDir $outDir -GhOut $ghOut -StepSummary $stepSummary
+    $run.ExitCode | Should -Be 1
+
+    $summary = Get-Content -LiteralPath (Join-Path $outDir 'verification-summary.json') -Raw | ConvertFrom-Json
+    $summary.outcome.status | Should -Be 'fail'
+    $summary.deltas.newUnknownRequirementIds | Should -Contain 'REQ_NEW'
+  }
+
+  It 'fails when new uncovered requirement IDs are introduced' {
+    $outDir = Join-Path $TestDrive 'out-new-uncovered'
+    New-Item -ItemType Directory -Path $outDir -Force | Out-Null
+
+    $tracePath = Join-Path $TestDrive 'trace-new-uncovered.json'
+    $baselinePath = Join-Path $TestDrive 'baseline-new-uncovered.json'
+    $ghOut = Join-Path $TestDrive 'gh-output-new-uncovered.txt'
+    $stepSummary = Join-Path $TestDrive 'summary-new-uncovered.md'
+
+    Write-JsonFile -Path $tracePath -Data @{
+      summary = @{ requirements = @{ total = 4; covered = 3; uncovered = 1 } }
+      gaps = @{
+        unknownRequirementIds = @()
+        requirementsWithoutTests = @('REQ_UNCOVERED_NEW')
+      }
+    }
+
+    Write-JsonFile -Path $baselinePath -Data @{
+      schema = 'requirements-verification-baseline/v1'
+      schemaVersion = '1.0.0'
+      allowlist = @{
+        unknownRequirementIds = @()
+        uncoveredRequirementIds = @('REQ_EXISTING')
+      }
+    }
+
+    $run = Invoke-GateScript -TracePath $tracePath -BaselinePath $baselinePath -OutDir $outDir -GhOut $ghOut -StepSummary $stepSummary
+    $run.ExitCode | Should -Be 1
+
+    $summary = Get-Content -LiteralPath (Join-Path $outDir 'verification-summary.json') -Raw | ConvertFrom-Json
+    $summary.outcome.status | Should -Be 'fail'
+    $summary.deltas.newUncoveredRequirementIds | Should -Contain 'REQ_UNCOVERED_NEW'
+  }
+}

--- a/tools/Verify-RequirementsGate.ps1
+++ b/tools/Verify-RequirementsGate.ps1
@@ -3,6 +3,7 @@ param(
   [string]$TestsPath = 'tests',
   [string]$ResultsRoot = 'tests/results',
   [string]$OutDir = 'tests/results/_agent/verification',
+  [string]$TraceMatrixPath,
   [string]$BaselinePolicyPath = 'tools/policy/requirements-verification-baseline.json',
   [string]$GitHubOutputPath = $env:GITHUB_OUTPUT,
   [string]$StepSummaryPath = $env:GITHUB_STEP_SUMMARY
@@ -16,20 +17,44 @@ if (-not (Test-Path -LiteralPath $OutDir -PathType Container)) {
   New-Item -ItemType Directory -Path $OutDir -Force | Out-Null
 }
 
-$traceScript = Join-Path $repoRoot 'tools/Traceability-Matrix.ps1'
-if (-not (Test-Path -LiteralPath $traceScript -PathType Leaf)) {
-  throw "Traceability matrix script not found: $traceScript"
+$resolvedTracePath = $null
+if ($TraceMatrixPath) {
+  if (-not (Test-Path -LiteralPath $TraceMatrixPath -PathType Leaf)) {
+    throw "Trace matrix path does not exist: $TraceMatrixPath"
+  }
+  $resolvedTracePath = (Resolve-Path -LiteralPath $TraceMatrixPath).Path
+} else {
+  $traceScript = Join-Path $repoRoot 'tools/Traceability-Matrix.ps1'
+  if (-not (Test-Path -LiteralPath $traceScript -PathType Leaf)) {
+    throw "Traceability matrix script not found: $traceScript"
+  }
+
+  pwsh -NoLogo -NoProfile -File $traceScript -TestsPath $TestsPath -ResultsRoot $ResultsRoot -OutDir $OutDir -RenderHtml | Out-Host
+
+  $generatedTracePath = Join-Path $OutDir 'trace-matrix.json'
+  if (-not (Test-Path -LiteralPath $generatedTracePath -PathType Leaf)) {
+    throw "Traceability matrix output missing: $generatedTracePath"
+  }
+  $resolvedTracePath = (Resolve-Path -LiteralPath $generatedTracePath).Path
 }
 
-pwsh -NoLogo -NoProfile -File $traceScript -TestsPath $TestsPath -ResultsRoot $ResultsRoot -OutDir $OutDir -RenderHtml | Out-Host
-
-$tracePath = Join-Path $OutDir 'trace-matrix.json'
-if (-not (Test-Path -LiteralPath $tracePath -PathType Leaf)) {
-  throw "Traceability matrix output missing: $tracePath"
+if (-not (Test-Path -LiteralPath $BaselinePolicyPath -PathType Leaf)) {
+  throw "Baseline policy path does not exist: $BaselinePolicyPath"
 }
 
-$trace = Get-Content -LiteralPath $tracePath -Raw | ConvertFrom-Json -Depth 20
-$baseline = Get-Content -LiteralPath $BaselinePolicyPath -Raw | ConvertFrom-Json -Depth 10
+$trace = Get-Content -LiteralPath $resolvedTracePath -Raw | ConvertFrom-Json -Depth 20
+$baselineResolvedPath = (Resolve-Path -LiteralPath $BaselinePolicyPath).Path
+$baseline = Get-Content -LiteralPath $baselineResolvedPath -Raw | ConvertFrom-Json -Depth 10
+
+if (-not $baseline.allowlist) {
+  throw "Baseline policy is missing 'allowlist': $BaselinePolicyPath"
+}
+if (-not ($baseline.allowlist.PSObject.Properties.Name -contains 'unknownRequirementIds')) {
+  throw "Baseline policy is missing allowlist.unknownRequirementIds: $BaselinePolicyPath"
+}
+if (-not ($baseline.allowlist.PSObject.Properties.Name -contains 'uncoveredRequirementIds')) {
+  throw "Baseline policy is missing allowlist.uncoveredRequirementIds: $BaselinePolicyPath"
+}
 
 $allowedUnknown = @($baseline.allowlist.unknownRequirementIds | ForEach-Object { [string]$_ })
 $allowedUncovered = @($baseline.allowlist.uncoveredRequirementIds | ForEach-Object { [string]$_ })
@@ -46,8 +71,9 @@ $summary = [ordered]@{
   schema = 'requirements-verification/v1'
   schemaVersion = '1.0.0'
   generatedAtUtc = (Get-Date).ToUniversalTime().ToString('o')
-  traceMatrixPath = [IO.Path]::GetRelativePath($repoRoot, (Resolve-Path -LiteralPath $tracePath).Path).Replace('\\', '/')
-  baselinePolicyPath = [IO.Path]::GetRelativePath($repoRoot, (Resolve-Path -LiteralPath $BaselinePolicyPath).Path).Replace('\\', '/')
+  traceMatrixPath = [IO.Path]::GetRelativePath($repoRoot, $resolvedTracePath).Replace('\\', '/')
+  baselinePolicyPath = [IO.Path]::GetRelativePath($repoRoot, $baselineResolvedPath).Replace('\\', '/')
+  traceSource = if ($TraceMatrixPath) { 'provided' } else { 'generated' }
   metrics = [ordered]@{
     requirementTotal = [int]$trace.summary.requirements.total
     requirementCovered = [int]$trace.summary.requirements.covered


### PR DESCRIPTION
## Summary
- harden `tools/Verify-RequirementsGate.ps1` with deterministic input handling:
  - optional `-TraceMatrixPath` override for reproducible local/CI helper use
  - explicit baseline policy validation for required allowlist keys
  - explicit `traceSource` metadata in machine-readable summary
- add regression tests in `tests/RequirementsVerificationGate.Tests.ps1` covering:
  - baseline pass case
  - fail on new unknown requirement IDs
  - fail on new uncovered requirement IDs
- document reproducible local verification commands in `docs/knowledgebase/FEATURE_BRANCH_POLICY.md`

## Validation
- `pwsh -NoLogo -NonInteractive -NoProfile -File tools/Verify-RequirementsGate.ps1 -TestsPath tests -ResultsRoot tests/results -OutDir tests/results/_agent/verification -BaselinePolicyPath tools/policy/requirements-verification-baseline.json`
- `pwsh -NoLogo -NonInteractive -NoProfile -File Invoke-PesterTests.ps1 -IncludePatterns 'RequirementsVerificationGate.Tests.ps1' -IntegrationMode exclude -ResultsPath tests/results`
- `pwsh -NoLogo -NonInteractive -NoProfile -File tools/PrePush-Checks.ps1`

Closes #186