### PR TITLE
Expand merge payload edge-case diagnostics coverage (#202)

### DIFF
--- a/docs/knowledgebase/FEATURE_BRANCH_POLICY.md
+++ b/docs/knowledgebase/FEATURE_BRANCH_POLICY.md
@@ -146,6 +146,9 @@ checked into `tools/priority/policy.json` so `priority:policy` stays authoritati
   pwsh -NoLogo -NoProfile -Command "Get-Content tests/results/_agent/priority/merge-sync-dry-run.json -Raw | ConvertFrom-Json | Select-Object schema,selectedMode,finalMode,@{Name='baseRefName';Expression={$_.prState.baseRefName}},policyTrace | ConvertTo-Json -Depth 6"
   ```
 
+`prState.baseRefName` is normalized to lowercase branch names (for example,
+`refs/heads/Main` → `main`) before mode diagnostics are emitted.
+
 - Optional parity run for non-LV checks using the published tools image:
 
   ```powershell

--- a/tools/priority/__tests__/merge-sync-pr.test.mjs
+++ b/tools/priority/__tests__/merge-sync-pr.test.mjs
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import {
   buildMergeSummaryPayload,
   buildPolicyTrace,
+  normalizeBaseRefName,
   selectMergeMode,
   shouldRetryWithAuto,
   getMergeQueueBranches
@@ -198,7 +199,7 @@ test('buildMergeSummaryPayload captures auto mode policy-driven selection detail
       state: 'OPEN',
       mergeStateStatus: 'BLOCKED',
       mergeable: 'MERGEABLE',
-      baseRefName: 'main',
+      baseRefName: 'refs/heads/main',
       isDraft: false,
       url: 'https://example.test/pr/456'
     },
@@ -209,6 +210,13 @@ test('buildMergeSummaryPayload captures auto mode policy-driven selection detail
   assert.equal(payload.finalReason, 'merge-queue-branch-main');
   assert.equal(payload.prState.baseRefName, 'main');
   assert.deepEqual(payload.policyTrace.mergeQueueBranches, ['main']);
+});
+
+test('normalizeBaseRefName handles refs prefix and casing', () => {
+  assert.equal(normalizeBaseRefName('refs/heads/Main'), 'main');
+  assert.equal(normalizeBaseRefName('DEVELOP'), 'develop');
+  assert.equal(normalizeBaseRefName(''), '');
+  assert.equal(normalizeBaseRefName(undefined), '');
 });
 
 test('buildMergeSummaryPayload captures admin override selection details', () => {

--- a/tools/priority/merge-sync-pr.mjs
+++ b/tools/priority/merge-sync-pr.mjs
@@ -116,6 +116,18 @@ function normalizeLower(value) {
   return typeof value === 'string' ? value.toLowerCase() : '';
 }
 
+export function normalizeBaseRefName(value) {
+  const lowered = normalizeLower(value).trim();
+  if (!lowered) {
+    return '';
+  }
+  const refsPrefix = 'refs/heads/';
+  if (lowered.startsWith(refsPrefix)) {
+    return lowered.substring(refsPrefix.length);
+  }
+  return lowered;
+}
+
 export function getMergeQueueBranches(policy) {
   const branches = new Set();
   const rulesets = policy?.rulesets;
@@ -163,6 +175,7 @@ export function buildMergeSummaryPayload({
   prInfo,
   createdAt = new Date().toISOString()
 }) {
+  const normalizedBaseRefName = normalizeBaseRefName(prInfo?.baseRefName);
   return {
     schema: 'priority/sync-merge@v1',
     createdAt,
@@ -180,7 +193,7 @@ export function buildMergeSummaryPayload({
       state: prInfo?.state ?? null,
       mergeStateStatus: prInfo?.mergeStateStatus ?? null,
       mergeable: prInfo?.mergeable ?? null,
-      baseRefName: prInfo?.baseRefName ?? null,
+      baseRefName: normalizedBaseRefName || null,
       isDraft: Boolean(prInfo?.isDraft)
     },
     prUrl: prInfo?.url ?? null
@@ -191,7 +204,7 @@ export function selectMergeMode(prInfo, { admin = false, mergeQueueBranches = ne
   const state = normalizeUpper(prInfo?.state);
   const mergeState = normalizeUpper(prInfo?.mergeStateStatus);
   const mergeable = normalizeUpper(prInfo?.mergeable);
-  const baseRefName = normalizeLower(prInfo?.baseRefName);
+  const baseRefName = normalizeBaseRefName(prInfo?.baseRefName);
   const isDraft = Boolean(prInfo?.isDraft);
 
   if (state === 'MERGED') {


### PR DESCRIPTION
## Summary
- normalize `baseRefName` handling for merge diagnostics (including `refs/heads/*` inputs)
- add edge-case regression coverage for queue branch matching and summary payload base branch normalization
- document normalized base branch behavior in merge helper diagnostics notes

## Testing
- node --test tools/priority/__tests__/merge-sync-pr.test.mjs

Closes #202