### PR TITLE
chore(tasks): use run-script wrapper for npm-based tasks (#237)

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -57,7 +57,7 @@
         "-NoLogo",
         "-NoProfile",
         "-Command",
-        "$env:GH_TOKEN = Get-Content -Raw 'C:\\github_token.txt'; npm run smoke:vi-stage"
+        "$env:GH_TOKEN = Get-Content -Raw 'C:\\github_token.txt'; node tools/npm/run-script.mjs smoke:vi-stage"
       ],
       "options": {
         "cwd": "${workspaceFolder}"
@@ -152,9 +152,9 @@
     {
       "label": "VI History: Run local suite",
       "type": "process",
-      "command": "npm",
+      "command": "node",
       "args": [
-        "run",
+        "tools/npm/run-script.mjs",
         "history:run",
         "--",
         "-ViPath",
@@ -172,9 +172,9 @@
     {
       "label": "VI History: Dispatch workflow",
       "type": "process",
-      "command": "npm",
+      "command": "node",
       "args": [
-        "run",
+        "tools/npm/run-script.mjs",
         "history:dispatch",
         "--",
         "-ViPath",


### PR DESCRIPTION
## Summary
- route VS Code task entries from raw npm invocations to node tools/npm/run-script.mjs
- keep task labels, args, and operator UX unchanged
- align task execution with AGENTS wrapper guidance

## Validation
- /mnt/c/Program Files/nodejs/node.exe tools/npm/run-script.mjs safe-watch:contract