### PR TITLE
fix(prepush): normalize mixed-shell remote auth probes (#229)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,6 +139,10 @@ line buffers).
   - Installs `actionlint` (`vars.ACTIONLINT_VERSION`, default 1.7.7) if missing.
   - Runs `actionlint` across `.github/workflows`.
   - Optionally round-trips YAML with `ruamel.yaml` (if Python available).
+  - For mixed WSL/Windows shells, prefer HTTPS fetch + SSH push on `origin` to avoid
+    `git ls-remote` auth drift across terminals:
+    - `git remote set-url origin https://github.com/<owner>/<repo>.git`
+    - `git remote set-url --push origin git@github.com:<owner>/<repo>.git`
 - For VI history/container work, run Docker fast-loop before push:
   - Single-lane strict (recommended first, no runtime auto-repair/engine switching):
     - `pwsh -NoLogo -NoProfile -File tools/Test-DockerDesktopFastLoop.ps1 -LaneScope linux -StepTimeoutSeconds 600`

--- a/tests/Assert-NoAmbiguousRemoteRefs.Tests.ps1
+++ b/tests/Assert-NoAmbiguousRemoteRefs.Tests.ps1
@@ -1,0 +1,112 @@
+Set-StrictMode -Version Latest
+
+Describe 'Assert-NoAmbiguousRemoteRefs.ps1' {
+  BeforeAll {
+    $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+    $script:GuardScript = Join-Path $script:RepoRoot 'tools' 'Assert-NoAmbiguousRemoteRefs.ps1'
+    if (-not (Test-Path -LiteralPath $script:GuardScript -PathType Leaf)) {
+      throw "Guard script not found: $script:GuardScript"
+    }
+  }
+
+  AfterEach {
+    Remove-Item Function:\global:git -ErrorAction SilentlyContinue
+  }
+
+  It 'falls back to HTTPS probe when SSH remote probe fails' {
+    function global:git {
+      param([Parameter(ValueFromRemainingArguments = $true)][string[]]$Args)
+      $command = ($Args -join ' ')
+      switch -Regex ($command) {
+        '^ls-remote --heads --tags origin$' {
+          $global:LASTEXITCODE = 128
+          return @('Permission denied (publickey).')
+        }
+        '^remote get-url origin$' {
+          $global:LASTEXITCODE = 0
+          return @('git@github.com:svelderrainruiz/compare-vi-cli-action.git')
+        }
+        '^ls-remote --heads --tags https://github.com/svelderrainruiz/compare-vi-cli-action.git$' {
+          $global:LASTEXITCODE = 0
+          return @(
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa`trefs/heads/develop",
+            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb`trefs/tags/v0.6.0"
+          )
+        }
+        default {
+          $global:LASTEXITCODE = 0
+          return @()
+        }
+      }
+    }
+
+    { & $script:GuardScript -Remote origin } | Should -Not -Throw
+  }
+
+  It 'reports both probe attempts when SSH and HTTPS fail' {
+    function global:git {
+      param([Parameter(ValueFromRemainingArguments = $true)][string[]]$Args)
+      $command = ($Args -join ' ')
+      switch -Regex ($command) {
+        '^ls-remote --heads --tags origin$' {
+          $global:LASTEXITCODE = 128
+          return @('Permission denied (publickey).')
+        }
+        '^remote get-url origin$' {
+          $global:LASTEXITCODE = 0
+          return @('git@github.com:svelderrainruiz/compare-vi-cli-action.git')
+        }
+        '^ls-remote --heads --tags https://github.com/svelderrainruiz/compare-vi-cli-action.git$' {
+          $global:LASTEXITCODE = 128
+          return @('Authentication failed.')
+        }
+        default {
+          $global:LASTEXITCODE = 0
+          return @()
+        }
+      }
+    }
+
+    $thrown = $null
+    try {
+      & $script:GuardScript -Remote origin
+    } catch {
+      $thrown = $_
+    }
+
+    $thrown | Should -Not -BeNullOrEmpty
+    $thrown.Exception.Message | Should -Match 'Attempt 1'
+    $thrown.Exception.Message | Should -Match 'Attempt 2'
+    $thrown.Exception.Message | Should -Match 'Mixed-shell recommendation'
+  }
+
+  It 'still fails when refs are ambiguous after HTTPS fallback' {
+    function global:git {
+      param([Parameter(ValueFromRemainingArguments = $true)][string[]]$Args)
+      $command = ($Args -join ' ')
+      switch -Regex ($command) {
+        '^ls-remote --heads --tags origin$' {
+          $global:LASTEXITCODE = 128
+          return @('Permission denied (publickey).')
+        }
+        '^remote get-url origin$' {
+          $global:LASTEXITCODE = 0
+          return @('git@github.com:svelderrainruiz/compare-vi-cli-action.git')
+        }
+        '^ls-remote --heads --tags https://github.com/svelderrainruiz/compare-vi-cli-action.git$' {
+          $global:LASTEXITCODE = 0
+          return @(
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa`trefs/heads/release/v0.6.0",
+            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb`trefs/tags/release/v0.6.0"
+          )
+        }
+        default {
+          $global:LASTEXITCODE = 0
+          return @()
+        }
+      }
+    }
+
+    { & $script:GuardScript -Remote origin } | Should -Throw -ExpectedMessage '*Ambiguous remote refs detected*'
+  }
+}

--- a/tools/Assert-NoAmbiguousRemoteRefs.ps1
+++ b/tools/Assert-NoAmbiguousRemoteRefs.ps1
@@ -20,6 +20,75 @@ Remote name to inspect. Defaults to `origin`.
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
+function Invoke-GitLsRemoteProbe {
+  param(
+    [Parameter(Mandatory)][string]$RemoteSpec,
+    [Parameter(Mandatory)][string]$Label
+  )
+
+  $oldPrompt = $env:GIT_TERMINAL_PROMPT
+  try {
+    $env:GIT_TERMINAL_PROMPT = '0'
+    $lines = git ls-remote --heads --tags $RemoteSpec
+    $exitCode = $LASTEXITCODE
+  } finally {
+    $env:GIT_TERMINAL_PROMPT = $oldPrompt
+  }
+
+  [pscustomobject]@{
+    Label    = $Label
+    Remote   = $RemoteSpec
+    ExitCode = $exitCode
+    Succeeded = ($exitCode -eq 0)
+    Lines    = @($lines)
+  }
+}
+
+function Convert-GitHubSshToHttps {
+  param([Parameter(Mandatory)][string]$RemoteUrl)
+
+  if ($RemoteUrl -match '^(?:ssh://)?git@github\.com[:/](?<path>[^\s]+?)(?:\.git)?$') {
+    $repoPath = $Matches['path']
+    return "https://github.com/$repoPath.git"
+  }
+
+  return $null
+}
+
+function Get-LsRemoteFailureMessage {
+  param(
+    [Parameter(Mandatory)][string]$RemoteName,
+    [Parameter(Mandatory)][System.Collections.IEnumerable]$Attempts,
+    [Parameter()][string]$RemoteUrl,
+    [Parameter()][string]$FallbackUrl
+  )
+
+  $lines = @(
+    "git ls-remote probe failed for remote '$RemoteName'."
+  )
+
+  $index = 0
+  foreach ($attempt in @($Attempts)) {
+    $index += 1
+    $lines += ("Attempt {0} ({1}: {2}) exited with code {3}." -f $index, $attempt.Label, $attempt.Remote, $attempt.ExitCode)
+  }
+
+  if (-not [string]::IsNullOrWhiteSpace($RemoteUrl)) {
+    $lines += "Remote URL: $RemoteUrl"
+  }
+  if (-not [string]::IsNullOrWhiteSpace($FallbackUrl)) {
+    $lines += "HTTPS fallback URL: $FallbackUrl"
+  }
+
+  $lines += ''
+  $lines += 'Configure one of the following and retry:'
+  $lines += '- SSH path: ensure an SSH key/agent is available in this shell.'
+  $lines += '- HTTPS path: set remote fetch URL to https://github.com/<owner>/<repo>.git and authenticate via credential helper.'
+  $lines += '- Mixed-shell recommendation: keep fetch over HTTPS and push over SSH using `git remote set-url --push`.'
+
+  return ($lines -join [Environment]::NewLine)
+}
+
 if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
   throw 'git must be available on PATH.'
 }
@@ -29,10 +98,33 @@ if (-not $remoteTrim) {
   throw 'Remote name cannot be empty.'
 }
 
-$lsRemoteArgs = @('ls-remote', '--heads', '--tags', $remoteTrim)
-$rawRefs = git @lsRemoteArgs
-if ($LASTEXITCODE -ne 0) {
-  throw "git ls-remote failed (exit $LASTEXITCODE)."
+$attempts = @()
+$primaryProbe = Invoke-GitLsRemoteProbe -RemoteSpec $remoteTrim -Label 'remote-name'
+$attempts += $primaryProbe
+
+$rawRefs = $null
+$remoteUrl = $null
+$fallbackUrl = $null
+
+if ($primaryProbe.Succeeded) {
+  $rawRefs = $primaryProbe.Lines
+} else {
+  $remoteUrl = (git remote get-url $remoteTrim 2>$null)
+  if ($LASTEXITCODE -eq 0 -and $remoteUrl) {
+    $fallbackUrl = Convert-GitHubSshToHttps -RemoteUrl $remoteUrl
+  }
+
+  if (-not [string]::IsNullOrWhiteSpace($fallbackUrl)) {
+    $fallbackProbe = Invoke-GitLsRemoteProbe -RemoteSpec $fallbackUrl -Label 'https-fallback'
+    $attempts += $fallbackProbe
+    if ($fallbackProbe.Succeeded) {
+      $rawRefs = $fallbackProbe.Lines
+    }
+  }
+
+  if (-not $rawRefs) {
+    throw (Get-LsRemoteFailureMessage -RemoteName $remoteTrim -Attempts $attempts -RemoteUrl $remoteUrl -FallbackUrl $fallbackUrl)
+  }
 }
 
 if (-not $rawRefs) {
@@ -41,7 +133,7 @@ if (-not $rawRefs) {
 }
 
 $entries = @()
-foreach ($line in $rawRefs -split "`n") {
+foreach ($line in (@($rawRefs) -join "`n") -split "(`r`n|`n)") {
   $parts = $line.Trim() -split "`t"
   if ($parts.Count -lt 2) { continue }
   $sha = $parts[0].Trim()


### PR DESCRIPTION
## Summary
- harden `tools/Assert-NoAmbiguousRemoteRefs.ps1` with deterministic probe behavior:
  - first try remote-name `git ls-remote --heads --tags <remote>`
  - if that fails and the remote URL is GitHub SSH, retry with HTTPS fallback
  - emit explicit multi-attempt diagnostics and mixed-shell setup guidance when probes fail
- add focused tests in `tests/Assert-NoAmbiguousRemoteRefs.Tests.ps1` covering:
  - SSH probe failure + HTTPS fallback success
  - SSH + HTTPS failure diagnostics
  - ambiguous refs still failing after fallback
- document recommended mixed-shell remote configuration in `AGENTS.md`

## Validation
- `/mnt/c/Program Files/PowerShell/7/pwsh.exe -NoLogo -NoProfile -Command "Invoke-Pester -Path 'tests/Assert-NoAmbiguousRemoteRefs.Tests.ps1' -Output Detailed"`

Closes #229
