### PR TITLE
Stabilize merge helper summary payload contracts (#200)

### DIFF
--- a/docs/knowledgebase/FEATURE_BRANCH_POLICY.md
+++ b/docs/knowledgebase/FEATURE_BRANCH_POLICY.md
@@ -140,6 +140,12 @@ checked into `tools/priority/policy.json` so `priority:policy` stays authoritati
   node tools/priority/merge-sync-pr.mjs --pr <number> --repo <owner/repo> --dry-run --summary-path tests/results/_agent/priority/merge-sync-dry-run.json
   ```
 
+- Inspect stable summary payload fields (`selectedMode`, `finalMode`, `prState.baseRefName`):
+
+  ```powershell
+  pwsh -NoLogo -NoProfile -Command "Get-Content tests/results/_agent/priority/merge-sync-dry-run.json -Raw | ConvertFrom-Json | Select-Object schema,selectedMode,finalMode,@{Name='baseRefName';Expression={$_.prState.baseRefName}},policyTrace | ConvertTo-Json -Depth 6"
+  ```
+
 - Optional parity run for non-LV checks using the published tools image:
 
   ```powershell

--- a/tools/priority/__tests__/merge-sync-pr.test.mjs
+++ b/tools/priority/__tests__/merge-sync-pr.test.mjs
@@ -1,6 +1,12 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { buildPolicyTrace, selectMergeMode, shouldRetryWithAuto, getMergeQueueBranches } from '../merge-sync-pr.mjs';
+import {
+  buildMergeSummaryPayload,
+  buildPolicyTrace,
+  selectMergeMode,
+  shouldRetryWithAuto,
+  getMergeQueueBranches
+} from '../merge-sync-pr.mjs';
 
 test('selectMergeMode chooses auto for policy-blocked merge states', () => {
   const selection = selectMergeMode({
@@ -143,4 +149,94 @@ test('buildPolicyTrace emits deterministic sorted queue branch metadata', () => 
     manifestPath: 'tools/priority/policy.json',
     mergeQueueBranches: ['develop', 'main']
   });
+});
+
+test('buildMergeSummaryPayload remains stable for direct mode contracts', () => {
+  const payload = buildMergeSummaryPayload({
+    repo: 'owner/repo',
+    pr: 123,
+    mergeMethod: 'squash',
+    selectedMode: 'direct',
+    selectedReason: 'clean-mergeable',
+    finalMode: 'direct',
+    finalReason: 'clean-mergeable',
+    dryRun: true,
+    mergeQueueBranches: new Set(['main']),
+    attempts: [{ mode: 'direct', args: ['pr', 'merge'], exitCode: 0 }],
+    prInfo: {
+      state: 'OPEN',
+      mergeStateStatus: 'CLEAN',
+      mergeable: 'MERGEABLE',
+      baseRefName: 'develop',
+      isDraft: false,
+      url: 'https://example.test/pr/123'
+    },
+    createdAt: '2026-03-03T00:00:00.000Z'
+  });
+
+  assert.equal(payload.schema, 'priority/sync-merge@v1');
+  assert.equal(payload.selectedMode, 'direct');
+  assert.equal(payload.finalMode, 'direct');
+  assert.equal(payload.prState.baseRefName, 'develop');
+  assert.deepEqual(payload.policyTrace.mergeQueueBranches, ['main']);
+  assert.equal(payload.createdAt, '2026-03-03T00:00:00.000Z');
+});
+
+test('buildMergeSummaryPayload captures auto mode policy-driven selection details', () => {
+  const payload = buildMergeSummaryPayload({
+    repo: 'owner/repo',
+    pr: 456,
+    mergeMethod: 'squash',
+    selectedMode: 'auto',
+    selectedReason: 'merge-queue-branch-main',
+    finalMode: 'auto',
+    finalReason: 'merge-queue-branch-main',
+    dryRun: false,
+    mergeQueueBranches: new Set(['main']),
+    attempts: [{ mode: 'auto', args: ['pr', 'merge', '--auto'], exitCode: 0 }],
+    prInfo: {
+      state: 'OPEN',
+      mergeStateStatus: 'BLOCKED',
+      mergeable: 'MERGEABLE',
+      baseRefName: 'main',
+      isDraft: false,
+      url: 'https://example.test/pr/456'
+    },
+    createdAt: '2026-03-03T00:00:01.000Z'
+  });
+
+  assert.equal(payload.selectedMode, 'auto');
+  assert.equal(payload.finalReason, 'merge-queue-branch-main');
+  assert.equal(payload.prState.baseRefName, 'main');
+  assert.deepEqual(payload.policyTrace.mergeQueueBranches, ['main']);
+});
+
+test('buildMergeSummaryPayload captures admin override selection details', () => {
+  const payload = buildMergeSummaryPayload({
+    repo: 'owner/repo',
+    pr: 789,
+    mergeMethod: 'rebase',
+    selectedMode: 'admin',
+    selectedReason: 'explicit-admin-override',
+    finalMode: 'admin',
+    finalReason: 'explicit-admin-override',
+    dryRun: false,
+    mergeQueueBranches: new Set(['main']),
+    attempts: [{ mode: 'admin', args: ['pr', 'merge', '--admin'], exitCode: 0 }],
+    prInfo: {
+      state: 'OPEN',
+      mergeStateStatus: 'UNSTABLE',
+      mergeable: 'MERGEABLE',
+      baseRefName: 'develop',
+      isDraft: false,
+      url: 'https://example.test/pr/789'
+    },
+    createdAt: '2026-03-03T00:00:02.000Z'
+  });
+
+  assert.equal(payload.selectedMode, 'admin');
+  assert.equal(payload.finalMode, 'admin');
+  assert.equal(payload.selectedReason, 'explicit-admin-override');
+  assert.equal(payload.prState.baseRefName, 'develop');
+  assert.equal(payload.attempts.length, 1);
 });

--- a/tools/priority/merge-sync-pr.mjs
+++ b/tools/priority/merge-sync-pr.mjs
@@ -149,6 +149,44 @@ export function buildPolicyTrace(mergeQueueBranches = new Set()) {
   };
 }
 
+export function buildMergeSummaryPayload({
+  repo,
+  pr,
+  mergeMethod,
+  selectedMode,
+  selectedReason,
+  finalMode,
+  finalReason,
+  dryRun,
+  mergeQueueBranches,
+  attempts,
+  prInfo,
+  createdAt = new Date().toISOString()
+}) {
+  return {
+    schema: 'priority/sync-merge@v1',
+    createdAt,
+    repo,
+    pr,
+    mergeMethod,
+    selectedMode,
+    selectedReason,
+    finalMode,
+    finalReason,
+    dryRun,
+    policyTrace: buildPolicyTrace(mergeQueueBranches),
+    attempts,
+    prState: {
+      state: prInfo?.state ?? null,
+      mergeStateStatus: prInfo?.mergeStateStatus ?? null,
+      mergeable: prInfo?.mergeable ?? null,
+      baseRefName: prInfo?.baseRefName ?? null,
+      isDraft: Boolean(prInfo?.isDraft)
+    },
+    prUrl: prInfo?.url ?? null
+  };
+}
+
 export function selectMergeMode(prInfo, { admin = false, mergeQueueBranches = new Set() } = {}) {
   const state = normalizeUpper(prInfo?.state);
   const mergeState = normalizeUpper(prInfo?.mergeStateStatus);
@@ -354,9 +392,7 @@ export async function runMergeSync({
     }
   }
 
-  const payload = {
-    schema: 'priority/sync-merge@v1',
-    createdAt: new Date().toISOString(),
+  const payload = buildMergeSummaryPayload({
     repo: resolvedRepo,
     pr: options.pr,
     mergeMethod: options.method,
@@ -365,17 +401,10 @@ export async function runMergeSync({
     finalMode,
     finalReason,
     dryRun: options.dryRun,
-    policyTrace: buildPolicyTrace(mergeQueueBranches),
+    mergeQueueBranches,
     attempts,
-    prState: {
-      state: prInfo.state ?? null,
-      mergeStateStatus: prInfo.mergeStateStatus ?? null,
-      mergeable: prInfo.mergeable ?? null,
-      baseRefName: prInfo.baseRefName ?? null,
-      isDraft: Boolean(prInfo.isDraft)
-    },
-    prUrl: prInfo.url ?? null
-  };
+    prInfo
+  });
   await maybeWriteSummary(options.summaryPath, payload);
 
   console.log(`[priority:merge-sync] final mode=${finalMode} reason=${finalReason}`);


### PR DESCRIPTION
## Summary
- refactor merge helper summary construction into an exported payload builder for stable contract testing
- add direct/auto/admin summary payload tests covering mode fields, base branch capture, and policy trace consistency
- document deterministic summary inspection commands for local dry-run diagnostics

## Testing
- node --test tools/priority/__tests__/merge-sync-pr.test.mjs

Closes #200