### PR TITLE
chore: simplify extension test script command (#281)

### DIFF
--- a/tools/vscode/comparevi-extension/package.json
+++ b/tools/vscode/comparevi-extension/package.json
@@ -216,7 +216,7 @@
     "compile": "tsc -p .",
     "watch": "tsc -p . --watch",
     "package": "vsce package",
-    "test": "npm run compile"
+    "test": "tsc -p ."
   },
   "devDependencies": {
     "@types/glob": "^8.1.0",


### PR DESCRIPTION
## Summary
- replace nested npm script invocation in extension package test script with equivalent direct compile command
- keep extension behavior unchanged

## Testing
- cmd.exe /c "cd /d D:\workspace\compare-vi-cli-action-fork\compare-vi-cli-action\tools\vscode\comparevi-extension && npm run test" *(fails in current environment: missing vscode type definitions / local extension deps not installed)*

Closes #281