### PR TITLE
Add drift guard for requirements verification check naming (#190)

### DIFF
--- a/.github/workflows/workflows-lint.yml
+++ b/.github/workflows/workflows-lint.yml
@@ -28,3 +28,8 @@ jobs:
       - name: Run actionlint
         run: ./bin/actionlint -color
 
+      - name: Assert requirements-verification check contract
+        shell: pwsh
+        run: |
+          pwsh -NoLogo -NonInteractive -NoProfile -File tools/Assert-RequirementsVerificationCheckContract.ps1
+

--- a/docs/knowledgebase/FEATURE_BRANCH_POLICY.md
+++ b/docs/knowledgebase/FEATURE_BRANCH_POLICY.md
@@ -109,6 +109,12 @@ checked into `tools/priority/policy.json` so `priority:policy` stays authoritati
     -SchemaPath docs/schemas/requirements-verification-v1.schema.json
   ```
 
+- Assert check naming drift guard (workflow + policy contract alignment):
+
+  ```powershell
+  pwsh -NoLogo -NonInteractive -NoProfile -File tools/Assert-RequirementsVerificationCheckContract.ps1
+  ```
+
 ### `main`
 - **Ruleset**: `8614140` (repository ruleset, scope `refs/heads/main`).
 - **Allowed merges**: queue-managed squash enforced by the `merge_queue` rule (`merge_method=SQUASH`); direct merges and

--- a/tests/RequirementsVerificationCheckContract.Tests.ps1
+++ b/tests/RequirementsVerificationCheckContract.Tests.ps1
@@ -1,0 +1,93 @@
+Describe 'Requirements verification check naming contract' {
+  BeforeAll {
+    $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+    $scriptPath = Join-Path $repoRoot 'tools/Assert-RequirementsVerificationCheckContract.ps1'
+
+    function Invoke-ContractScript {
+      param(
+        [Parameter(Mandatory)][string]$WorkflowPath,
+        [Parameter(Mandatory)][string]$BranchPolicyPath,
+        [Parameter(Mandatory)][string]$PriorityPolicyPath
+      )
+
+      $psi = [System.Diagnostics.ProcessStartInfo]::new()
+      $psi.FileName = 'pwsh'
+      $psi.Arguments = ('-NoLogo -NoProfile -NonInteractive -File "{0}" -WorkflowPath "{1}" -BranchRequiredChecksPath "{2}" -PriorityPolicyPath "{3}"' -f $scriptPath, $WorkflowPath, $BranchPolicyPath, $PriorityPolicyPath)
+      $psi.WorkingDirectory = $repoRoot
+      $psi.RedirectStandardOutput = $true
+      $psi.RedirectStandardError = $true
+      $psi.UseShellExecute = $false
+      $psi.CreateNoWindow = $true
+
+      $proc = [System.Diagnostics.Process]::Start($psi)
+      $stdout = $proc.StandardOutput.ReadToEnd()
+      $stderr = $proc.StandardError.ReadToEnd()
+      $proc.WaitForExit()
+
+      return [pscustomobject]@{
+        ExitCode = $proc.ExitCode
+        StdOut = $stdout
+        StdErr = $stderr
+      }
+    }
+
+    function Write-JsonFile {
+      param(
+        [Parameter(Mandatory)][string]$Path,
+        [Parameter(Mandatory)][object]$Data
+      )
+      $Data | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $Path -Encoding utf8
+    }
+  }
+
+  It 'passes against repository contract files' {
+    $workflowPath = Join-Path $repoRoot '.github/workflows/verification.yml'
+    $branchPolicyPath = Join-Path $repoRoot 'tools/policy/branch-required-checks.json'
+    $priorityPolicyPath = Join-Path $repoRoot 'tools/priority/policy.json'
+
+    $run = Invoke-ContractScript -WorkflowPath $workflowPath -BranchPolicyPath $branchPolicyPath -PriorityPolicyPath $priorityPolicyPath
+    $run.ExitCode | Should -Be 0
+    ($run.StdOut + $run.StdErr) | Should -Match 'verification-check-contract'
+  }
+
+  It 'fails when workflow job name drifts from required check context' {
+    $tmpWorkflow = Join-Path $TestDrive 'verification.yml'
+    $tmpBranchPolicy = Join-Path $TestDrive 'branch-required-checks.json'
+    $tmpPriorityPolicy = Join-Path $TestDrive 'policy.json'
+
+    @'
+name: Requirements Verification
+on:
+  workflow_dispatch:
+jobs:
+  verification:
+    name: verification-renamed
+    runs-on: ubuntu-latest
+'@ | Set-Content -LiteralPath $tmpWorkflow -Encoding utf8
+
+    Write-JsonFile -Path $tmpBranchPolicy -Data @{
+      schema = 'branch-required-checks/v1'
+      schemaVersion = '1.0.0'
+      branches = @{
+        develop = @('Requirements Verification / requirements-verification')
+      }
+    }
+
+    Write-JsonFile -Path $tmpPriorityPolicy -Data @{
+      branches = @{
+        develop = @{
+          required_status_checks = @('Requirements Verification / requirements-verification')
+        }
+      }
+      rulesets = @{
+        '8811898' = @{
+          required_status_checks = @('Requirements Verification / requirements-verification')
+        }
+      }
+    }
+
+    $run = Invoke-ContractScript -WorkflowPath $tmpWorkflow -BranchPolicyPath $tmpBranchPolicy -PriorityPolicyPath $tmpPriorityPolicy
+    $run.ExitCode | Should -Be 1
+    ($run.StdOut + $run.StdErr) | Should -Match 'Workflow job name mismatch'
+  }
+}

--- a/tools/Assert-RequirementsVerificationCheckContract.ps1
+++ b/tools/Assert-RequirementsVerificationCheckContract.ps1
@@ -1,0 +1,87 @@
+[CmdletBinding()]
+param(
+  [string]$WorkflowPath = '.github/workflows/verification.yml',
+  [string]$BranchRequiredChecksPath = 'tools/policy/branch-required-checks.json',
+  [string]$PriorityPolicyPath = 'tools/priority/policy.json',
+  [string]$BranchName = 'develop',
+  [string]$RulesetId = '8811898',
+  [string]$WorkflowName = 'Requirements Verification',
+  [string]$JobId = 'verification',
+  [string]$JobName = 'requirements-verification'
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$errors = New-Object System.Collections.Generic.List[string]
+
+function Add-ContractError {
+  param([string]$Message)
+  $errors.Add($Message) | Out-Null
+}
+
+function Read-JsonFile {
+  param([string]$Path)
+  if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+    throw "File not found: $Path"
+  }
+  return (Get-Content -LiteralPath $Path -Raw | ConvertFrom-Json -Depth 20)
+}
+
+if (-not (Test-Path -LiteralPath $WorkflowPath -PathType Leaf)) {
+  throw "Workflow file not found: $WorkflowPath"
+}
+
+$workflowContent = Get-Content -LiteralPath $WorkflowPath -Raw
+$expectedCheckName = "$WorkflowName / $JobName"
+
+$workflowNamePattern = '(?m)^name:\s*' + [regex]::Escape($WorkflowName) + '\s*$'
+if (-not [regex]::IsMatch($workflowContent, $workflowNamePattern)) {
+  Add-ContractError "Workflow name mismatch in $WorkflowPath (expected '$WorkflowName')."
+}
+
+$jobIdPattern = '(?m)^\s{2}' + [regex]::Escape($JobId) + ':\s*$'
+if (-not [regex]::IsMatch($workflowContent, $jobIdPattern)) {
+  Add-ContractError "Workflow job id '$JobId' is missing in $WorkflowPath."
+}
+
+$jobNamePattern = '(?m)^\s{4}name:\s*' + [regex]::Escape($JobName) + '\s*$'
+if (-not [regex]::IsMatch($workflowContent, $jobNamePattern)) {
+  Add-ContractError "Workflow job name mismatch in $WorkflowPath (expected '$JobName')."
+}
+
+$branchPolicy = Read-JsonFile -Path $BranchRequiredChecksPath
+if (-not $branchPolicy.branches) {
+  Add-ContractError "Missing branches node in $BranchRequiredChecksPath."
+} else {
+  $developChecks = @($branchPolicy.branches.$BranchName)
+  if ($developChecks.Count -eq 0) {
+    Add-ContractError "Missing required checks for branch '$BranchName' in $BranchRequiredChecksPath."
+  } elseif ($developChecks -notcontains $expectedCheckName) {
+    Add-ContractError "Required check '$expectedCheckName' missing from $BranchRequiredChecksPath for branch '$BranchName'."
+  }
+}
+
+$priorityPolicy = Read-JsonFile -Path $PriorityPolicyPath
+$priorityBranchChecks = @($priorityPolicy.branches.$BranchName.required_status_checks)
+if ($priorityBranchChecks.Count -eq 0) {
+  Add-ContractError "Missing priority branch checks for '$BranchName' in $PriorityPolicyPath."
+} elseif ($priorityBranchChecks -notcontains $expectedCheckName) {
+  Add-ContractError "Required check '$expectedCheckName' missing from $PriorityPolicyPath branch '$BranchName'."
+}
+
+$rulesetChecks = @($priorityPolicy.rulesets.$RulesetId.required_status_checks)
+if ($rulesetChecks.Count -eq 0) {
+  Add-ContractError "Missing ruleset '$RulesetId' required checks in $PriorityPolicyPath."
+} elseif ($rulesetChecks -notcontains $expectedCheckName) {
+  Add-ContractError "Required check '$expectedCheckName' missing from ruleset '$RulesetId' in $PriorityPolicyPath."
+}
+
+if ($errors.Count -gt 0) {
+  foreach ($errorMessage in $errors) {
+    Write-Error $errorMessage
+  }
+  exit 1
+}
+
+Write-Host "[verification-check-contract] OK: $expectedCheckName" -ForegroundColor Green

--- a/tools/PrePush-Checks.ps1
+++ b/tools/PrePush-Checks.ps1
@@ -126,6 +126,21 @@ if ($code -ne 0) {
 }
 Write-Host '[pre-push] actionlint OK' -ForegroundColor Green
 
+$verificationContractScript = Join-Path $root 'tools' 'Assert-RequirementsVerificationCheckContract.ps1'
+if (Test-Path -LiteralPath $verificationContractScript -PathType Leaf) {
+  Write-Host '[pre-push] Verifying requirements-verification check naming contract' -ForegroundColor Cyan
+  Push-Location $root
+  try {
+    pwsh -NoLogo -NonInteractive -NoProfile -File $verificationContractScript
+    if ($LASTEXITCODE -ne 0) {
+      throw "Assert-RequirementsVerificationCheckContract.ps1 failed (exit=$LASTEXITCODE)."
+    }
+  } finally {
+    Pop-Location | Out-Null
+  }
+  Write-Host '[pre-push] requirements-verification check contract OK' -ForegroundColor Green
+}
+
 $updateReportScript = Join-Path $root 'tools' 'icon-editor' 'Update-IconEditorFixtureReport.ps1'
 if (Test-Path -LiteralPath $updateReportScript -PathType Leaf) {
   $skipLegacyFixtureChecks = $SkipIconEditorFixtureChecks `


### PR DESCRIPTION
## Summary
- add deterministic drift-guard script `tools/Assert-RequirementsVerificationCheckContract.ps1` that enforces alignment across:
  - `.github/workflows/verification.yml` workflow/job naming
  - `tools/policy/branch-required-checks.json` required check contract
  - `tools/priority/policy.json` branch + ruleset required status checks
- wire guard into local pre-merge checks via `tools/PrePush-Checks.ps1`
- wire guard into CI via `.github/workflows/workflows-lint.yml`
- add regression tests in `tests/RequirementsVerificationCheckContract.Tests.ps1` (pass + naming-drift failure)
- document local guard invocation in `docs/knowledgebase/FEATURE_BRANCH_POLICY.md`

## Validation
- `pwsh -NoLogo -NonInteractive -NoProfile -File Invoke-PesterTests.ps1 -IncludePatterns 'RequirementsVerificationCheckContract.Tests.ps1' -IntegrationMode exclude -ResultsPath tests/results`
- `pwsh -NoLogo -NonInteractive -NoProfile -File tools/Assert-RequirementsVerificationCheckContract.ps1`
- `pwsh -NoLogo -NonInteractive -NoProfile -File tools/PrePush-Checks.ps1`

Closes #190