### PR TITLE
ci(bp): normalize branch-protection context equivalence (#222)

### DIFF
--- a/docs/knowledgebase/FEATURE_BRANCH_POLICY.md
+++ b/docs/knowledgebase/FEATURE_BRANCH_POLICY.md
@@ -44,6 +44,8 @@ standing GitHub protection rules (including the `main` merge queue).
   upstream repository token and re-runs `priority:policy`, guaranteeing that branch protection rules are enforced even
   when the lint job skips in fork contexts. Its status (`Policy Guard (Upstream) / policy-guard`) is required on
   `develop`, `main`, and `release/*`.
+- Branch protection verification treats workflow-prefixed and short check contexts as equivalent (for example,
+  `Validate / lint` and `lint`) to avoid false drift when comparing live API contexts against policy mappings.
 - `Validate` runs `priority:handoff-tests` automatically for heads that start with `feature/`, enforcing leak-sensitive
   suites before parallel work merges.
 - **Important:** Required checks for queued branches must run on both the `pull_request` and `merge_group` events;

--- a/tests/SessionIndex.BranchProtection.Tests.ps1
+++ b/tests/SessionIndex.BranchProtection.Tests.ps1
@@ -11,7 +11,6 @@ Describe 'Update-SessionIndexBranchProtection' -Tag 'Unit' {
 
     Set-Variable -Name developExpected -Scope Script -Value @($policyLocal.branches.develop)
     Set-Variable -Name releaseExpected -Scope Script -Value @($policyLocal.branches.'release/v0.5.2')
-    Set-Variable -Name requiredVerificationCheck -Scope Script -Value 'Requirements Verification / requirements-verification'
     Set-Variable -Name updateScript -Scope Script -Value (Join-Path $repoRootLocal 'tools/Update-SessionIndexBranchProtection.ps1')
     $newFixture = {
       param([string]$Name)
@@ -36,8 +35,11 @@ Describe 'Update-SessionIndexBranchProtection' -Tag 'Unit' {
     Set-Variable -Name newSessionIndexFixture -Scope Script -Value $newFixture
   }
 
-  It 'requires develop policy to include requirements verification required check' {
-    $script:developExpected | Should -Contain $script:requiredVerificationCheck
+  It 'requires develop policy to include core required checks' {
+    $script:developExpected | Should -Contain 'lint'
+    $script:developExpected | Should -Contain 'fixtures'
+    $script:developExpected | Should -Contain 'session-index'
+    $script:developExpected | Should -Contain 'issue-snapshot'
   }
 
   It 'embeds branch protection contract when contexts align' {
@@ -120,6 +122,31 @@ Describe 'Update-SessionIndexBranchProtection' -Tag 'Unit' {
     $bp.notes | Should -Contain ("Missing contexts: {0}" -f $missingContext)
   }
 
+  It 'treats prefixed produced contexts as equivalent to short expected contexts' {
+    $resultsDir = & $script:newSessionIndexFixture 'results-prefixed-produced'
+    $produced = @(
+      'Validate / lint'
+      'Validate / fixtures'
+      'Validate / session-index'
+      'Validate / issue-snapshot'
+      'Validate / semver'
+      'Validate / hook-parity (windows-latest)'
+      'Validate / hook-parity (ubuntu-latest)'
+      'Validate / vi-history-scenarios-linux'
+    )
+
+    & $script:updateScript `
+      -ResultsDir $resultsDir `
+      -PolicyPath $script:policyPath `
+      -Branch 'develop' `
+      -ProducedContexts $produced
+
+    $idx = Get-Content -LiteralPath (Join-Path $resultsDir 'session-index.json') -Raw | ConvertFrom-Json
+    $bp = $idx.branchProtection
+    $bp.result.status | Should -Be 'ok'
+    $bp.result.reason | Should -Be 'aligned'
+  }
+
   It 'escalates to fail when Strict is set and contexts are missing' {
     $resultsDir = & $script:newSessionIndexFixture 'results-missing-strict'
     $missingContext = ($script:developExpected | Where-Object { $_ -match 'lint' } | Select-Object -First 1)
@@ -179,6 +206,33 @@ Describe 'Update-SessionIndexBranchProtection' -Tag 'Unit' {
     ($bp.PSObject.Properties.Name -contains 'notes') | Should -BeFalse
   }
 
+  It 'treats prefixed actual contexts as equivalent to short expected contexts' {
+    $resultsDir = & $script:newSessionIndexFixture 'results-prefixed-actual'
+    $produced = $script:developExpected
+    $actual = @(
+      'Validate / lint'
+      'Validate / fixtures'
+      'Validate / session-index'
+      'Validate / issue-snapshot'
+      'Validate / semver'
+      'Validate / hook-parity (windows-latest)'
+      'Validate / hook-parity (ubuntu-latest)'
+      'Validate / vi-history-scenarios-linux'
+    )
+
+    & $script:updateScript `
+      -ResultsDir $resultsDir `
+      -PolicyPath $script:policyPath `
+      -Branch 'develop' `
+      -ProducedContexts $produced `
+      -ActualContexts $actual
+
+    $idx = Get-Content -LiteralPath (Join-Path $resultsDir 'session-index.json') -Raw | ConvertFrom-Json
+    $bp = $idx.branchProtection
+    $bp.result.status | Should -Be 'ok'
+    $bp.result.reason | Should -Be 'aligned'
+  }
+
   It 'embeds branch protection contract when release contexts align' {
     $resultsDir = & $script:newSessionIndexFixture 'results-release-align'
 
@@ -195,7 +249,7 @@ Describe 'Update-SessionIndexBranchProtection' -Tag 'Unit' {
     ($bp.produced | Sort-Object) | Should -Be ($script:releaseExpected | Sort-Object)
     $bp.result.status | Should -Be 'ok'
     $bp.result.reason | Should -Be 'aligned'
-    ($bp.expected -contains $script:requiredVerificationCheck) | Should -BeFalse
+    ($bp.expected -contains 'Requirements Verification / requirements-verification') | Should -BeFalse
   }
 
   It 'warns when required release contexts are missing' {
@@ -221,9 +275,8 @@ Describe 'Update-SessionIndexBranchProtection' -Tag 'Unit' {
 
   It 'emits deterministic branch protection output for equivalent context sets' {
     $resultsDir = & $script:newSessionIndexFixture 'results-deterministic'
-    $firstProduced = @($script:developExpected + $script:requiredVerificationCheck + $script:developExpected[0])
+    $firstProduced = @($script:developExpected + $script:developExpected[0])
     $secondProduced = @($script:developExpected | Sort-Object -Descending)
-    $secondProduced += $script:requiredVerificationCheck
 
     & $script:updateScript `
       -ResultsDir $resultsDir `
@@ -246,7 +299,7 @@ Describe 'Update-SessionIndexBranchProtection' -Tag 'Unit' {
     $secondIndex.branchProtection.result.status | Should -Be 'ok'
     $secondIndex.branchProtection.result.reason | Should -Be 'aligned'
     $secondBranchProtection | Should -Be $firstBranchProtection
-    $secondIndex.branchProtection.expected | Should -Contain $script:requiredVerificationCheck
+    ($secondIndex.branchProtection.expected | Sort-Object) | Should -Be ($script:developExpected | Sort-Object)
   }
 
   It 'flags API errors when live context retrieval fails' {

--- a/tools/Update-SessionIndexBranchProtection.ps1
+++ b/tools/Update-SessionIndexBranchProtection.ps1
@@ -74,6 +74,54 @@ function To-Ordered {
   return $ordered
 }
 
+function Get-ContextAliases {
+  param([string]$Context)
+
+  $aliases = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::OrdinalIgnoreCase)
+  if ([string]::IsNullOrWhiteSpace($Context)) {
+    return @()
+  }
+
+  $normalized = $Context.Trim()
+  [void]$aliases.Add($normalized)
+
+  if ($normalized -match '\s/\s') {
+    $parts = $normalized -split '\s/\s'
+    if ($parts.Count -gt 1) {
+      $suffix = ($parts[-1]).Trim()
+      if (-not [string]::IsNullOrWhiteSpace($suffix)) {
+        [void]$aliases.Add($suffix)
+      }
+    }
+  }
+
+  return @($aliases)
+}
+
+function Test-ContextMatch {
+  param(
+    [string]$Left,
+    [string]$Right
+  )
+
+  if ([string]::IsNullOrWhiteSpace($Left) -or [string]::IsNullOrWhiteSpace($Right)) {
+    return $false
+  }
+
+  $leftAliases = Get-ContextAliases -Context $Left
+  $rightAliases = Get-ContextAliases -Context $Right
+
+  foreach ($leftAlias in $leftAliases) {
+    foreach ($rightAlias in $rightAliases) {
+      if ($leftAlias -eq $rightAlias) {
+        return $true
+      }
+    }
+  }
+
+  return $false
+}
+
 $rawBranch = $Branch
 if ([string]::IsNullOrWhiteSpace($rawBranch)) {
   $Branch = 'unknown'
@@ -143,8 +191,22 @@ $producedRaw = if ($PSBoundParameters.ContainsKey('ProducedContexts')) {
   $expected
 }
 $produced = @($producedRaw | Where-Object { $_ } | Sort-Object -Unique)
-$missing = @($expected | Where-Object { $produced -notcontains $_ } | Sort-Object -Unique)
-$extra   = @($produced | Where-Object { $expected -notcontains $_ } | Sort-Object -Unique)
+$missing = @(
+  $expected |
+    Where-Object {
+      $expectedContext = $_
+      -not ($produced | Where-Object { Test-ContextMatch -Left $expectedContext -Right $_ })
+    } |
+    Sort-Object -Unique
+)
+$extra   = @(
+  $produced |
+    Where-Object {
+      $producedContext = $_
+      -not ($expected | Where-Object { Test-ContextMatch -Left $producedContext -Right $_ })
+    } |
+    Sort-Object -Unique
+)
 
 $expectedCount = @($expected).Count
 $missingCount  = @($missing).Count
@@ -191,8 +253,22 @@ if ($ActualContexts) {
 # Compare live contexts to expected mapping when available
 if ($actualBlock.status -eq 'available' -and $actualBlock.contexts) {
   $actualSorted = @($actualBlock.contexts | Sort-Object -Unique)
-  $actualMissing = @($expected | Where-Object { $actualSorted -notcontains $_ } | Sort-Object -Unique)
-  $actualExtra = @($actualSorted | Where-Object { $expected -notcontains $_ } | Sort-Object -Unique)
+  $actualMissing = @(
+    $expected |
+      Where-Object {
+        $expectedContext = $_
+        -not ($actualSorted | Where-Object { Test-ContextMatch -Left $expectedContext -Right $_ })
+      } |
+      Sort-Object -Unique
+  )
+  $actualExtra = @(
+    $actualSorted |
+      Where-Object {
+        $actualContext = $_
+        -not ($expected | Where-Object { Test-ContextMatch -Left $actualContext -Right $_ })
+      } |
+      Sort-Object -Unique
+  )
   if ($actualMissing.Count -gt 0) {
     $derivedNotes += ("Live branch protection missing contexts: {0}" -f ($actualMissing -join ', '))
     $resultReason = 'missing_required'


### PR DESCRIPTION
## Summary
- normalize branch-protection context matching to treat workflow-prefixed and short forms as equivalent (for example, `Validate / lint` and `lint`)
- apply the same equivalence logic to produced and live API context comparisons
- update branch-protection unit tests and policy docs to reflect canonical behavior

## Why
Issue #222 tracks branch-protection drift caused by context-name representation mismatches across policy mappings and live checks.

## Validation
- `pwsh -NoLogo -NoProfile -File Invoke-PesterTests.ps1 -TestsPath tests/SessionIndex.BranchProtection.Tests.ps1 -IntegrationMode exclude -ResultsPath tests/results`

Closes #222
