### PR TITLE
test(tasks): guard safe PR watch task contracts (#233)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,6 +139,8 @@ line buffers).
   - Installs `actionlint` (`vars.ACTIONLINT_VERSION`, default 1.7.7) if missing.
   - Runs `actionlint` across `.github/workflows`.
   - Optionally round-trips YAML with `ruamel.yaml` (if Python available).
+  - Validate safe PR watch task contracts before task/workspace changes:
+    - `node tools/npm/run-script.mjs safe-watch:contract`
   - For mixed WSL/Windows shells, prefer HTTPS fetch + SSH push on `origin` to avoid
     `git ls-remote` auth drift across terminals:
     - `git remote set-url origin https://github.com/<owner>/<repo>.git`
@@ -307,6 +309,12 @@ Use `tools/workflows/update_workflows.py` for mechanical updates (comment-preser
     repaint loops that can destabilize integrated terminals.
   - Smoke-check the watcher behavior (expected: one summary line plus either delta entries or a no-change heartbeat):
     - `node tools/npm/run-script.mjs ci:watch:safe -- --PullRequest <pr-number> -IntervalSeconds 20 -HeartbeatPolls 1 -MaxPolls 2`
+  - If `safe-watch:contract` fails, restore expected task labels/inputs and argument wiring in:
+    - `.vscode/tasks.json`
+    - `compare-vi-cli-action.code-workspace`
+    - `compare-vi-cli-action.command-center.code-workspace`
+    - `compare-vi-cli-action.fork-plane.code-workspace`
+    - `compare-vi-cli-action.upstream-plane.code-workspace`
 
 ## LVCompare observability
 

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "priority:sync": "node tools/priority/sync-standing-priority.mjs",
     "priority:sync:docker": "pwsh -NoLogo -NoProfile -File tools/Run-NonLVChecksInDocker.ps1 -ToolsImageTag comparevi-tools:local -UseToolsImage -PrioritySync -SkipActionlint -SkipMarkdown -SkipDocs -SkipWorkflow -SkipDotnetCliBuild",
     "priority:test": "node --test tools/priority/__tests__/*.mjs",
+    "safe-watch:contract": "node --test tools/priority/__tests__/safe-watch-task-contract.test.mjs",
     "priority:validate": "node tools/priority/dispatch-validate.mjs",
     "publish:cli": "pwsh -NoLogo -NoProfile -File tools/Publish-Cli.ps1",
     "release:branch": "node tools/priority/create-release-branch.mjs",

--- a/tools/priority/__tests__/safe-watch-task-contract.test.mjs
+++ b/tools/priority/__tests__/safe-watch-task-contract.test.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parse as parseJsonc } from 'jsonc-parser';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+
+const FILE_CONTRACTS = [
+  {
+    file: '.vscode/tasks.json',
+    label: 'CI: Watch PR checks (safe snapshot)',
+    inputId: 'watchPrNumber',
+    expectedCwd: '${workspaceFolder}'
+  },
+  {
+    file: 'compare-vi-cli-action.command-center.code-workspace',
+    label: 'Command Center: watch PR checks (safe, fork plane)',
+    inputId: 'watchPullRequest',
+    expectedCwd: '${workspaceFolder:PLANE_FORK__compare-vi-cli-action}'
+  },
+  {
+    file: 'compare-vi-cli-action.code-workspace',
+    label: 'Command Center: watch PR checks (safe, fork plane)',
+    inputId: 'watchPullRequest',
+    expectedCwd: '${workspaceFolder:PLANE_FORK__compare-vi-cli-action}'
+  },
+  {
+    file: 'compare-vi-cli-action.fork-plane.code-workspace',
+    label: 'Fork Plane: watch PR checks (safe)',
+    inputId: 'forkWatchPullRequest',
+    expectedCwd: '${workspaceFolder:PLANE_FORK__compare-vi-cli-action}'
+  },
+  {
+    file: 'compare-vi-cli-action.upstream-plane.code-workspace',
+    label: 'Upstream Plane: watch PR checks (safe)',
+    inputId: 'upstreamWatchPullRequest',
+    expectedCwd: '${workspaceFolder:PLANE_UPSTREAM__compare-vi-cli-action}'
+  }
+];
+
+function readJsonc(relativePath) {
+  const absolutePath = path.join(repoRoot, relativePath);
+  const text = readFileSync(absolutePath, 'utf8');
+  const parsed = parseJsonc(text);
+  return { absolutePath, parsed };
+}
+
+function findTaskContainer(parsed) {
+  if (Array.isArray(parsed?.tasks)) {
+    return { tasks: parsed.tasks, inputs: parsed.inputs ?? [] };
+  }
+  return {
+    tasks: parsed?.tasks?.tasks ?? [],
+    inputs: parsed?.tasks?.inputs ?? []
+  };
+}
+
+function assertSafeWatcherArgs(task, inputId) {
+  const args = task?.args ?? [];
+  assert.ok(Array.isArray(args), `Task '${task?.label ?? '<unknown>'}' args must be an array`);
+  assert.ok(args.includes('ci:watch:safe'), `Task '${task.label}' must call ci:watch:safe`);
+  assert.ok(args.includes('--PullRequest'), `Task '${task.label}' must pass --PullRequest`);
+  assert.ok(args.includes(`\${input:${inputId}}`), `Task '${task.label}' must reference input ${inputId}`);
+
+  const intervalIndex = args.indexOf('-IntervalSeconds');
+  assert.ok(intervalIndex >= 0, `Task '${task.label}' must include -IntervalSeconds`);
+  assert.equal(String(args[intervalIndex + 1]), '20', `Task '${task.label}' must set -IntervalSeconds 20`);
+
+  const heartbeatIndex = args.indexOf('-HeartbeatPolls');
+  assert.ok(heartbeatIndex >= 0, `Task '${task.label}' must include -HeartbeatPolls`);
+  assert.equal(String(args[heartbeatIndex + 1]), '3', `Task '${task.label}' must set -HeartbeatPolls 3`);
+}
+
+test('safe PR watch task contract is enforced across committed workspace configs', () => {
+  for (const contract of FILE_CONTRACTS) {
+    const { parsed } = readJsonc(contract.file);
+    const { tasks, inputs } = findTaskContainer(parsed);
+
+    const safeTask = tasks.find((task) => task?.label === contract.label);
+    assert.ok(safeTask, `${contract.file} must contain task '${contract.label}'`);
+    assert.equal(safeTask.command, 'node', `Task '${contract.label}' in ${contract.file} must use node command`);
+    assert.equal(
+      safeTask?.options?.cwd,
+      contract.expectedCwd,
+      `Task '${contract.label}' in ${contract.file} must use cwd '${contract.expectedCwd}'`
+    );
+
+    assertSafeWatcherArgs(safeTask, contract.inputId);
+
+    const input = inputs.find((entry) => entry?.id === contract.inputId);
+    assert.ok(input, `${contract.file} must define input '${contract.inputId}'`);
+    assert.equal(input.type, 'promptString', `Input '${contract.inputId}' in ${contract.file} must be promptString`);
+  }
+});


### PR DESCRIPTION
## Summary
- add deterministic safe-watch task contract test at `tools/priority/__tests__/safe-watch-task-contract.test.mjs`
- validate committed workspace/task configs expose expected safe polling task labels, argument wiring, and PR input prompts
- add focused script entrypoint `safe-watch:contract`
- update `AGENTS.md` local-gates guidance with the quick check command and drift troubleshooting restore paths

## Validation
- `/mnt/c/Program Files/nodejs/node.exe tools/npm/run-script.mjs safe-watch:contract`

Closes #233
