### PR TITLE
chore(prepush): enforce safe-watch task contract check (#235)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,8 +138,9 @@ line buffers).
 - Run `tools/PrePush-Checks.ps1` before pushing:
   - Installs `actionlint` (`vars.ACTIONLINT_VERSION`, default 1.7.7) if missing.
   - Runs `actionlint` across `.github/workflows`.
+  - Runs safe PR watch task contract validation (`safe-watch:contract`).
   - Optionally round-trips YAML with `ruamel.yaml` (if Python available).
-  - Validate safe PR watch task contracts before task/workspace changes:
+  - Validate safe PR watch task contracts manually before task/workspace changes when iterating locally:
     - `node tools/npm/run-script.mjs safe-watch:contract`
   - For mixed WSL/Windows shells, prefer HTTPS fetch + SSH push on `origin` to avoid
     `git ls-remote` auth drift across terminals:

--- a/tools/PrePush-Checks.ps1
+++ b/tools/PrePush-Checks.ps1
@@ -126,6 +126,13 @@ if ($code -ne 0) {
 }
 Write-Host '[pre-push] actionlint OK' -ForegroundColor Green
 
+Write-Host '[pre-push] Validating safe PR watch task contract' -ForegroundColor Cyan
+$safeWatchContractExit = Invoke-NodeTestSanitized -Args @('--test','tools/priority/__tests__/safe-watch-task-contract.test.mjs')
+if ($safeWatchContractExit -ne 0) {
+  throw "safe-watch task contract validation failed (exit=$safeWatchContractExit)."
+}
+Write-Host '[pre-push] safe-watch task contract OK' -ForegroundColor Green
+
 $verificationContractScript = Join-Path $root 'tools' 'Assert-RequirementsVerificationCheckContract.ps1'
 if (Test-Path -LiteralPath $verificationContractScript -PathType Leaf) {
   Write-Host '[pre-push] Verifying requirements-verification check naming contract' -ForegroundColor Cyan


### PR DESCRIPTION
## Summary
- integrate safe-watch task contract validation into `tools/PrePush-Checks.ps1`
- fail early when `tools/priority/__tests__/safe-watch-task-contract.test.mjs` detects workspace task drift
- align `AGENTS.md` local-gates wording with pre-push behavior while keeping manual command guidance

## Validation
- `/mnt/c/Program Files/nodejs/node.exe tools/npm/run-script.mjs safe-watch:contract`
- `/mnt/c/Program Files/PowerShell/7/pwsh.exe -NoLogo -NoProfile -File tools/PrePush-Checks.ps1 -SkipIconEditorFixtureChecks`

Refs #235
