### PR TITLE
priority: normalize usage text to wrapper syntax (#275)

### DIFF
--- a/tools/priority/__tests__/dryrun-helpers.test.mjs
+++ b/tools/priority/__tests__/dryrun-helpers.test.mjs
@@ -140,7 +140,7 @@ test('dry-run helpers create metadata and restore branch context', async (t) => 
   assert.equal(initialBranch, dryrunFeatureBranch);
 
   const helpOutput = run('node', [releaseCreate, '--help'], { cwd: repoDir });
-  assert.match(helpOutput, /Usage: npm run release:branch:dry/);
+  assert.match(helpOutput, /Usage: node tools\/npm\/run-script\.mjs release:branch:dry/);
   const helpBranches = run('git', ['branch', '--list', 'release/--help'], { cwd: repoDir });
   assert.equal(helpBranches, '');
 

--- a/tools/priority/create-feature-branch.dryrun.mjs
+++ b/tools/priority/create-feature-branch.dryrun.mjs
@@ -14,7 +14,7 @@ import {
 } from './lib/branch-utils.mjs';
 
 const USAGE_LINES = [
-  'Usage: npm run feature:branch:dry -- <slug>',
+  'Usage: node tools/npm/run-script.mjs feature:branch:dry -- <slug>',
   '',
   'Creates a feature/<slug> branch (dry-run) and records metadata under tests/results/_agent/feature/.',
   '',

--- a/tools/priority/create-release-branch.dryrun.mjs
+++ b/tools/priority/create-release-branch.dryrun.mjs
@@ -14,7 +14,7 @@ import {
 } from './lib/branch-utils.mjs';
 
 const USAGE_LINES = [
-  'Usage: npm run release:branch:dry -- <version>',
+  'Usage: node tools/npm/run-script.mjs release:branch:dry -- <version>',
   '',
   'Creates a release/<version> branch (dry-run) and records metadata under tests/results/_agent/release/.',
   '',

--- a/tools/priority/create-release-branch.mjs
+++ b/tools/priority/create-release-branch.mjs
@@ -25,7 +25,7 @@ import {
 } from './lib/release-utils.mjs';
 
 const USAGE_LINES = [
-  'Usage: npm run release:branch -- <version>',
+  'Usage: node tools/npm/run-script.mjs release:branch -- <version>',
   '',
   'Creates a release/<version> branch from upstream/develop, performs the version bump, pushes to your fork,',
   'and opens a PR targeting main.',
@@ -71,7 +71,7 @@ function buildPrBody(tag) {
     `- prepare ${tag} for release`,
     '',
     '## Testing',
-    '- npm run priority:test',
+    '- node tools/npm/run-script.mjs priority:test',
     ''
   ].join('\n');
 }

--- a/tools/priority/finalize-feature.dryrun.mjs
+++ b/tools/priority/finalize-feature.dryrun.mjs
@@ -12,7 +12,7 @@ import {
 } from './lib/branch-utils.mjs';
 
 const USAGE_LINES = [
-  'Usage: npm run feature:finalize:dry -- <slug>',
+  'Usage: node tools/npm/run-script.mjs feature:finalize:dry -- <slug>',
   '',
   'Simulates rebasing feature/<slug> onto develop and writes metadata under tests/results/_agent/feature/.',
   '',

--- a/tools/priority/finalize-release.dryrun.mjs
+++ b/tools/priority/finalize-release.dryrun.mjs
@@ -12,7 +12,7 @@ import {
 } from './lib/branch-utils.mjs';
 
 const USAGE_LINES = [
-  'Usage: npm run release:finalize:dry -- <version>',
+  'Usage: node tools/npm/run-script.mjs release:finalize:dry -- <version>',
   '',
   'Simulates fast-forwarding release/<version> into main/develop and writes metadata under tests/results/_agent/release/.',
   '',

--- a/tools/priority/finalize-release.mjs
+++ b/tools/priority/finalize-release.mjs
@@ -25,7 +25,7 @@ import {
 } from './lib/release-utils.mjs';
 
 const USAGE_LINES = [
-  'Usage: npm run release:finalize -- <version>',
+  'Usage: node tools/npm/run-script.mjs release:finalize -- <version>',
   '',
   'Fast-forwards main to release/<version>, creates a draft GitHub release, and fast-forwards develop to match.',
   '',

--- a/tools/priority/sync-standing-priority.mjs
+++ b/tools/priority/sync-standing-priority.mjs
@@ -518,7 +518,7 @@ export function buildRouter(issue, policy) {
       addAction({
         key: 'release:branch',
         priority: 38,
-        scripts: ['pwsh -Command "Write-Host Run npm run release:branch -- <version>"'],
+        scripts: ['pwsh -Command "Write-Host Run node tools/npm/run-script.mjs release:branch -- <version>"'],
         rationale: 'release label present but no release branch metadata detected'
       });
     }


### PR DESCRIPTION
## Summary
- update tools/priority usage/help text from npm run examples to wrapper command syntax
- update release prep router hint text accordingly
- align dry-run helper test expectation with updated usage text

## Testing
- /mnt/c/Program Files/nodejs/node.exe tools/npm/run-script.mjs priority:test

Closes #275