### PR TITLE
Add merge retry-flow summary diagnostics coverage (#204)

### DIFF
--- a/docs/knowledgebase/FEATURE_BRANCH_POLICY.md
+++ b/docs/knowledgebase/FEATURE_BRANCH_POLICY.md
@@ -149,6 +149,13 @@ checked into `tools/priority/policy.json` so `priority:policy` stays authoritati
 `prState.baseRefName` is normalized to lowercase branch names (for example,
 `refs/heads/Main` → `main`) before mode diagnostics are emitted.
 
+- Inspect retry-flow transitions (`selectedMode`, `finalMode`, `attempts`) from the
+  dry-run summary:
+
+  ```powershell
+  pwsh -NoLogo -NoProfile -Command "Get-Content tests/results/_agent/priority/merge-sync-dry-run.json -Raw | ConvertFrom-Json | Select-Object selectedMode,finalMode,finalReason,attempts | ConvertTo-Json -Depth 8"
+  ```
+
 - Optional parity run for non-LV checks using the published tools image:
 
   ```powershell

--- a/tools/priority/__tests__/merge-sync-pr.test.mjs
+++ b/tools/priority/__tests__/merge-sync-pr.test.mjs
@@ -248,3 +248,41 @@ test('buildMergeSummaryPayload captures admin override selection details', () =>
   assert.equal(payload.prState.baseRefName, 'develop');
   assert.equal(payload.attempts.length, 1);
 });
+
+test('buildMergeSummaryPayload preserves direct-to-auto retry attempt sequence', () => {
+  const payload = buildMergeSummaryPayload({
+    repo: 'owner/repo',
+    pr: 910,
+    mergeMethod: 'squash',
+    selectedMode: 'direct',
+    selectedReason: 'clean-mergeable',
+    finalMode: 'auto',
+    finalReason: 'direct-merge-policy-block-retry-auto',
+    dryRun: false,
+    mergeQueueBranches: new Set(['main']),
+    attempts: [
+      { mode: 'direct', args: ['pr', 'merge', '--squash'], exitCode: 1 },
+      { mode: 'auto', args: ['pr', 'merge', '--squash', '--auto'], exitCode: 0 }
+    ],
+    prInfo: {
+      state: 'OPEN',
+      mergeStateStatus: 'UNSTABLE',
+      mergeable: 'MERGEABLE',
+      baseRefName: 'develop',
+      isDraft: false,
+      url: 'https://example.test/pr/910'
+    },
+    createdAt: '2026-03-03T00:00:03.000Z'
+  });
+
+  assert.equal(payload.selectedMode, 'direct');
+  assert.equal(payload.finalMode, 'auto');
+  assert.equal(payload.finalReason, 'direct-merge-policy-block-retry-auto');
+  assert.deepEqual(
+    payload.attempts.map((attempt) => ({ mode: attempt.mode, exitCode: attempt.exitCode })),
+    [
+      { mode: 'direct', exitCode: 1 },
+      { mode: 'auto', exitCode: 0 }
+    ]
+  );
+});


### PR DESCRIPTION
## Summary
- add merge helper summary payload test coverage for direct->auto retry transitions
- assert deterministic attempts ordering and mode/finalReason diagnostics in summary contract
- document local snippet to inspect selected/final mode transitions and attempts from dry-run summary

## Testing
- node --test tools/priority/__tests__/merge-sync-pr.test.mjs

Closes #204