### PR TITLE
Add helper-level contract tests for verification required-check inclusion (#192)

### DIFF
--- a/docs/knowledgebase/FEATURE_BRANCH_POLICY.md
+++ b/docs/knowledgebase/FEATURE_BRANCH_POLICY.md
@@ -115,6 +115,20 @@ checked into `tools/priority/policy.json` so `priority:policy` stays authoritati
   pwsh -NoLogo -NonInteractive -NoProfile -File tools/Assert-RequirementsVerificationCheckContract.ps1
   ```
 
+- Validate branch-protection helper contract deterministically (explicitly includes
+  `Requirements Verification / requirements-verification` in develop policy):
+
+  ```powershell
+  pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Path 'tests/SessionIndex.BranchProtection.Tests.ps1','tests/GetBranchProtectionRequiredChecks.Tests.ps1','tests/RequirementsVerificationCheckContract.Tests.ps1' -Output Detailed"
+  ```
+
+- Optional parity run for non-LV checks using the published tools image:
+
+  ```powershell
+  $env:COMPAREVI_TOOLS_IMAGE = 'ghcr.io/svelderrainruiz/comparevi-tools:latest'
+  pwsh -NoLogo -NoProfile -File tools/Run-NonLVChecksInDocker.ps1 -UseToolsImage
+  ```
+
 ### `main`
 - **Ruleset**: `8614140` (repository ruleset, scope `refs/heads/main`).
 - **Allowed merges**: queue-managed squash enforced by the `merge_queue` rule (`merge_method=SQUASH`); direct merges and

--- a/tests/GetBranchProtectionRequiredChecks.Tests.ps1
+++ b/tests/GetBranchProtectionRequiredChecks.Tests.ps1
@@ -2,6 +2,7 @@ Describe 'Get-BranchProtectionRequiredChecks' -Tag 'Unit' {
   BeforeAll {
     $repoRoot = (Get-Location).Path
     Set-Variable -Name scriptPath -Scope Script -Value (Join-Path $repoRoot 'tools/Get-BranchProtectionRequiredChecks.ps1')
+    Set-Variable -Name requiredVerificationCheck -Scope Script -Value 'Requirements Verification / requirements-verification'
   }
 
   It 'returns contexts when API succeeds' {
@@ -10,10 +11,12 @@ Describe 'Get-BranchProtectionRequiredChecks' -Tag 'Unit' {
         required_status_checks = [pscustomobject]@{
           contexts = @()
           checks   = @(
-            @{ context = 'Validate / lint' },
-            @{ context = 'Validate / fixtures' },
             @{ context = 'Validate / session-index' },
+            @{ context = 'Validate / lint' },
+            @{ context = 'Requirements Verification / requirements-verification' },
+            @{ context = 'Validate / fixtures' },
             @{ context = 'Validate / issue-snapshot' },
+            @{ context = 'Validate / lint' },
             @{ context = 'Policy Guard (Upstream) / policy-guard' }
           )
         }
@@ -24,12 +27,45 @@ Describe 'Get-BranchProtectionRequiredChecks' -Tag 'Unit' {
     $result.status | Should -Be 'available'
     $expected = @(
       'Policy Guard (Upstream) / policy-guard',
+      'Requirements Verification / requirements-verification',
       'Validate / fixtures',
       'Validate / issue-snapshot',
       'Validate / lint',
       'Validate / session-index'
     )
-    ($result.contexts | Sort-Object) | Should -Be ($expected | Sort-Object)
+    $result.contexts | Should -Be $expected
+    $result.contexts | Should -Contain $script:requiredVerificationCheck
+    @($result.notes).Length | Should -Be 0
+  }
+
+  It 'normalizes contexts payload ordering and duplicates' {
+    Mock Invoke-RestMethod {
+      [pscustomobject]@{
+        required_status_checks = [pscustomobject]@{
+          contexts = @(
+            'Validate / session-index',
+            'Validate / lint',
+            'Requirements Verification / requirements-verification',
+            'Validate / fixtures',
+            'Validate / lint',
+            'Validate / issue-snapshot',
+            'Policy Guard (Upstream) / policy-guard'
+          )
+        }
+      }
+    }
+
+    $result = & $script:scriptPath -Owner 'octo' -Repository 'repo' -Branch 'develop' -Token 'token'
+    $result.status | Should -Be 'available'
+    $expected = @(
+      'Policy Guard (Upstream) / policy-guard',
+      'Requirements Verification / requirements-verification',
+      'Validate / fixtures',
+      'Validate / issue-snapshot',
+      'Validate / lint',
+      'Validate / session-index'
+    )
+    $result.contexts | Should -Be $expected
     @($result.notes).Length | Should -Be 0
   }
 

--- a/tests/SessionIndex.BranchProtection.Tests.ps1
+++ b/tests/SessionIndex.BranchProtection.Tests.ps1
@@ -10,6 +10,7 @@ Describe 'Update-SessionIndexBranchProtection' -Tag 'Unit' {
     Set-Variable -Name policy -Scope Script -Value $policyLocal
 
     Set-Variable -Name developExpected -Scope Script -Value @($policyLocal.branches.develop)
+    Set-Variable -Name requiredVerificationCheck -Scope Script -Value 'Requirements Verification / requirements-verification'
     Set-Variable -Name updateScript -Scope Script -Value (Join-Path $repoRootLocal 'tools/Update-SessionIndexBranchProtection.ps1')
     $newFixture = {
       param([string]$Name)
@@ -32,6 +33,10 @@ Describe 'Update-SessionIndexBranchProtection' -Tag 'Unit' {
       return $resultsDir
     }
     Set-Variable -Name newSessionIndexFixture -Scope Script -Value $newFixture
+  }
+
+  It 'requires develop policy to include requirements verification required check' {
+    $script:developExpected | Should -Contain $script:requiredVerificationCheck
   }
 
   It 'embeds branch protection contract when contexts align' {
@@ -171,6 +176,36 @@ Describe 'Update-SessionIndexBranchProtection' -Tag 'Unit' {
     $bp.actual.status | Should -Be 'available'
     ($bp.actual.contexts | Sort-Object) | Should -Be ($actual | Sort-Object)
     ($bp.PSObject.Properties.Name -contains 'notes') | Should -BeFalse
+  }
+
+  It 'emits deterministic branch protection output for equivalent context sets' {
+    $resultsDir = & $script:newSessionIndexFixture 'results-deterministic'
+    $firstProduced = @($script:developExpected + $script:requiredVerificationCheck + $script:developExpected[0])
+    $secondProduced = @($script:developExpected | Sort-Object -Descending)
+    $secondProduced += $script:requiredVerificationCheck
+
+    & $script:updateScript `
+      -ResultsDir $resultsDir `
+      -PolicyPath $script:policyPath `
+      -Branch 'develop' `
+      -ProducedContexts $firstProduced
+
+    $firstIndex = Get-Content -LiteralPath (Join-Path $resultsDir 'session-index.json') -Raw | ConvertFrom-Json
+    $firstBranchProtection = $firstIndex.branchProtection | ConvertTo-Json -Depth 10 -Compress
+
+    & $script:updateScript `
+      -ResultsDir $resultsDir `
+      -PolicyPath $script:policyPath `
+      -Branch 'develop' `
+      -ProducedContexts $secondProduced
+
+    $secondIndex = Get-Content -LiteralPath (Join-Path $resultsDir 'session-index.json') -Raw | ConvertFrom-Json
+    $secondBranchProtection = $secondIndex.branchProtection | ConvertTo-Json -Depth 10 -Compress
+
+    $secondIndex.branchProtection.result.status | Should -Be 'ok'
+    $secondIndex.branchProtection.result.reason | Should -Be 'aligned'
+    $secondBranchProtection | Should -Be $firstBranchProtection
+    $secondIndex.branchProtection.expected | Should -Contain $script:requiredVerificationCheck
   }
 
   It 'flags API errors when live context retrieval fails' {

--- a/tools/Get-BranchProtectionRequiredChecks.ps1
+++ b/tools/Get-BranchProtectionRequiredChecks.ps1
@@ -54,6 +54,7 @@ try {
       $contexts = @($statusSection.checks | ForEach-Object { $_.context } | Where-Object { $_ })
     }
   }
+  $contexts = @($contexts | Sort-Object -Unique)
   [pscustomobject]@{
     status   = 'available'
     contexts = $contexts


### PR DESCRIPTION
## Summary
- add explicit helper-level assertions that develop required checks include `Requirements Verification / requirements-verification`
- add deterministic-order regression coverage for branch-protection helper output
- document local deterministic validation commands, including parity run with published `ghcr.io/svelderrainruiz/comparevi-tools:latest`

## Testing
- pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Path 'tests/SessionIndex.BranchProtection.Tests.ps1','tests/GetBranchProtectionRequiredChecks.Tests.ps1','tests/RequirementsVerificationCheckContract.Tests.ps1' -Output Detailed"

Closes #192