### PR TITLE
Add merge-mode guardrails for develop vs main (#196)

### DIFF
--- a/docs/knowledgebase/FEATURE_BRANCH_POLICY.md
+++ b/docs/knowledgebase/FEATURE_BRANCH_POLICY.md
@@ -128,6 +128,12 @@ checked into `tools/priority/policy.json` so `priority:policy` stays authoritati
   node --test tools/priority/__tests__/check-policy-apply.test.mjs
   ```
 
+- Validate merge-mode selection guardrails (`develop` direct merge vs `main` merge-queue/auto):
+
+  ```powershell
+  node --test tools/priority/__tests__/merge-sync-pr.test.mjs
+  ```
+
 - Optional parity run for non-LV checks using the published tools image:
 
   ```powershell

--- a/tools/priority/__tests__/merge-sync-pr.test.mjs
+++ b/tools/priority/__tests__/merge-sync-pr.test.mjs
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { selectMergeMode, shouldRetryWithAuto } from '../merge-sync-pr.mjs';
+import { selectMergeMode, shouldRetryWithAuto, getMergeQueueBranches } from '../merge-sync-pr.mjs';
 
 test('selectMergeMode chooses auto for policy-blocked merge states', () => {
   const selection = selectMergeMode({
@@ -17,12 +17,32 @@ test('selectMergeMode chooses direct for clean mergeable PRs', () => {
   const selection = selectMergeMode({
     state: 'OPEN',
     isDraft: false,
+    baseRefName: 'develop',
     mergeStateStatus: 'CLEAN',
     mergeable: 'MERGEABLE'
   });
   assert.deepEqual(selection, {
     mode: 'direct',
     reason: 'clean-mergeable'
+  });
+});
+
+test('selectMergeMode chooses auto for merge-queue branches', () => {
+  const selection = selectMergeMode(
+    {
+      state: 'OPEN',
+      isDraft: false,
+      baseRefName: 'main',
+      mergeStateStatus: 'CLEAN',
+      mergeable: 'MERGEABLE'
+    },
+    {
+      mergeQueueBranches: new Set(['main'])
+    }
+  );
+  assert.deepEqual(selection, {
+    mode: 'auto',
+    reason: 'merge-queue-branch-main'
   });
 });
 
@@ -89,4 +109,30 @@ test('shouldRetryWithAuto detects policy-blocked direct merge failures', () => {
     }),
     false
   );
+});
+
+test('getMergeQueueBranches returns exact queue-managed branches from policy rulesets', () => {
+  const policy = {
+    rulesets: {
+      develop: {
+        includes: ['refs/heads/develop'],
+        merge_queue: null
+      },
+      main: {
+        includes: ['refs/heads/main'],
+        merge_queue: {
+          merge_method: 'SQUASH'
+        }
+      },
+      release: {
+        includes: ['refs/heads/release/*'],
+        merge_queue: {
+          merge_method: 'SQUASH'
+        }
+      }
+    }
+  };
+
+  const branches = getMergeQueueBranches(policy);
+  assert.deepEqual(Array.from(branches).sort(), ['main']);
 });

--- a/tools/priority/merge-sync-pr.mjs
+++ b/tools/priority/merge-sync-pr.mjs
@@ -112,10 +112,41 @@ function normalizeUpper(value) {
   return typeof value === 'string' ? value.toUpperCase() : '';
 }
 
-export function selectMergeMode(prInfo, { admin = false } = {}) {
+function normalizeLower(value) {
+  return typeof value === 'string' ? value.toLowerCase() : '';
+}
+
+export function getMergeQueueBranches(policy) {
+  const branches = new Set();
+  const rulesets = policy?.rulesets;
+  if (!rulesets || typeof rulesets !== 'object') {
+    return branches;
+  }
+
+  for (const ruleset of Object.values(rulesets)) {
+    if (!ruleset?.merge_queue) {
+      continue;
+    }
+    const includes = Array.isArray(ruleset.includes) ? ruleset.includes : [];
+    for (const ref of includes) {
+      if (typeof ref !== 'string') {
+        continue;
+      }
+      const match = ref.match(/^refs\/heads\/(.+)$/i);
+      if (match && match[1] && !match[1].includes('*')) {
+        branches.add(match[1].toLowerCase());
+      }
+    }
+  }
+
+  return branches;
+}
+
+export function selectMergeMode(prInfo, { admin = false, mergeQueueBranches = new Set() } = {}) {
   const state = normalizeUpper(prInfo?.state);
   const mergeState = normalizeUpper(prInfo?.mergeStateStatus);
   const mergeable = normalizeUpper(prInfo?.mergeable);
+  const baseRefName = normalizeLower(prInfo?.baseRefName);
   const isDraft = Boolean(prInfo?.isDraft);
 
   if (state === 'MERGED') {
@@ -135,6 +166,10 @@ export function selectMergeMode(prInfo, { admin = false } = {}) {
   }
   if (mergeable === 'UNMERGEABLE') {
     throw new Error('PR is UNMERGEABLE. Resolve branch/ruleset blockers before merge automation.');
+  }
+
+  if (baseRefName && mergeQueueBranches.has(baseRefName)) {
+    return { mode: 'auto', reason: `merge-queue-branch-${baseRefName}` };
   }
 
   if (mergeState === 'CLEAN' && (mergeable === 'MERGEABLE' || mergeable === '')) {
@@ -171,7 +206,7 @@ function parseJsonOutput(raw, { label }) {
 function readPrInfo({ repoRoot, repo, pr }) {
   const result = spawnSync(
     'gh',
-    ['pr', 'view', String(pr), '--repo', repo, '--json', 'number,state,isDraft,mergeStateStatus,mergeable,url'],
+    ['pr', 'view', String(pr), '--repo', repo, '--json', 'number,state,isDraft,mergeStateStatus,mergeable,baseRefName,url'],
     {
       cwd: repoRoot,
       encoding: 'utf8',
@@ -240,12 +275,16 @@ export async function runMergeSync({
     return `${upstream.owner}/${upstream.repo}`;
   })();
 
+  const policyRaw = await readFile(manifestPath, 'utf8');
+  const policy = JSON.parse(policyRaw);
+  const mergeQueueBranches = getMergeQueueBranches(policy);
+
   const prInfo = readPrInfo({
     repoRoot,
     repo: resolvedRepo,
     pr: options.pr
   });
-  const selection = selectMergeMode(prInfo, { admin: options.admin });
+  const selection = selectMergeMode(prInfo, { admin: options.admin, mergeQueueBranches });
   console.log(
     `[priority:merge-sync] selected mode=${selection.mode} reason=${selection.reason} mergeState=${prInfo.mergeStateStatus ?? 'n/a'}`
   );


### PR DESCRIPTION
## Summary
- make `merge-sync-pr` select auto mode immediately for queue-managed branches based on `tools/priority/policy.json`
- keep direct merge selection for non-queue branches (like `develop`) and preserve existing retry logic
- add regression tests for merge-queue branch extraction and mode selection contract

## Testing
- node --test tools/priority/__tests__/merge-sync-pr.test.mjs
- node --test tools/priority/__tests__/check-policy-apply.test.mjs

Closes #196