### PR TITLE
docs: align planning markdown wrapper examples (#273)

### DIFF
--- a/issue-134.md
+++ b/issue-134.md
@@ -26,13 +26,13 @@ further architectural work.
 - [ ] Enhance the panel UI: provider switcher, commit ref inputs with swap, preset CRUD, CLI preview
       (copy/open), image thumbnails, status bar spinner + toggle.
 - [ ] Update unit/integration tests (including multi-root + g-cli warning path) and keep
-      `npm run test:unit`, `npm run test:ext` green via the CLI harness.
+      `node tools/npm/run-script.mjs test:unit`, `node tools/npm/run-script.mjs test:ext` green via the CLI harness.
 - [ ] Update docs (README/CONTRIBUTING) and mark this issue as the standing priority (superseding #127).
 
 ## Testing Guidance
 
-- `npm run test:unit` — provider registry, state builder, telemetry, health check helpers (≥80% coverage).
-- `npm run test:ext` — manual/commit compare, provider switching, status bar toggle, presets, g-cli stub,
+- `node tools/npm/run-script.mjs test:unit` — provider registry, state builder, telemetry, health check helpers (≥80% coverage).
+- `node tools/npm/run-script.mjs test:ext` — manual/commit compare, provider switching, status bar toggle, presets, g-cli stub,
   multi-root behaviour, artifact snapshots.
 - Optional: add a "dry run" flag for the harness if CI needs a quick sanity check.
 

--- a/issues-drafts/588-vipm-provider-plan.md
+++ b/issues-drafts/588-vipm-provider-plan.md
@@ -34,7 +34,7 @@
 
 ## Milestone 4 - CI & telemetry and release cutover
 - [ ] Wire an optional CI job (nightly / on-demand) to execute the comparison harness and publish metrics artifacts.
-- [ ] Add README/docs entry describing provider selection, requirements, and how to trigger the comparison locally (`npm run vipm:compare` or VS Code task).
+- [ ] Add README/docs entry describing provider selection, requirements, and how to trigger the comparison locally (`node tools/npm/run-script.mjs vipm:compare` or VS Code task).
 - [ ] Monitor early runs; set simple thresholds (e.g., flag if provider B is >20% slower or fails).
 - [ ] Tag and publish the next release once full validation (Validate / lint + Pester) passes with providers integrated.
 - [ ] Port the provider stack to the upstream icon-editor repository and cut the matching release there once the action completes its rollout.


### PR DESCRIPTION
## Summary
- replace remaining planning markdown npm command examples with wrapper syntax
- keep planning content and intent unchanged

## Testing
- not run (docs-only change)

Closes #273