### PR TITLE
chore(vscode): add safe PR check tasks across workspaces (#231)

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -314,6 +314,27 @@
       },
       "group": "test",
       "problemMatcher": []
+    },
+    {
+      "label": "CI: Watch PR checks (safe snapshot)",
+      "type": "process",
+      "command": "node",
+      "args": [
+        "tools/npm/run-script.mjs",
+        "ci:watch:safe",
+        "--",
+        "--PullRequest",
+        "${input:watchPrNumber}",
+        "-IntervalSeconds",
+        "20",
+        "-HeartbeatPolls",
+        "3"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}"
+      },
+      "group": "test",
+      "problemMatcher": []
     }
   ],
   "inputs": [
@@ -416,6 +437,12 @@
         }
       ],
       "default": "64"
+    },
+    {
+      "id": "watchPrNumber",
+      "type": "promptString",
+      "description": "Pull request number for safe PR check polling",
+      "default": "1"
     }
   ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -297,9 +297,16 @@ Use `tools/workflows/update_workflows.py` for mechanical updates (comment-preser
   status under the `watchers.rest` node. Run it after the watcher step if you update the workflow or run the watcher
   manually.
 - For PR status polling in VS Code terminals, prefer snapshot mode instead of `gh pr checks --watch`:
-  - `node tools/npm/run-script.mjs ci:watch:safe -- --PullRequest <pr-number> -IntervalSeconds 20`
+  - VS Code task: `CI: Watch PR checks (safe snapshot)`
+  - Workspace tasks:
+    - `Command Center: watch PR checks (safe, fork plane)`
+    - `Fork Plane: watch PR checks (safe)`
+    - `Upstream Plane: watch PR checks (safe)`
+  - CLI equivalent: `node tools/npm/run-script.mjs ci:watch:safe -- --PullRequest <pr-number> -IntervalSeconds 20`
   - The helper emits delta/heartbeat summaries using repeated `gh pr checks --json` snapshots and avoids high-volume
     repaint loops that can destabilize integrated terminals.
+  - Smoke-check the watcher behavior (expected: one summary line plus either delta entries or a no-change heartbeat):
+    - `node tools/npm/run-script.mjs ci:watch:safe -- --PullRequest <pr-number> -IntervalSeconds 20 -HeartbeatPolls 1 -MaxPolls 2`
 
 ## LVCompare observability
 

--- a/compare-vi-cli-action.code-workspace
+++ b/compare-vi-cli-action.code-workspace
@@ -120,6 +120,26 @@
           "cwd": "${workspaceFolder:PLANE_UPSTREAM__compare-vi-cli-action}"
         },
         "problemMatcher": []
+      },
+      {
+        "label": "Command Center: watch PR checks (safe, fork plane)",
+        "type": "process",
+        "command": "node",
+        "args": [
+          "tools/npm/run-script.mjs",
+          "ci:watch:safe",
+          "--",
+          "--PullRequest",
+          "${input:watchPullRequest}",
+          "-IntervalSeconds",
+          "20",
+          "-HeartbeatPolls",
+          "3"
+        ],
+        "options": {
+          "cwd": "${workspaceFolder:PLANE_FORK__compare-vi-cli-action}"
+        },
+        "problemMatcher": []
       }
     ],
     "inputs": [
@@ -134,6 +154,12 @@
         "type": "promptString",
         "description": "Branch name to watch latest Validate run",
         "default": "develop"
+      },
+      {
+        "id": "watchPullRequest",
+        "type": "promptString",
+        "description": "Pull request number for safe check polling",
+        "default": "1"
       }
     ]
   }

--- a/compare-vi-cli-action.command-center.code-workspace
+++ b/compare-vi-cli-action.command-center.code-workspace
@@ -120,6 +120,26 @@
           "cwd": "${workspaceFolder:PLANE_UPSTREAM__compare-vi-cli-action}"
         },
         "problemMatcher": []
+      },
+      {
+        "label": "Command Center: watch PR checks (safe, fork plane)",
+        "type": "process",
+        "command": "node",
+        "args": [
+          "tools/npm/run-script.mjs",
+          "ci:watch:safe",
+          "--",
+          "--PullRequest",
+          "${input:watchPullRequest}",
+          "-IntervalSeconds",
+          "20",
+          "-HeartbeatPolls",
+          "3"
+        ],
+        "options": {
+          "cwd": "${workspaceFolder:PLANE_FORK__compare-vi-cli-action}"
+        },
+        "problemMatcher": []
       }
     ],
     "inputs": [
@@ -134,6 +154,12 @@
         "type": "promptString",
         "description": "Branch name to watch latest Validate run",
         "default": "develop"
+      },
+      {
+        "id": "watchPullRequest",
+        "type": "promptString",
+        "description": "Pull request number for safe check polling",
+        "default": "1"
       }
     ]
   }

--- a/compare-vi-cli-action.fork-plane.code-workspace
+++ b/compare-vi-cli-action.fork-plane.code-workspace
@@ -70,6 +70,26 @@
           "cwd": "${workspaceFolder:PLANE_FORK__compare-vi-cli-action}"
         },
         "problemMatcher": []
+      },
+      {
+        "label": "Fork Plane: watch PR checks (safe)",
+        "type": "process",
+        "command": "node",
+        "args": [
+          "tools/npm/run-script.mjs",
+          "ci:watch:safe",
+          "--",
+          "--PullRequest",
+          "${input:forkWatchPullRequest}",
+          "-IntervalSeconds",
+          "20",
+          "-HeartbeatPolls",
+          "3"
+        ],
+        "options": {
+          "cwd": "${workspaceFolder:PLANE_FORK__compare-vi-cli-action}"
+        },
+        "problemMatcher": []
       }
     ],
     "inputs": [
@@ -78,6 +98,12 @@
         "type": "promptString",
         "description": "Branch/ref for Validate dispatch from fork plane",
         "default": "develop"
+      },
+      {
+        "id": "forkWatchPullRequest",
+        "type": "promptString",
+        "description": "Pull request number to monitor with safe snapshots",
+        "default": "1"
       }
     ]
   }

--- a/compare-vi-cli-action.upstream-plane.code-workspace
+++ b/compare-vi-cli-action.upstream-plane.code-workspace
@@ -71,6 +71,26 @@
           "cwd": "${workspaceFolder:PLANE_UPSTREAM__compare-vi-cli-action}"
         },
         "problemMatcher": []
+      },
+      {
+        "label": "Upstream Plane: watch PR checks (safe)",
+        "type": "process",
+        "command": "node",
+        "args": [
+          "tools/npm/run-script.mjs",
+          "ci:watch:safe",
+          "--",
+          "--PullRequest",
+          "${input:upstreamWatchPullRequest}",
+          "-IntervalSeconds",
+          "20",
+          "-HeartbeatPolls",
+          "3"
+        ],
+        "options": {
+          "cwd": "${workspaceFolder:PLANE_UPSTREAM__compare-vi-cli-action}"
+        },
+        "problemMatcher": []
       }
     ],
     "inputs": [
@@ -84,6 +104,12 @@
         "id": "mergePrNumber",
         "type": "promptString",
         "description": "PR number to merge with priority:merge-sync"
+      },
+      {
+        "id": "upstreamWatchPullRequest",
+        "type": "promptString",
+        "description": "Pull request number to monitor with safe snapshots",
+        "default": "1"
       }
     ]
   }


### PR DESCRIPTION
## Summary
- add first-class VS Code tasks for safe PR check polling in all committed workspace configs:
  - command-center alias workspace
  - command-center workspace
  - fork-plane workspace
  - upstream-plane workspace
  - shared `.vscode/tasks.json`
- wire task prompts for PR number and standardize safe polling args (`-IntervalSeconds 20 -HeartbeatPolls 3`)
- update `AGENTS.md` runbook guidance to make safe tasks the default and include a smoke-check command for heartbeat/delta output

## Validation
- `/mnt/c/Program Files/nodejs/node.exe -e "const fs=require('fs');const files=['.vscode/tasks.json','compare-vi-cli-action.code-workspace','compare-vi-cli-action.command-center.code-workspace','compare-vi-cli-action.fork-plane.code-workspace','compare-vi-cli-action.upstream-plane.code-workspace'];for(const f of files){JSON.parse(fs.readFileSync(f,'utf8').replace(/^\uFEFF/,''));console.log('OK',f)}"`
- `/mnt/c/Program Files/nodejs/node.exe tools/npm/run-script.mjs ci:watch:safe -- --PullRequest 230 -MaxPolls 1 -HeartbeatPolls 1 -IntervalSeconds 20`

Closes #231
