### PR TITLE
ci(watcher): enforce session-index watcher merge guarantees (#221)

### DIFF
--- a/tests/Update.SessionIndexWatcher.Tests.ps1
+++ b/tests/Update.SessionIndexWatcher.Tests.ps1
@@ -1,0 +1,75 @@
+Describe 'Update-SessionIndexWatcher' -Tag 'Unit' {
+  BeforeAll {
+    $repoRoot = (Get-Location).Path
+    $script:updateScript = Join-Path $repoRoot 'tools/Update-SessionIndexWatcher.ps1'
+    $script:ensureScript = Join-Path $repoRoot 'tools/Ensure-SessionIndex.ps1'
+
+    $newFixture = {
+      param([string]$Name)
+
+      $resultsDir = Join-Path $TestDrive $Name
+      New-Item -ItemType Directory -Force -Path $resultsDir | Out-Null
+
+      $summary = @{
+        total = 1
+        passed = 1
+        failed = 0
+        errors = 0
+        skipped = 0
+        duration_s = 0.1
+        schemaVersion = '1.0.0'
+      } | ConvertTo-Json
+      Set-Content -LiteralPath (Join-Path $resultsDir 'pester-summary.json') -Value $summary -Encoding UTF8
+
+      & $script:ensureScript -ResultsDir $resultsDir -SummaryJson 'pester-summary.json' | Out-Null
+      return $resultsDir
+    }
+    Set-Variable -Name newSessionIndexFixture -Scope Script -Value $newFixture
+  }
+
+  It 'merges valid watcher summary into session index' {
+    $resultsDir = & $script:newSessionIndexFixture 'watcher-valid'
+    $watcherPath = Join-Path $TestDrive 'watcher-valid.json'
+    $watcher = @{
+      schema = 'ci-watch/rest-v1'
+      status = 'completed'
+      conclusion = 'success'
+      htmlUrl = 'https://example.invalid/run/1'
+      polledAtUtc = (Get-Date).ToUniversalTime().ToString('o')
+      jobs = @()
+    } | ConvertTo-Json
+    Set-Content -LiteralPath $watcherPath -Value $watcher -Encoding UTF8
+
+    & $script:updateScript -ResultsDir $resultsDir -WatcherJson $watcherPath
+
+    $idx = Get-Content -LiteralPath (Join-Path $resultsDir 'session-index.json') -Raw | ConvertFrom-Json
+    $idx.watchers.rest.status | Should -Be 'completed'
+    $idx.watchers.rest.conclusion | Should -Be 'success'
+    $idx.watchers.rest.schema | Should -Be 'ci-watch/rest-v1'
+  }
+
+  It 'records missing-file watcher status when watcher json path does not exist' {
+    $resultsDir = & $script:newSessionIndexFixture 'watcher-missing'
+    $watcherPath = Join-Path $TestDrive 'does-not-exist.json'
+
+    & $script:updateScript -ResultsDir $resultsDir -WatcherJson $watcherPath
+
+    $idx = Get-Content -LiteralPath (Join-Path $resultsDir 'session-index.json') -Raw | ConvertFrom-Json
+    $idx.watchers.rest.status | Should -Be 'missing-file'
+    $idx.watchers.rest.conclusion | Should -Be 'watcher-error'
+    $idx.watchers.rest.watcherPath | Should -Be $watcherPath
+  }
+
+  It 'records invalid-json watcher status when watcher payload is malformed' {
+    $resultsDir = & $script:newSessionIndexFixture 'watcher-invalid'
+    $watcherPath = Join-Path $TestDrive 'invalid-watcher.json'
+    Set-Content -LiteralPath $watcherPath -Value '{ invalid json' -Encoding UTF8
+
+    & $script:updateScript -ResultsDir $resultsDir -WatcherJson $watcherPath
+
+    $idx = Get-Content -LiteralPath (Join-Path $resultsDir 'session-index.json') -Raw | ConvertFrom-Json
+    $idx.watchers.rest.status | Should -Be 'invalid-json'
+    $idx.watchers.rest.conclusion | Should -Be 'watcher-error'
+    ($idx.watchers.rest.notes | Measure-Object).Count | Should -BeGreaterThan 0
+  }
+}

--- a/tools/Update-SessionIndexWatcher.ps1
+++ b/tools/Update-SessionIndexWatcher.ps1
@@ -7,14 +7,57 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-if (-not $WatcherJson) {
-  Write-Verbose '[watcher-session] WatcherJson path not provided; skipping.'
-  return
+function Update-SessionIndexWithWatcher {
+  param(
+    [pscustomobject]$SessionIndex,
+    [psobject]$WatcherPayload,
+    [string]$SummaryLine
+  )
+
+  $watchersObject = $null
+  if ($SessionIndex.PSObject.Properties.Name -contains 'watchers') {
+    $watchersObject = $SessionIndex.watchers
+  }
+  if (-not $watchersObject) {
+    $watchersObject = [pscustomobject]@{}
+  }
+  $watchersObject | Add-Member -NotePropertyName 'rest' -NotePropertyValue $WatcherPayload -Force
+  $SessionIndex | Add-Member -NotePropertyName 'watchers' -NotePropertyValue $watchersObject -Force
+
+  if ($SummaryLine -and $SessionIndex.PSObject.Properties.Name -contains 'stepSummary' -and $SessionIndex.stepSummary) {
+    $summaryLines = @($SessionIndex.stepSummary, '', '### Watcher (REST)', $SummaryLine)
+    if ($WatcherPayload.PSObject.Properties.Name -contains 'htmlUrl' -and $WatcherPayload.htmlUrl) {
+      $summaryLines += "- URL: $($WatcherPayload.htmlUrl)"
+    }
+    $SessionIndex.stepSummary = ($summaryLines -join "`n")
+  }
+
+  return $SessionIndex
 }
 
-if (-not (Test-Path -LiteralPath $WatcherJson -PathType Leaf)) {
-  Write-Verbose "[watcher-session] Watcher file not found: $WatcherJson"
-  return
+function New-WatcherFallback {
+  param(
+    [string]$Status,
+    [string]$Reason,
+    [string]$PathHint,
+    [string]$ParseError
+  )
+
+  $payload = [ordered]@{
+    schema      = 'ci-watch/rest-v1'
+    status      = $Status
+    conclusion  = 'watcher-error'
+    polledAtUtc = (Get-Date).ToUniversalTime().ToString('o')
+    jobs        = @()
+    notes       = @($Reason)
+  }
+  if ($PathHint) {
+    $payload['watcherPath'] = $PathHint
+  }
+  if ($ParseError) {
+    $payload['parseError'] = $ParseError
+  }
+  return [pscustomobject]$payload
 }
 
 if (-not (Test-Path -LiteralPath $ResultsDir -PathType Container)) {
@@ -42,28 +85,32 @@ try {
   return
 }
 
-try {
-  $watch = Get-Content -LiteralPath $WatcherJson -Raw | ConvertFrom-Json -ErrorAction Stop
-} catch {
-  Write-Warning "[watcher-session] Failed to parse watcher summary: $_"
-  return
+$watch = $null
+$summaryLine = $null
+
+if (-not $WatcherJson) {
+  Write-Warning '[watcher-session] WatcherJson path not provided; recording watcher status as missing-input.'
+  $watch = New-WatcherFallback -Status 'missing-input' -Reason 'WatcherJson path not provided to Update-SessionIndexWatcher.'
+  $summaryLine = '- Status: missing-input/watcher-error'
+} elseif (-not (Test-Path -LiteralPath $WatcherJson -PathType Leaf)) {
+  Write-Warning "[watcher-session] Watcher file not found: $WatcherJson"
+  $watch = New-WatcherFallback -Status 'missing-file' -Reason 'Watcher summary file was not found.' -PathHint $WatcherJson
+  $summaryLine = '- Status: missing-file/watcher-error'
+} else {
+  try {
+    $watch = Get-Content -LiteralPath $WatcherJson -Raw | ConvertFrom-Json -ErrorAction Stop
+    $status = if ($watch.PSObject.Properties.Name -contains 'status' -and $watch.status) { $watch.status } else { 'unknown' }
+    $conclusion = if ($watch.PSObject.Properties.Name -contains 'conclusion' -and $watch.conclusion) { $watch.conclusion } else { 'unknown' }
+    $summaryLine = "- Status: $status/$conclusion"
+  } catch {
+    $parseError = $_.Exception.Message
+    Write-Warning "[watcher-session] Failed to parse watcher summary: $parseError"
+    $watch = New-WatcherFallback -Status 'invalid-json' -Reason 'Watcher summary JSON could not be parsed.' -PathHint $WatcherJson -ParseError $parseError
+    $summaryLine = '- Status: invalid-json/watcher-error'
+  }
 }
 
-$watchersObject = $null
-if ($idx.PSObject.Properties.Name -contains 'watchers') {
-  $watchersObject = $idx.watchers
-}
-if (-not $watchersObject) {
-  $watchersObject = [pscustomobject]@{}
-}
-$watchersObject | Add-Member -NotePropertyName 'rest' -NotePropertyValue $watch -Force
-$idx | Add-Member -NotePropertyName 'watchers' -NotePropertyValue $watchersObject -Force
-
-if ($idx.PSObject.Properties.Name -contains 'stepSummary' -and $idx.stepSummary) {
-  $summaryLines = @($idx.stepSummary, '', '### Watcher (REST)', "- Status: $($watch.status ?? 'unknown')", "- Conclusion: $($watch.conclusion ?? 'unknown')")
-  if ($watch.htmlUrl) { $summaryLines += "- URL: $($watch.htmlUrl)" }
-  $idx.stepSummary = ($summaryLines -join "`n")
-}
+$idx = Update-SessionIndexWithWatcher -SessionIndex $idx -WatcherPayload $watch -SummaryLine $summaryLine
 
 $idx | ConvertTo-Json -Depth 10 | Out-File -FilePath $idxPath -Encoding utf8
 Write-Verbose "[watcher-session] Updated session index with REST watcher summary."


### PR DESCRIPTION
## Summary
- harden `Update-SessionIndexWatcher.ps1` to always surface watcher merge state in `session-index.json`
- record explicit fallback watcher states for missing input, missing file, and invalid JSON (`watcher-error` conclusion)
- add focused unit tests covering valid merge + fallback behaviors

## Why
Issue #221 requires watcher/session-index telemetry consistency and explicit surfacing of missing/invalid watcher artifacts.

## Validation
- `pwsh -NoLogo -NoProfile -File Invoke-PesterTests.ps1 -TestsPath tests/Update.SessionIndexWatcher.Tests.ps1 -IntegrationMode exclude -ResultsPath tests/results`
- `node tools/npm/run-script.mjs schema:watcher:validate`

Closes #221
