### PR TITLE
docs: align release finalize wrapper examples (#271)

### DIFF
--- a/PR_RELEASE_CHECKLIST_v0.5.4.md
+++ b/PR_RELEASE_CHECKLIST_v0.5.4.md
@@ -26,5 +26,5 @@
 - [ ] Tag v0.5.4 on `main`.
 - [ ] Monitor release workflows (`Validate`, `vi-compare-refs`, staging smoke)
   after the tag.
-- [ ] Back-merge `release/v0.5.4` into `develop` via `npm run release:finalize -- 0.5.4`
+- [ ] Back-merge `release/v0.5.4` into `develop` via `node tools/npm/run-script.mjs release:finalize -- 0.5.4`
   and ensure bucket telemetry docs stay in sync.

--- a/PR_RELEASE_CHECKLIST_v0.6.0.md
+++ b/PR_RELEASE_CHECKLIST_v0.6.0.md
@@ -25,5 +25,5 @@
 
 - [ ] Tag v0.6.0 on `main`.
 - [ ] Monitor release workflows (`Validate`, `vi-compare-refs`, staging smoke) after the tag.
-- [ ] Back-merge `release/v0.6.0` into `develop` via `npm run release:finalize -- 0.6.0`
+- [ ] Back-merge `release/v0.6.0` into `develop` via `node tools/npm/run-script.mjs release:finalize -- 0.6.0`
   and ensure auto-config docs stay in sync.

--- a/PR_RELEASE_DESCRIPTION_v0.5.4.md
+++ b/PR_RELEASE_DESCRIPTION_v0.5.4.md
@@ -37,5 +37,5 @@ Post-Release
 
 - Tag v0.5.4 on `main`.
 - Monitor release workflows (`Validate`, `vi-compare-refs`, staging smoke) to ensure bucket totals render as expected.
-- Fast-forward `develop` from `release/v0.5.4` (handled via `npm run release:finalize -- 0.5.4`) and track any follow-up
+- Fast-forward `develop` from `release/v0.5.4` (handled via `node tools/npm/run-script.mjs release:finalize -- 0.5.4`) and track any follow-up
   fixes (fixture drift, additional bucket coverage).

--- a/PR_RELEASE_DESCRIPTION_v0.6.0.md
+++ b/PR_RELEASE_DESCRIPTION_v0.6.0.md
@@ -27,6 +27,6 @@
 ## Post-Tag Tasks
 
 - Tag v0.6.0 on `main`.
-- Fast-forward `develop` from `release/v0.6.0` (handled via `npm run release:finalize -- 0.6.0`) and track any follow-up
+- Fast-forward `develop` from `release/v0.6.0` (handled via `node tools/npm/run-script.mjs release:finalize -- 0.6.0`) and track any follow-up
   documentation.
 - Publish GitHub release notes summarising the auto-config flow and new compare defaults.

--- a/RELEASE_NOTES_v0.5.4.md
+++ b/RELEASE_NOTES_v0.5.4.md
@@ -37,5 +37,5 @@ Post-Release
 
 - Tag `v0.5.4` on `main` once required checks complete.
 - Monitor release workflows (`Validate`, `vi-compare-refs`, staging smoke) and ensure bucket totals render in summaries.
-- Run `npm run release:finalize -- 0.5.4` to fast-forward `main`/`develop`, draft the GitHub release, and archive the
+- Run `node tools/npm/run-script.mjs release:finalize -- 0.5.4` to fast-forward `main`/`develop`, draft the GitHub release, and archive the
   finalize metadata.

--- a/RELEASE_NOTES_v0.6.0.md
+++ b/RELEASE_NOTES_v0.6.0.md
@@ -39,5 +39,5 @@ Post-Release
 - Tag `v0.6.0` on `main` once required checks complete.
 - Monitor release workflows (`Validate`, `vi-compare-refs`, staging smoke) and ensure the auto-config tasks surface in
   summaries.
-- Run `npm run release:finalize -- 0.6.0` to fast-forward `main`/`develop`, draft the GitHub release, and archive the
+- Run `node tools/npm/run-script.mjs release:finalize -- 0.6.0` to fast-forward `main`/`develop`, draft the GitHub release, and archive the
   finalize metadata.


### PR DESCRIPTION
## Summary
- replace raw npm release finalize examples with wrapper syntax in release docs
- keep versioned release guidance unchanged

## Testing
- not run (docs-only change)

Closes #271