### PR TITLE
Add schema validation contract for requirements verification summary (#188)

### DIFF
--- a/.github/workflows/verification.yml
+++ b/.github/workflows/verification.yml
@@ -35,6 +35,13 @@ jobs:
             -GitHubOutputPath $env:GITHUB_OUTPUT `
             -StepSummaryPath $env:GITHUB_STEP_SUMMARY
 
+      - name: Validate verification summary schema
+        shell: pwsh
+        run: |
+          pwsh -NoLogo -NonInteractive -NoProfile -File tools/Invoke-JsonSchemaLite.ps1 `
+            -JsonPath tests/results/_agent/verification/verification-summary.json `
+            -SchemaPath docs/schemas/requirements-verification-v1.schema.json
+
       - name: Upload verification artifacts
         if: always()
         uses: actions/upload-artifact@v5

--- a/docs/knowledgebase/FEATURE_BRANCH_POLICY.md
+++ b/docs/knowledgebase/FEATURE_BRANCH_POLICY.md
@@ -101,6 +101,14 @@ checked into `tools/priority/policy.json` so `priority:policy` stays authoritati
   ./Invoke-PesterTests.ps1 -IncludePatterns 'RequirementsVerificationGate.Tests.ps1'
   ```
 
+- Validate the gate output contract schema explicitly:
+
+  ```powershell
+  pwsh -NoLogo -NonInteractive -NoProfile -File tools/Invoke-JsonSchemaLite.ps1 \
+    -JsonPath tests/results/_agent/verification/verification-summary.json \
+    -SchemaPath docs/schemas/requirements-verification-v1.schema.json
+  ```
+
 ### `main`
 - **Ruleset**: `8614140` (repository ruleset, scope `refs/heads/main`).
 - **Allowed merges**: queue-managed squash enforced by the `merge_queue` rule (`merge_method=SQUASH`); direct merges and

--- a/docs/schemas/requirements-verification-v1.schema.json
+++ b/docs/schemas/requirements-verification-v1.schema.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "requirements-verification/v1",
+  "type": "object",
+  "required": [
+    "schema",
+    "schemaVersion",
+    "generatedAtUtc",
+    "traceMatrixPath",
+    "baselinePolicyPath",
+    "traceSource",
+    "metrics",
+    "deltas",
+    "outcome"
+  ],
+  "properties": {
+    "schema": { "const": "requirements-verification/v1" },
+    "schemaVersion": { "type": "string" },
+    "generatedAtUtc": { "type": "string", "format": "date-time" },
+    "traceMatrixPath": { "type": "string" },
+    "baselinePolicyPath": { "type": "string" },
+    "traceSource": { "type": "string", "enum": ["generated", "provided"] },
+    "metrics": {
+      "type": "object",
+      "required": [
+        "requirementTotal",
+        "requirementCovered",
+        "requirementUncovered",
+        "unknownRequirementIds"
+      ],
+      "properties": {
+        "requirementTotal": { "type": "integer", "minimum": 0 },
+        "requirementCovered": { "type": "integer", "minimum": 0 },
+        "requirementUncovered": { "type": "integer", "minimum": 0 },
+        "unknownRequirementIds": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      },
+      "additionalProperties": false
+    },
+    "deltas": {
+      "type": "object",
+      "required": [
+        "newUnknownRequirementIds",
+        "newUncoveredRequirementIds"
+      ],
+      "properties": {
+        "newUnknownRequirementIds": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "newUncoveredRequirementIds": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      },
+      "additionalProperties": false
+    },
+    "outcome": {
+      "type": "object",
+      "required": ["status", "kind"],
+      "properties": {
+        "status": { "type": "string", "enum": ["pass", "fail"] },
+        "kind": {
+          "type": "string",
+          "enum": ["requirements_coverage_ok", "requirements_coverage_regression"]
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/tests/RequirementsVerificationGate.Tests.ps1
+++ b/tests/RequirementsVerificationGate.Tests.ps1
@@ -2,6 +2,8 @@ Describe 'Requirements verification gate' {
   BeforeAll {
     $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
     $scriptPath = Join-Path $repoRoot 'tools/Verify-RequirementsGate.ps1'
+    $schemaLitePath = Join-Path $repoRoot 'tools/Invoke-JsonSchemaLite.ps1'
+    $summarySchemaPath = Join-Path $repoRoot 'docs/schemas/requirements-verification-v1.schema.json'
 
     function Invoke-GateScript {
       param(
@@ -80,6 +82,10 @@ Describe 'Requirements verification gate' {
     $summary.deltas.newUncoveredRequirementIds.Count | Should -Be 0
 
     (Get-Content -LiteralPath $ghOut -Raw) | Should -Match 'verification-status=pass'
+
+    $schemaValidation = & pwsh -NoLogo -NonInteractive -NoProfile -File $schemaLitePath -JsonPath $summaryPath -SchemaPath $summarySchemaPath
+    $LASTEXITCODE | Should -Be 0
+    ($schemaValidation -join "`n") | Should -Match 'Schema-lite validation passed.'
   }
 
   It 'fails when new unknown requirement IDs are introduced' {


### PR DESCRIPTION
## Summary
- add deterministic schema artifact for requirements verification summary output:
  - `docs/schemas/requirements-verification-v1.schema.json`
- enforce schema validation in `.github/workflows/verification.yml` after gate generation
- extend regression coverage in `tests/RequirementsVerificationGate.Tests.ps1` to assert generated `verification-summary.json` validates against the schema
- document reproducible local schema-validation command in `docs/knowledgebase/FEATURE_BRANCH_POLICY.md`

## Validation
- `pwsh -NoLogo -NonInteractive -NoProfile -File Invoke-PesterTests.ps1 -IncludePatterns 'RequirementsVerificationGate.Tests.ps1' -IntegrationMode exclude -ResultsPath tests/results`
- `pwsh -NoLogo -NonInteractive -NoProfile -File tools/Verify-RequirementsGate.ps1 -TestsPath tests -ResultsRoot tests/results -OutDir tests/results/_agent/verification -BaselinePolicyPath tools/policy/requirements-verification-baseline.json`
- `pwsh -NoLogo -NonInteractive -NoProfile -File tools/Invoke-JsonSchemaLite.ps1 -JsonPath tests/results/_agent/verification/verification-summary.json -SchemaPath docs/schemas/requirements-verification-v1.schema.json`
- `pwsh -NoLogo -NonInteractive -NoProfile -File tools/PrePush-Checks.ps1`

Closes #188