### PR TITLE
docs(devguide): use wrappers for smoke commands (#255)

### DIFF
--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -46,14 +46,14 @@ Quick reference for building, testing, and releasing the LVCompare composite act
 - **Smoke tests**
   - `pwsh -File tools/Test-PRVIStagingSmoke.ps1 -DryRun`
     (planning pass; prints the branch/PR that would be created)
-  - `npm run smoke:vi-stage` (full sweep; requires
+  - `node tools/npm/run-script.mjs smoke:vi-stage` (full sweep; requires
     `GH_TOKEN`/`GITHUB_TOKEN` with push + workflow scopes)
   - `pwsh -File tools/Test-PRVIHistorySmoke.ps1 -DryRun`
     (plan the `/vi-history` entry-point smoke)
   - `pwsh -File tools/Test-PRVIHistorySmoke.ps1 -Scenario sequential -DryRun`
     (plan the sequential multi-category history smoke; steps defined in
     `fixtures/vi-history/sequential.json`)
-  - `npm run smoke:vi-history` (full `/vi-history` dispatch; requires
+  - `node tools/npm/run-script.mjs smoke:vi-history` (full `/vi-history` dispatch; requires
     `GH_TOKEN`/`GITHUB_TOKEN` with repo + workflow scopes)
   - GitHub workflow "Smoke VI Staging" (`.github/workflows/vi-staging-smoke.yml`)
     - Trigger from the Actions UI or `gh workflow run vi-staging-smoke.yml`.


### PR DESCRIPTION
## Summary
- switch DEVELOPER_GUIDE smoke command examples from raw npm run to wrapper invocation
- keep surrounding guidance unchanged

## Validation
- targeted grep confirms smoke commands now use node tools/npm/run-script.mjs
- markdown lint for this file reports substantial pre-existing violations outside this change