### PR TITLE
docs(health): use wrapper for snapshot command (#259)

### DIFF
--- a/docs/HEALTH_SNAPSHOT_COMMAND.md
+++ b/docs/HEALTH_SNAPSHOT_COMMAND.md
@@ -13,7 +13,7 @@ Outputs:
 ## Command
 
 ```bash
-npm run priority:health-snapshot
+node tools/npm/run-script.mjs priority:health-snapshot
 ```
 
 ## Data sources


### PR DESCRIPTION
## Summary
- replace raw npm health snapshot command with wrapper invocation in command doc
- keep all surrounding instructions unchanged

## Validation
- grep confirms command now uses node tools/npm/run-script.mjs priority:health-snapshot