### PR TITLE
Expand fallback merge reason mapping coverage (#210)

### DIFF
--- a/docs/knowledgebase/FEATURE_BRANCH_POLICY.md
+++ b/docs/knowledgebase/FEATURE_BRANCH_POLICY.md
@@ -159,6 +159,13 @@ checked into `tools/priority/policy.json` so `priority:policy` stays authoritati
   pwsh -NoLogo -NoProfile -Command "Get-Content tests/results/_agent/priority/merge-sync-dry-run.json -Raw | ConvertFrom-Json | Select-Object selectedMode,selectedReason,@{Name='mergeState';Expression={$_.prState.mergeStateStatus}},@{Name='baseRef';Expression={$_.prState.baseRefName}} | ConvertTo-Json -Depth 4"
   ```
 
+- Inspect fallback reason mapping output (`merge-state-unspecified`) when merge
+  state is absent:
+
+  ```powershell
+  pwsh -NoLogo -NoProfile -Command "Get-Content tests/results/_agent/priority/merge-sync-dry-run.json -Raw | ConvertFrom-Json | Select-Object selectedMode,selectedReason,@{Name='fallbackExpected';Expression={'merge-state-unspecified'}},@{Name='baseRef';Expression={$_.prState.baseRefName}} | ConvertTo-Json -Depth 4"
+  ```
+
 `prState.baseRefName` is normalized to lowercase branch names (for example,
 `refs/heads/Main` → `main`) before mode diagnostics are emitted.
 

--- a/tools/priority/__tests__/merge-sync-pr.test.mjs
+++ b/tools/priority/__tests__/merge-sync-pr.test.mjs
@@ -39,6 +39,43 @@ test('selectMergeMode maps unknown merge state to unknown reason when queue bran
   });
 });
 
+test('selectMergeMode maps missing merge state to merge-state-unspecified when queue branch is absent', () => {
+  const selection = selectMergeMode(
+    {
+      state: 'OPEN',
+      isDraft: false,
+      baseRefName: 'develop',
+      mergeable: 'MERGEABLE'
+    },
+    {
+      mergeQueueBranches: new Set(['main'])
+    }
+  );
+  assert.deepEqual(selection, {
+    mode: 'auto',
+    reason: 'merge-state-unspecified'
+  });
+});
+
+test('selectMergeMode maps empty merge state to merge-state-unspecified when queue branch is absent', () => {
+  const selection = selectMergeMode(
+    {
+      state: 'OPEN',
+      isDraft: false,
+      baseRefName: 'develop',
+      mergeStateStatus: '',
+      mergeable: 'MERGEABLE'
+    },
+    {
+      mergeQueueBranches: new Set(['main'])
+    }
+  );
+  assert.deepEqual(selection, {
+    mode: 'auto',
+    reason: 'merge-state-unspecified'
+  });
+});
+
 test('selectMergeMode chooses direct for clean mergeable PRs', () => {
   const selection = selectMergeMode({
     state: 'OPEN',
@@ -98,6 +135,24 @@ test('selectMergeMode preserves queue reason precedence when merge state is unkn
       isDraft: false,
       baseRefName: 'refs/heads/main',
       mergeStateStatus: 'UNKNOWN',
+      mergeable: 'MERGEABLE'
+    },
+    {
+      mergeQueueBranches: new Set(['main'])
+    }
+  );
+  assert.deepEqual(selection, {
+    mode: 'auto',
+    reason: 'merge-queue-branch-main'
+  });
+});
+
+test('selectMergeMode preserves queue reason precedence when merge state is missing', () => {
+  const selection = selectMergeMode(
+    {
+      state: 'OPEN',
+      isDraft: false,
+      baseRefName: 'refs/heads/main',
       mergeable: 'MERGEABLE'
     },
     {


### PR DESCRIPTION
## Summary
- add fallback reason regression coverage for missing/empty `mergeStateStatus` when queue branch is absent
- assert queue-branch reason precedence remains stable when merge state is missing
- add deterministic docs snippet to inspect fallback reason mapping output from merge summary payload

## Testing
- node --test tools/priority/__tests__/merge-sync-pr.test.mjs

Closes #210