### PR TITLE
docs(kb): use wrapper for vi-history smoke command (#257)

### DIFF
--- a/docs/knowledgebase/VICompare-Refs-Workflow.md
+++ b/docs/knowledgebase/VICompare-Refs-Workflow.md
@@ -110,7 +110,7 @@
   The rendered summary/comment includes `### Mobile Preview` with inline `<img ...history-image-...>` tags, capped by
   comment safety limits. Totals expose `previewImages` and `markdownTruncated`; per-target metadata surfaces under
   `targets[].reportImages` in `pr-vi-history-summary@v1`.
-  For a full end-to-end validation, run the smoke helper (`pwsh -File tools/Test-PRVIHistorySmoke.ps1` or `npm run smoke:vi-history`) to create a scratch PR, dispatch the workflow, and record the results under `tests/results/_agent/smoke/vi-history/`.
+  For a full end-to-end validation, run the smoke helper (`pwsh -File tools/Test-PRVIHistorySmoke.ps1` or `node tools/npm/run-script.mjs smoke:vi-history`) to create a scratch PR, dispatch the workflow, and record the results under `tests/results/_agent/smoke/vi-history/`.
   Benchmark/delta evidence is emitted alongside smoke summaries under
   `tests/results/_agent/smoke/vi-history/benchmarks/` (`vi-history-benchmark@v1` and
   `vi-history-benchmark-delta@v1`) with a markdown comment body ready for PR/issue posting.


### PR DESCRIPTION
## Summary
- replace raw npm smoke helper reference with wrapper invocation in VI history knowledgebase doc
- preserve surrounding workflow guidance text

## Validation
- grep confirms the smoke helper line now references node tools/npm/run-script.mjs smoke:vi-history