### PR TITLE
Harden required-check drift coverage for helper validators (#194)

### DIFF
--- a/docs/knowledgebase/FEATURE_BRANCH_POLICY.md
+++ b/docs/knowledgebase/FEATURE_BRANCH_POLICY.md
@@ -122,6 +122,12 @@ checked into `tools/priority/policy.json` so `priority:policy` stays authoritati
   pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Path 'tests/SessionIndex.BranchProtection.Tests.ps1','tests/GetBranchProtectionRequiredChecks.Tests.ps1','tests/RequirementsVerificationCheckContract.Tests.ps1' -Output Detailed"
   ```
 
+- Validate policy helper drift coverage for develop and release required-check contracts:
+
+  ```powershell
+  node --test tools/priority/__tests__/check-policy-apply.test.mjs
+  ```
+
 - Optional parity run for non-LV checks using the published tools image:
 
   ```powershell

--- a/tests/SessionIndex.BranchProtection.Tests.ps1
+++ b/tests/SessionIndex.BranchProtection.Tests.ps1
@@ -10,6 +10,7 @@ Describe 'Update-SessionIndexBranchProtection' -Tag 'Unit' {
     Set-Variable -Name policy -Scope Script -Value $policyLocal
 
     Set-Variable -Name developExpected -Scope Script -Value @($policyLocal.branches.develop)
+    Set-Variable -Name releaseExpected -Scope Script -Value @($policyLocal.branches.'release/v0.5.2')
     Set-Variable -Name requiredVerificationCheck -Scope Script -Value 'Requirements Verification / requirements-verification'
     Set-Variable -Name updateScript -Scope Script -Value (Join-Path $repoRootLocal 'tools/Update-SessionIndexBranchProtection.ps1')
     $newFixture = {
@@ -176,6 +177,46 @@ Describe 'Update-SessionIndexBranchProtection' -Tag 'Unit' {
     $bp.actual.status | Should -Be 'available'
     ($bp.actual.contexts | Sort-Object) | Should -Be ($actual | Sort-Object)
     ($bp.PSObject.Properties.Name -contains 'notes') | Should -BeFalse
+  }
+
+  It 'embeds branch protection contract when release contexts align' {
+    $resultsDir = & $script:newSessionIndexFixture 'results-release-align'
+
+    & $script:updateScript `
+      -ResultsDir $resultsDir `
+      -PolicyPath $script:policyPath `
+      -Branch 'release/v0.5.2' `
+      -ProducedContexts $script:releaseExpected
+
+    $idx = Get-Content -LiteralPath (Join-Path $resultsDir 'session-index.json') -Raw | ConvertFrom-Json
+    $bp = $idx.branchProtection
+    $bp.branch | Should -Be 'release/v0.5.2'
+    ($bp.expected | Sort-Object) | Should -Be ($script:releaseExpected | Sort-Object)
+    ($bp.produced | Sort-Object) | Should -Be ($script:releaseExpected | Sort-Object)
+    $bp.result.status | Should -Be 'ok'
+    $bp.result.reason | Should -Be 'aligned'
+    ($bp.expected -contains $script:requiredVerificationCheck) | Should -BeFalse
+  }
+
+  It 'warns when required release contexts are missing' {
+    $resultsDir = & $script:newSessionIndexFixture 'results-release-missing'
+    $missingContext = ($script:releaseExpected | Where-Object { $_ -match 'publish' } | Select-Object -First 1)
+    if (-not $missingContext) {
+      $missingContext = $script:releaseExpected | Select-Object -First 1
+    }
+    $produced = $script:releaseExpected | Where-Object { $_ -ne $missingContext }
+
+    & $script:updateScript `
+      -ResultsDir $resultsDir `
+      -PolicyPath $script:policyPath `
+      -Branch 'release/v0.5.2' `
+      -ProducedContexts $produced
+
+    $idx = Get-Content -LiteralPath (Join-Path $resultsDir 'session-index.json') -Raw | ConvertFrom-Json
+    $bp = $idx.branchProtection
+    $bp.result.status | Should -Be 'warn'
+    $bp.result.reason | Should -Be 'missing_required'
+    $bp.notes | Should -Contain ("Missing contexts: {0}" -f $missingContext)
   }
 
   It 'emits deterministic branch protection output for equivalent context sets' {

--- a/tools/policy/branch-required-checks.json
+++ b/tools/policy/branch-required-checks.json
@@ -15,6 +15,14 @@
       "vi-binary-check",
       "vi-compare",
       "Policy Guard (Upstream) / policy-guard"
+    ],
+    "release/v0.5.2": [
+      "pester",
+      "publish",
+      "vi-binary-check",
+      "vi-compare",
+      "mock-cli",
+      "Policy Guard (Upstream) / policy-guard"
     ]
   }
 }

--- a/tools/priority/__tests__/check-policy-apply.test.mjs
+++ b/tools/priority/__tests__/check-policy-apply.test.mjs
@@ -25,6 +25,7 @@ test('priority:policy --apply updates rulesets for develop/main/release', async 
     'Validate / fixtures',
     'Validate / session-index',
     'Validate / issue-snapshot',
+    'Requirements Verification / requirements-verification',
     'Policy Guard (Upstream) / policy-guard'
   ];
   const expectedMainChecks = [
@@ -453,6 +454,12 @@ test('priority:policy --apply updates rulesets for develop/main/release', async 
   assert.deepEqual(
     statusRuleRelease.parameters.required_status_checks.map((check) => check.context).sort(),
     ['Policy Guard (Upstream) / policy-guard', 'mock-cli', 'pester', 'publish', 'vi-binary-check', 'vi-compare'].sort()
+  );
+  assert.ok(
+    !statusRuleRelease.parameters.required_status_checks.some(
+      (check) => check.context === 'Requirements Verification / requirements-verification'
+    ),
+    'release ruleset should not include requirements-verification check'
   );
 
   assert.ok(


### PR DESCRIPTION
## Summary
- extend branch required-check policy coverage to include `release/v0.5.2` for helper validation
- add release-context session-index branch-protection tests for aligned and missing-required drift cases
- strengthen `priority:policy` apply tests to assert develop includes requirements-verification and release excludes it
- document deterministic local validation command for policy helper drift coverage

## Testing
- pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Path 'tests/SessionIndex.BranchProtection.Tests.ps1','tests/GetBranchProtectionRequiredChecks.Tests.ps1','tests/RequirementsVerificationCheckContract.Tests.ps1' -Output Detailed"
- node --test tools/priority/__tests__/check-policy-apply.test.mjs

Closes #194