### PR TITLE
fix(tasks): dedupe local diff stateless task label (#239)

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -18,38 +18,6 @@
       "problemMatcher": []
     },
     {
-      "label": "Local: Verify diff session (real, stateless)",
-      "type": "process",
-      "command": "pwsh",
-      "args": [
-        "-NoLogo",
-        "-NoProfile",
-        "-File",
-        "tools/Run-LocalDiffSession.ps1",
-        "-BaseVi",
-        "${input:localDiffBase}",
-        "-HeadVi",
-        "${input:localDiffHead}",
-        "-Mode",
-        "${input:localDiffMode}",
-        "-ResultsRoot",
-        "${input:localDiffResultsReal}",
-        "-ProbeSetup",
-        "-AutoConfig",
-        "-Stateless",
-        "-RenderReport",
-        "-ArchiveDir",
-        "tests/results/_agent/local-diff/latest",
-        "-ArchiveZip",
-        "tests/results/_agent/local-diff/latest.zip"
-      ],
-      "options": {
-        "cwd": "${workspaceFolder}"
-      },
-      "group": "test",
-      "problemMatcher": []
-    },
-    {
       "label": "Smoke: VI staging label",
       "type": "process",
       "command": "pwsh",


### PR DESCRIPTION
## Summary
- remove duplicate VS Code task label for Local: Verify diff session (real, stateless)
- keep canonical task wired to tools/Verify-LocalDiffSession.ps1
- eliminate ambiguous task resolution in VS Code

## Validation
- /mnt/c/Program Files/nodejs/node.exe tools/npm/run-script.mjs safe-watch:contract