### PR TITLE
Harden fallback reason behavior for unset mergeable states (#213)

### DIFF
--- a/docs/knowledgebase/FEATURE_BRANCH_POLICY.md
+++ b/docs/knowledgebase/FEATURE_BRANCH_POLICY.md
@@ -166,6 +166,12 @@ checked into `tools/priority/policy.json` so `priority:policy` stays authoritati
   pwsh -NoLogo -NoProfile -Command "Get-Content tests/results/_agent/priority/merge-sync-dry-run.json -Raw | ConvertFrom-Json | Select-Object selectedMode,selectedReason,@{Name='fallbackExpected';Expression={'merge-state-unspecified'}},@{Name='baseRef';Expression={$_.prState.baseRefName}} | ConvertTo-Json -Depth 4"
   ```
 
+- Inspect minimal fallback diagnostics fields (reason + mergeability context):
+
+  ```powershell
+  pwsh -NoLogo -NoProfile -Command "Get-Content tests/results/_agent/priority/merge-sync-dry-run.json -Raw | ConvertFrom-Json | Select-Object selectedReason,@{Name='mergeState';Expression={$_.prState.mergeStateStatus}},@{Name='mergeable';Expression={$_.prState.mergeable}},@{Name='baseRef';Expression={$_.prState.baseRefName}} | ConvertTo-Json -Depth 4"
+  ```
+
 `prState.baseRefName` is normalized to lowercase branch names (for example,
 `refs/heads/Main` → `main`) before mode diagnostics are emitted.
 

--- a/tools/priority/__tests__/merge-sync-pr.test.mjs
+++ b/tools/priority/__tests__/merge-sync-pr.test.mjs
@@ -39,6 +39,23 @@ test('selectMergeMode maps unknown merge state to unknown reason when queue bran
   });
 });
 
+test('selectMergeMode maps absent merge state with unset mergeable to merge-state-unspecified when queue branch is absent', () => {
+  const selection = selectMergeMode(
+    {
+      state: 'OPEN',
+      isDraft: false,
+      baseRefName: 'develop'
+    },
+    {
+      mergeQueueBranches: new Set(['main'])
+    }
+  );
+  assert.deepEqual(selection, {
+    mode: 'auto',
+    reason: 'merge-state-unspecified'
+  });
+});
+
 test('selectMergeMode maps missing merge state to merge-state-unspecified when queue branch is absent', () => {
   const selection = selectMergeMode(
     {
@@ -136,6 +153,23 @@ test('selectMergeMode preserves queue reason precedence when merge state is unkn
       baseRefName: 'refs/heads/main',
       mergeStateStatus: 'UNKNOWN',
       mergeable: 'MERGEABLE'
+    },
+    {
+      mergeQueueBranches: new Set(['main'])
+    }
+  );
+  assert.deepEqual(selection, {
+    mode: 'auto',
+    reason: 'merge-queue-branch-main'
+  });
+});
+
+test('selectMergeMode preserves queue reason precedence when mergeable is unset and merge state is absent', () => {
+  const selection = selectMergeMode(
+    {
+      state: 'OPEN',
+      isDraft: false,
+      baseRefName: 'refs/heads/main'
     },
     {
       mergeQueueBranches: new Set(['main'])


### PR DESCRIPTION
## Summary
- add fallback reason tests for absent merge state with unset mergeable on non-queue branches
- assert queue-branch reason precedence remains stable when mergeable/mergeState are both absent
- add deterministic docs snippet to inspect minimal fallback diagnostics fields from summary payload

## Testing
- node --test tools/priority/__tests__/merge-sync-pr.test.mjs

Closes #213