### PR TITLE
docs(agent): use wrapper in staging smoke example (#243)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,7 +76,7 @@ line buffers).
 - Pattern filter: `./Invoke-PesterTests.ps1 -IncludePatterns 'CompareVI.*'`
 - Staging smoke:
   - `pwsh -File tools/Test-PRVIStagingSmoke.ps1 -DryRun` (plan only)
-  - `npm run smoke:vi-stage` (full run; uses fixtures/vi-attr for a baked-in VI
+  - `node tools/npm/run-script.mjs smoke:vi-stage` (full run; uses fixtures/vi-attr for a baked-in VI
     attribute diff)
   Both flows post artifact links and the updated PR summary comment.
 - Containerized non-LV checks: `pwsh -File tools/Run-NonLVChecksInDocker.ps1`


### PR DESCRIPTION
## Summary
- replace AGENTS staging smoke raw npm run example with wrapper invocation
- keep command intent and surrounding guidance unchanged

## Validation
- /mnt/c/Program Files/PowerShell/7/pwsh.exe -NoLogo -NoProfile -File tools/Lint-Markdown.ps1 -Paths AGENTS.md (MD013 warnings only)