### PR TITLE
Expand unknown-state merge reason coverage (#208)

### DIFF
--- a/docs/knowledgebase/FEATURE_BRANCH_POLICY.md
+++ b/docs/knowledgebase/FEATURE_BRANCH_POLICY.md
@@ -153,6 +153,12 @@ checked into `tools/priority/policy.json` so `priority:policy` stays authoritati
   pwsh -NoLogo -NoProfile -Command "Get-Content tests/results/_agent/priority/merge-sync-dry-run.json -Raw | ConvertFrom-Json | Select-Object selectedMode,selectedReason,finalMode,finalReason | ConvertTo-Json -Depth 4"
   ```
 
+- Inspect unknown-state reason output explicitly:
+
+  ```powershell
+  pwsh -NoLogo -NoProfile -Command "Get-Content tests/results/_agent/priority/merge-sync-dry-run.json -Raw | ConvertFrom-Json | Select-Object selectedMode,selectedReason,@{Name='mergeState';Expression={$_.prState.mergeStateStatus}},@{Name='baseRef';Expression={$_.prState.baseRefName}} | ConvertTo-Json -Depth 4"
+  ```
+
 `prState.baseRefName` is normalized to lowercase branch names (for example,
 `refs/heads/Main` → `main`) before mode diagnostics are emitted.
 

--- a/tools/priority/__tests__/merge-sync-pr.test.mjs
+++ b/tools/priority/__tests__/merge-sync-pr.test.mjs
@@ -20,6 +20,25 @@ test('selectMergeMode chooses auto for policy-blocked merge states', () => {
   assert.match(selection.reason, /merge-state-blocked/);
 });
 
+test('selectMergeMode maps unknown merge state to unknown reason when queue branch is absent', () => {
+  const selection = selectMergeMode(
+    {
+      state: 'OPEN',
+      isDraft: false,
+      baseRefName: 'develop',
+      mergeStateStatus: 'UNKNOWN',
+      mergeable: 'MERGEABLE'
+    },
+    {
+      mergeQueueBranches: new Set(['main'])
+    }
+  );
+  assert.deepEqual(selection, {
+    mode: 'auto',
+    reason: 'unknown-merge-state'
+  });
+});
+
 test('selectMergeMode chooses direct for clean mergeable PRs', () => {
   const selection = selectMergeMode({
     state: 'OPEN',
@@ -60,6 +79,25 @@ test('selectMergeMode keeps queue reason stable for refs/heads base branch value
       isDraft: false,
       baseRefName: 'refs/heads/Main',
       mergeStateStatus: 'UNSTABLE',
+      mergeable: 'MERGEABLE'
+    },
+    {
+      mergeQueueBranches: new Set(['main'])
+    }
+  );
+  assert.deepEqual(selection, {
+    mode: 'auto',
+    reason: 'merge-queue-branch-main'
+  });
+});
+
+test('selectMergeMode preserves queue reason precedence when merge state is unknown', () => {
+  const selection = selectMergeMode(
+    {
+      state: 'OPEN',
+      isDraft: false,
+      baseRefName: 'refs/heads/main',
+      mergeStateStatus: 'UNKNOWN',
       mergeable: 'MERGEABLE'
     },
     {

--- a/tools/priority/merge-sync-pr.mjs
+++ b/tools/priority/merge-sync-pr.mjs
@@ -1,12 +1,14 @@
 #!/usr/bin/env node
 
-import { writeFile } from 'node:fs/promises';
+import { readFile, writeFile } from 'node:fs/promises';
 import { spawnSync } from 'node:child_process';
 import path from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 import { ensureGhCli, resolveUpstream } from './lib/remote-utils.mjs';
 import { getRepoRoot } from './lib/branch-utils.mjs';
+
+const manifestPath = new URL('./policy.json', import.meta.url);
 
 const USAGE_LINES = [
   'Usage: node tools/priority/merge-sync-pr.mjs --pr <number> [options]',


### PR DESCRIPTION
## Summary
- add unknown-state merge reason tests for non-queue branches and preserve queue-branch reason precedence
- add deterministic docs snippet to inspect unknown-state reason output in merge summary payload
- fix merge helper runtime policy manifest read path by importing `readFile` and defining manifest path

## Testing
- node --test tools/priority/__tests__/merge-sync-pr.test.mjs
- node --test tools/priority/__tests__/check-policy-apply.test.mjs

Closes #208