### PR TITLE
docs(agent): make watcher smoke command copy-safe (#247)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -312,8 +312,12 @@ Use `tools/workflows/update_workflows.py` for mechanical updates (comment-preser
   - The helper emits delta/heartbeat summaries using repeated `gh pr checks --json` snapshots and avoids high-volume
     repaint loops that can destabilize integrated terminals.
   - Smoke-check the watcher behavior (expected: one summary line plus either delta entries or a no-change heartbeat):
-    - `node tools/npm/run-script.mjs ci:watch:safe -- --PullRequest <pr-number>`
-      `-IntervalSeconds 20 -HeartbeatPolls 1 -MaxPolls 2`
+
+    ```bash
+    node tools/npm/run-script.mjs ci:watch:safe -- --PullRequest <pr-number> \
+      -IntervalSeconds 20 -HeartbeatPolls 1 -MaxPolls 2
+    ```
+
   - If `safe-watch:contract` fails, restore expected task labels/inputs and argument wiring in:
     - `.vscode/tasks.json`
     - `compare-vi-cli-action.code-workspace`


### PR DESCRIPTION
## Summary
- replace split inline smoke-check command with fenced bash block
- preserve command arguments and watcher guidance text

## Validation
- /mnt/c/Program Files/PowerShell/7/pwsh.exe -NoLogo -NoProfile -File tools/Lint-Markdown.ps1 -Paths AGENTS.md