### PR TITLE
docs(agent): add gh body-file examples (#249)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,6 +135,12 @@ line buffers).
 - For `gh issue create` / `gh issue edit` with multiline Markdown bodies in mixed
   WSL/Windows shells, prefer `--body-file <path>` (or `-F`) over inline
   `--body "..."` to avoid backtick command substitution and quoting drift.
+  Example:
+
+  ```bash
+  gh issue create --title "<title>" --body-file issue-body.md
+  gh issue edit <number> --body-file issue-body.md
+  ```
 
 ## Local gates (pre-push)
 


### PR DESCRIPTION
## Summary
- add concrete gh issue create/edit body-file examples to AGENTS
- keep existing mixed-shell guidance intact

## Validation
- /mnt/c/Program Files/PowerShell/7/pwsh.exe -NoLogo -NoProfile -File tools/Lint-Markdown.ps1 -Paths AGENTS.md