### PR TITLE
Stabilize merge reason diagnostics contracts (#206)

### DIFF
--- a/docs/knowledgebase/FEATURE_BRANCH_POLICY.md
+++ b/docs/knowledgebase/FEATURE_BRANCH_POLICY.md
@@ -146,6 +146,13 @@ checked into `tools/priority/policy.json` so `priority:policy` stays authoritati
   pwsh -NoLogo -NoProfile -Command "Get-Content tests/results/_agent/priority/merge-sync-dry-run.json -Raw | ConvertFrom-Json | Select-Object schema,selectedMode,finalMode,@{Name='baseRefName';Expression={$_.prState.baseRefName}},policyTrace | ConvertTo-Json -Depth 6"
   ```
 
+- Inspect reason diagnostics (`selectedReason`, `finalReason`) for queue/non-queue
+  troubleshooting:
+
+  ```powershell
+  pwsh -NoLogo -NoProfile -Command "Get-Content tests/results/_agent/priority/merge-sync-dry-run.json -Raw | ConvertFrom-Json | Select-Object selectedMode,selectedReason,finalMode,finalReason | ConvertTo-Json -Depth 4"
+  ```
+
 `prState.baseRefName` is normalized to lowercase branch names (for example,
 `refs/heads/Main` → `main`) before mode diagnostics are emitted.
 

--- a/tools/priority/__tests__/merge-sync-pr.test.mjs
+++ b/tools/priority/__tests__/merge-sync-pr.test.mjs
@@ -53,6 +53,25 @@ test('selectMergeMode chooses auto for merge-queue branches', () => {
   });
 });
 
+test('selectMergeMode keeps queue reason stable for refs/heads base branch values', () => {
+  const selection = selectMergeMode(
+    {
+      state: 'OPEN',
+      isDraft: false,
+      baseRefName: 'refs/heads/Main',
+      mergeStateStatus: 'UNSTABLE',
+      mergeable: 'MERGEABLE'
+    },
+    {
+      mergeQueueBranches: new Set(['main'])
+    }
+  );
+  assert.deepEqual(selection, {
+    mode: 'auto',
+    reason: 'merge-queue-branch-main'
+  });
+});
+
 test('selectMergeMode honors explicit admin override', () => {
   const selection = selectMergeMode(
     {
@@ -285,4 +304,34 @@ test('buildMergeSummaryPayload preserves direct-to-auto retry attempt sequence',
       { mode: 'auto', exitCode: 0 }
     ]
   );
+});
+
+test('buildMergeSummaryPayload preserves selected/final reason fields for diagnostics', () => {
+  const payload = buildMergeSummaryPayload({
+    repo: 'owner/repo',
+    pr: 911,
+    mergeMethod: 'squash',
+    selectedMode: 'auto',
+    selectedReason: 'merge-state-unstable',
+    finalMode: 'auto',
+    finalReason: 'direct-merge-policy-block-retry-auto',
+    dryRun: false,
+    mergeQueueBranches: new Set(['main']),
+    attempts: [
+      { mode: 'direct', args: ['pr', 'merge', '--squash'], exitCode: 1 },
+      { mode: 'auto', args: ['pr', 'merge', '--squash', '--auto'], exitCode: 0 }
+    ],
+    prInfo: {
+      state: 'OPEN',
+      mergeStateStatus: 'UNSTABLE',
+      mergeable: 'MERGEABLE',
+      baseRefName: 'develop',
+      isDraft: false,
+      url: 'https://example.test/pr/911'
+    },
+    createdAt: '2026-03-03T00:00:04.000Z'
+  });
+
+  assert.equal(payload.selectedReason, 'merge-state-unstable');
+  assert.equal(payload.finalReason, 'direct-merge-policy-block-retry-auto');
 });


### PR DESCRIPTION
## Summary
- add merge helper tests that lock queue/non-queue reason semantics (including refs/heads base branch inputs)
- add summary payload test coverage for selectedReason/finalReason stability in diagnostics
- document deterministic reason inspection snippet for dry-run summary payload output

## Testing
- node --test tools/priority/__tests__/merge-sync-pr.test.mjs

Closes #206