### PR TITLE
docs(dual-plane): use wrappers for command references (#261)

### DIFF
--- a/docs/DUAL_PLANE_OPERATING_REQUIREMENTS.md
+++ b/docs/DUAL_PLANE_OPERATING_REQUIREMENTS.md
@@ -15,24 +15,24 @@ This document defines the objective verification contract for issue #665.
 
 | Requirement | Contract statement | Executable command/check | Evidence output | Owning issue(s) |
 | --- | --- | --- | --- | --- |
-| R1 Plane Separation | Upstream-targeting commands never run from fork context; fork commands never mutate upstream refs directly. | `npm run hooks:plane` and explicit dual-plane workspace task `cwd` wiring in `docs/DUAL_PLANE_WORKSPACES.md`. | Plane detection output from `hooks:plane`; named workspace folders and task wiring contract in docs. | #666 |
-| R2 Deterministic Health Snapshot | Snapshot must output upstream SHA, fork SHA, parity verdict, required-context verdict, and latest incident run IDs. | `npm run priority:health-snapshot` | `tests/results/_agent/health-snapshot/health-snapshot.json` and `tests/results/_agent/health-snapshot/health-snapshot.md` | #668 |
-| R3 Guardrails | Preflight fails fast on remote/repo mismatch; destructive operations log explicit branch/repo confirmations. | `pwsh -NoLogo -NoProfile -File tools/Assert-NoAmbiguousRemoteRefs.ps1`; `pwsh -NoLogo -NoProfile -File tools/PrePush-Checks.ps1`; `npm run priority:sync` | Guard script failure on ambiguous refs; pre-push gate output; standing-priority router/actions summary with repo/branch targeting. | #667 |
-| R4 Incident Triage | Standard flow for cancellations/failures with timestamps, failed step, and root-cause classification. | `npm run ci:watch:rest -- --run-id <id>` and `npm run priority:health-snapshot` | `tests/results/_agent/watcher-rest.json`; health snapshot incidents section and degraded notes. | #668 |
-| R5 Handoff Quality | Handoff includes commands, run URLs, and current open risk list. | `npm run priority:handoff-tests`; `pwsh -NoLogo -NoProfile -File tools/Print-AgentHandoff.ps1 -ApplyToggles -AutoTrim` | `tests/results/_agent/handoff/test-summary.json`; handoff watcher telemetry and session capsules under `tests/results/_agent/sessions/`. | #667 |
-| R6 Telemetry Contract Source | Snapshot/triage are session-index-first; no parallel long-lived run/branch/test metadata schema; migration allows v1+v2 with v2-first for new consumers. | `npm run priority:health-snapshot`; `pwsh -NoLogo -NoProfile -File tools/Test-SessionIndexV2Contract.ps1`; `npm run session-index:validate` | Health snapshot reports session-index source mode; v2 contract/validation outputs; migration docs and consumer matrix. | #668, #675, #676, #677, #678, #679 |
+| R1 Plane Separation | Upstream-targeting commands never run from fork context; fork commands never mutate upstream refs directly. | `node tools/npm/run-script.mjs hooks:plane` and explicit dual-plane workspace task `cwd` wiring in `docs/DUAL_PLANE_WORKSPACES.md`. | Plane detection output from `hooks:plane`; named workspace folders and task wiring contract in docs. | #666 |
+| R2 Deterministic Health Snapshot | Snapshot must output upstream SHA, fork SHA, parity verdict, required-context verdict, and latest incident run IDs. | `node tools/npm/run-script.mjs priority:health-snapshot` | `tests/results/_agent/health-snapshot/health-snapshot.json` and `tests/results/_agent/health-snapshot/health-snapshot.md` | #668 |
+| R3 Guardrails | Preflight fails fast on remote/repo mismatch; destructive operations log explicit branch/repo confirmations. | `pwsh -NoLogo -NoProfile -File tools/Assert-NoAmbiguousRemoteRefs.ps1`; `pwsh -NoLogo -NoProfile -File tools/PrePush-Checks.ps1`; `node tools/npm/run-script.mjs priority:sync` | Guard script failure on ambiguous refs; pre-push gate output; standing-priority router/actions summary with repo/branch targeting. | #667 |
+| R4 Incident Triage | Standard flow for cancellations/failures with timestamps, failed step, and root-cause classification. | `node tools/npm/run-script.mjs ci:watch:rest -- --run-id <id>` and `node tools/npm/run-script.mjs priority:health-snapshot` | `tests/results/_agent/watcher-rest.json`; health snapshot incidents section and degraded notes. | #668 |
+| R5 Handoff Quality | Handoff includes commands, run URLs, and current open risk list. | `node tools/npm/run-script.mjs priority:handoff-tests`; `pwsh -NoLogo -NoProfile -File tools/Print-AgentHandoff.ps1 -ApplyToggles -AutoTrim` | `tests/results/_agent/handoff/test-summary.json`; handoff watcher telemetry and session capsules under `tests/results/_agent/sessions/`. | #667 |
+| R6 Telemetry Contract Source | Snapshot/triage are session-index-first; no parallel long-lived run/branch/test metadata schema; migration allows v1+v2 with v2-first for new consumers. | `node tools/npm/run-script.mjs priority:health-snapshot`; `pwsh -NoLogo -NoProfile -File tools/Test-SessionIndexV2Contract.ps1`; `node tools/npm/run-script.mjs session-index:validate` | Health snapshot reports session-index source mode; v2 contract/validation outputs; migration docs and consumer matrix. | #668, #675, #676, #677, #678, #679 |
 
 ## Objective Verification Checklist
 
 Run these commands from repository root and confirm expected artifacts/results:
 
-1. `npm run hooks:plane`
+1. `node tools/npm/run-script.mjs hooks:plane`
 2. `pwsh -NoLogo -NoProfile -File tools/PrePush-Checks.ps1`
-3. `npm run priority:health-snapshot`
-4. `npm run ci:watch:rest -- --branch develop`
-5. `npm run priority:handoff-tests`
+3. `node tools/npm/run-script.mjs priority:health-snapshot`
+4. `node tools/npm/run-script.mjs ci:watch:rest -- --branch develop`
+5. `node tools/npm/run-script.mjs priority:handoff-tests`
 6. `pwsh -NoLogo -NoProfile -File tools/Test-SessionIndexV2Contract.ps1`
-7. `npm run session-index:validate`
+7. `node tools/npm/run-script.mjs session-index:validate`
 
 Passing these checks demonstrates the R1-R6 contract is executable, observable, and bounded to the declared ownership map.
 


### PR DESCRIPTION
## Summary
- replace dual-plane requirement/checklist npm run command examples with wrapper invocations
- preserve requirement semantics and surrounding non-command text

## Validation
- grep confirms no npm run command examples remain in docs/DUAL_PLANE_OPERATING_REQUIREMENTS.md