### PR TITLE
docs(agent): add shell-safe gh issue body-file guidance (#241)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,6 +132,9 @@ line buffers).
 - Keep commits focused; include `#<standing-number>` in subjects.
 - PRs should describe rationale, list affected workflows, and link to artifacts.
 - Ensure CI is green (lint + Pester). Verify no lingering processes on self-hosted runners.
+- For `gh issue create` / `gh issue edit` with multiline Markdown bodies in mixed
+  WSL/Windows shells, prefer `--body-file <path>` (or `-F`) over inline
+  `--body "..."` to avoid backtick command substitution and quoting drift.
 
 ## Local gates (pre-push)
 


### PR DESCRIPTION
## Summary
- document shell-safe guidance for gh issue create/edit markdown bodies
- prefer --body-file (-F) in mixed WSL/Windows shells to avoid backtick substitution
- keep guidance colocated in AGENTS commits/PR workflow section

## Validation
- /mnt/c/Program Files/PowerShell/7/pwsh.exe -NoLogo -NoProfile -File tools/Lint-Markdown.ps1 -Paths AGENTS.md (MD013 warnings only)