### PR TITLE
Harden merge helper diagnostics and policy traceability (#198)

### DIFF
--- a/docs/knowledgebase/FEATURE_BRANCH_POLICY.md
+++ b/docs/knowledgebase/FEATURE_BRANCH_POLICY.md
@@ -134,6 +134,12 @@ checked into `tools/priority/policy.json` so `priority:policy` stays authoritati
   node --test tools/priority/__tests__/merge-sync-pr.test.mjs
   ```
 
+- Generate a merge helper dry-run summary with policy trace metadata (`policyTrace.mergeQueueBranches`):
+
+  ```powershell
+  node tools/priority/merge-sync-pr.mjs --pr <number> --repo <owner/repo> --dry-run --summary-path tests/results/_agent/priority/merge-sync-dry-run.json
+  ```
+
 - Optional parity run for non-LV checks using the published tools image:
 
   ```powershell

--- a/tools/priority/__tests__/merge-sync-pr.test.mjs
+++ b/tools/priority/__tests__/merge-sync-pr.test.mjs
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { selectMergeMode, shouldRetryWithAuto, getMergeQueueBranches } from '../merge-sync-pr.mjs';
+import { buildPolicyTrace, selectMergeMode, shouldRetryWithAuto, getMergeQueueBranches } from '../merge-sync-pr.mjs';
 
 test('selectMergeMode chooses auto for policy-blocked merge states', () => {
   const selection = selectMergeMode({
@@ -135,4 +135,12 @@ test('getMergeQueueBranches returns exact queue-managed branches from policy rul
 
   const branches = getMergeQueueBranches(policy);
   assert.deepEqual(Array.from(branches).sort(), ['main']);
+});
+
+test('buildPolicyTrace emits deterministic sorted queue branch metadata', () => {
+  const trace = buildPolicyTrace(new Set(['main', 'develop', 'main']));
+  assert.deepEqual(trace, {
+    manifestPath: 'tools/priority/policy.json',
+    mergeQueueBranches: ['develop', 'main']
+  });
 });

--- a/tools/priority/merge-sync-pr.mjs
+++ b/tools/priority/merge-sync-pr.mjs
@@ -142,6 +142,13 @@ export function getMergeQueueBranches(policy) {
   return branches;
 }
 
+export function buildPolicyTrace(mergeQueueBranches = new Set()) {
+  return {
+    manifestPath: 'tools/priority/policy.json',
+    mergeQueueBranches: Array.from(mergeQueueBranches).sort()
+  };
+}
+
 export function selectMergeMode(prInfo, { admin = false, mergeQueueBranches = new Set() } = {}) {
   const state = normalizeUpper(prInfo?.state);
   const mergeState = normalizeUpper(prInfo?.mergeStateStatus);
@@ -358,11 +365,13 @@ export async function runMergeSync({
     finalMode,
     finalReason,
     dryRun: options.dryRun,
+    policyTrace: buildPolicyTrace(mergeQueueBranches),
     attempts,
     prState: {
       state: prInfo.state ?? null,
       mergeStateStatus: prInfo.mergeStateStatus ?? null,
       mergeable: prInfo.mergeable ?? null,
+      baseRefName: prInfo.baseRefName ?? null,
       isDraft: Boolean(prInfo.isDraft)
     },
     prUrl: prInfo.url ?? null


### PR DESCRIPTION
## Summary
- include deterministic policy trace metadata (`policyTrace.mergeQueueBranches`) in merge helper summary payloads
- include PR base branch in merge helper summary state for easier troubleshooting
- add regression test coverage for deterministic policy trace output and document local dry-run summary generation

## Testing
- node --test tools/priority/__tests__/merge-sync-pr.test.mjs
- node --test tools/priority/__tests__/check-policy-apply.test.mjs

Closes #198