### PR TITLE
docs(icon-editor): use wrapper for validate command (#263)

### DIFF
--- a/docs/ICON_EDITOR_PACKAGE.md
+++ b/docs/ICON_EDITOR_PACKAGE.md
@@ -154,7 +154,7 @@ carries the actual LabVIEW payload.
     -BaselineManifest 'D:\vip\fixture-manifest-1.4.1.700.json'
 
   # Run via npm helper (dry-run)
-  npm run icon-editor:validate -- --DryRun --SkipBootstrap --SkipLVCompare
+  node tools/npm/run-script.mjs icon-editor:validate -- --DryRun --SkipBootstrap --SkipLVCompare
   ```
 
 - Outputs land in `tests/results/_agent/icon-editor/local-validate` by default:


### PR DESCRIPTION
## Summary
- replace ICON_EDITOR_PACKAGE raw npm run validate example with wrapper invocation
- preserve surrounding guidance and flags unchanged

## Validation
- grep confirms icon-editor validate example now uses node tools/npm/run-script.mjs