### PR TITLE
Reconcile required-check contracts for main and release (#283)

### DIFF
--- a/docs/knowledgebase/FEATURE_BRANCH_POLICY.md
+++ b/docs/knowledgebase/FEATURE_BRANCH_POLICY.md
@@ -1,7 +1,7 @@
 <!-- markdownlint-disable-next-line MD041 -->
 # Feature Branch Enforcement & Merge Queue
 
-_Last updated: 2025-10-22 (standing priority #293)._ 
+_Last updated: 2026-03-05 (standing priority #283)._ 
 
 ## Purpose
 
@@ -43,7 +43,7 @@ standing GitHub protection rules (including the `main` merge queue).
 - `.github/workflows/policy-guard-upstream.yml` (triggered via `pull_request_target`) checks out the PR head with the
   upstream repository token and re-runs `priority:policy`, guaranteeing that branch protection rules are enforced even
   when the lint job skips in fork contexts. Its status (`Policy Guard (Upstream) / policy-guard`) is required on
-  `develop`, `main`, and `release/*`.
+  `main` and `release/*`.
 - Branch protection verification treats workflow-prefixed and short check contexts as equivalent (for example,
   `Validate / lint` and `lint`) to avoid false drift when comparing live API contexts against policy mappings.
 - `Validate` runs `priority:handoff-tests` automatically for heads that start with `feature/`, enforcing leak-sensitive
@@ -60,7 +60,7 @@ standing GitHub protection rules (including the `main` merge queue).
 ### GitHub rulesets
 | Ruleset ID | Scope                | Highlights                                                                                   |
 |------------|----------------------|----------------------------------------------------------------------------------------------|
-| `8811898`  | `refs/heads/develop` | Linear history required, squash-only merges, checks: `Validate / lint`, `Validate / fixtures`, `Validate / session-index`, `Validate / issue-snapshot`, `Requirements Verification / requirements-verification`, `Policy Guard (Upstream) / policy-guard` |
+| `8811898`  | `refs/heads/develop` | Linear history required, squash-only merges, checks: `lint`, `fixtures`, `session-index`, `issue-snapshot`, `semver`, `hook-parity (windows-latest)`, `hook-parity (ubuntu-latest)`, `vi-history-scenarios-linux` |
 | `8614140`  | `refs/heads/main`    | Merge queue enabled (`merge_method=SQUASH`, `grouping=ALLGREEN`, build queue <=5 entries, 5-minute quiet window). Required checks: `lint`, `pester`, `vi-binary-check`, `vi-compare`, `Policy Guard (Upstream) / policy-guard`. Requires one approving review with resolved threads. |
 | `8614172`  | `refs/heads/release/*` | No merge queue; protects against force-push/deletion. Required checks: `lint`, `pester`, `publish`, `vi-binary-check`, `vi-compare`, `mock-cli`, `Policy Guard (Upstream) / policy-guard`. Requires one approving review with resolved threads. |
 
@@ -87,8 +87,8 @@ checked into `tools/priority/policy.json` so `priority:policy` stays authoritati
 
 ### `develop`
 - **Merge strategy**: squash only (enforce linear history, disable merge commits).
-- **Required checks**: `Validate / lint`, `Validate / fixtures`, `Validate / session-index`, `Validate / issue-snapshot`,
-  `Requirements Verification / requirements-verification`, `Policy Guard (Upstream) / policy-guard`.
+- **Required checks**: `lint`, `fixtures`, `session-index`, `issue-snapshot`, `semver`, `hook-parity (windows-latest)`,
+  `hook-parity (ubuntu-latest)`, `vi-history-scenarios-linux`.
 - **Admin bypass**: leave disabled; administrators should only intervene when `priority:policy` confirms parity.
 - **Reapply**: Use `node tools/npm/run-script.mjs priority:policy -- --apply` to push the manifest configuration when drift is detected.
 
@@ -124,8 +124,8 @@ checked into `tools/priority/policy.json` so `priority:policy` stays authoritati
   pwsh -NoLogo -NonInteractive -NoProfile -File tools/Assert-RequirementsVerificationCheckContract.ps1
   ```
 
-- Validate branch-protection helper contract deterministically (explicitly includes
-  `Requirements Verification / requirements-verification` in develop policy):
+- Validate branch-protection helper contract deterministically (uses the canonical
+  `tools/policy/branch-required-checks.json` develop mapping):
 
   ```powershell
   pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Path 'tests/SessionIndex.BranchProtection.Tests.ps1','tests/GetBranchProtectionRequiredChecks.Tests.ps1','tests/RequirementsVerificationCheckContract.Tests.ps1' -Output Detailed"
@@ -208,7 +208,7 @@ checked into `tools/priority/policy.json` so `priority:policy` stays authoritati
   - `max_entries_to_build=5`, `min_entries_to_merge=1`, `max_entries_to_merge=5`
   - `min_entries_to_merge_wait_minutes=5`
   - `check_response_timeout_minutes=60`
-- **Required checks**: `lint`, `pester`, `vi-binary-check`, `vi-compare`.
+- **Required checks**: `lint`, `pester`, `vi-binary-check`, `vi-compare`, `Policy Guard (Upstream) / policy-guard`.
 - **Workflow triggers**: Ensure those required checks run on both `pull_request` and `merge_group` so queued entries can merge.
 - **Approval policy**: >= 1 review; dismiss stale reviews on push; require thread resolution.
 - **Quick verification**:
@@ -220,7 +220,7 @@ checked into `tools/priority/policy.json` so `priority:policy` stays authoritati
 
 ### `release/*`
 - **Ruleset**: `8614172` (scope `refs/heads/release/*`).
-- **Required checks**: `lint`, `pester`, `publish`, `vi-binary-check`, `vi-compare`, `mock-cli`.
+- **Required checks**: `lint`, `pester`, `publish`, `vi-binary-check`, `vi-compare`, `mock-cli`, `Policy Guard (Upstream) / policy-guard`.
 - **Approvals**: >= 1 review, stale review dismissal enabled, enforce thread resolution.
 - **Merge queue**: intentionally disabled; rely on manual review + required checks.
 - **Maintenance tip**: revisit after each release cycle to ensure the workflow matrix still emits the expected check
@@ -231,7 +231,7 @@ Prereq: All required checks for `main` must execute on both `pull_request` and `
 to confirm each workflow includes both triggers.
 
 1. Ensure the PR targets `main` (typically a release PR) and all required checks (`lint`, `pester`, `vi-binary-check`,
-   `vi-compare`) are green on the latest commit.
+   `vi-compare`, `Policy Guard (Upstream) / policy-guard`) are green on the latest commit.
 2. Click **Merge when ready** (queue-managed **squash**). Ensure >= 1 approval and all review threads are resolved; the
    queue enforces both before merging.
 3. Monitor `https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/queue/main`. GitHub stages entries, reruns

--- a/tests/SessionIndex.BranchProtection.Tests.ps1
+++ b/tests/SessionIndex.BranchProtection.Tests.ps1
@@ -10,7 +10,7 @@ Describe 'Update-SessionIndexBranchProtection' -Tag 'Unit' {
     Set-Variable -Name policy -Scope Script -Value $policyLocal
 
     Set-Variable -Name developExpected -Scope Script -Value @($policyLocal.branches.develop)
-    Set-Variable -Name releaseExpected -Scope Script -Value @($policyLocal.branches.'release/v0.5.2')
+    Set-Variable -Name releaseExpected -Scope Script -Value @($policyLocal.branches.'release/*')
     Set-Variable -Name updateScript -Scope Script -Value (Join-Path $repoRootLocal 'tools/Update-SessionIndexBranchProtection.ps1')
     $newFixture = {
       param([string]$Name)
@@ -239,12 +239,12 @@ Describe 'Update-SessionIndexBranchProtection' -Tag 'Unit' {
     & $script:updateScript `
       -ResultsDir $resultsDir `
       -PolicyPath $script:policyPath `
-      -Branch 'release/v0.5.2' `
+      -Branch 'release/v0.6.0' `
       -ProducedContexts $script:releaseExpected
 
     $idx = Get-Content -LiteralPath (Join-Path $resultsDir 'session-index.json') -Raw | ConvertFrom-Json
     $bp = $idx.branchProtection
-    $bp.branch | Should -Be 'release/v0.5.2'
+    $bp.branch | Should -Be 'release/v0.6.0'
     ($bp.expected | Sort-Object) | Should -Be ($script:releaseExpected | Sort-Object)
     ($bp.produced | Sort-Object) | Should -Be ($script:releaseExpected | Sort-Object)
     $bp.result.status | Should -Be 'ok'
@@ -263,7 +263,7 @@ Describe 'Update-SessionIndexBranchProtection' -Tag 'Unit' {
     & $script:updateScript `
       -ResultsDir $resultsDir `
       -PolicyPath $script:policyPath `
-      -Branch 'release/v0.5.2' `
+      -Branch 'release/v0.6.0' `
       -ProducedContexts $produced
 
     $idx = Get-Content -LiteralPath (Join-Path $resultsDir 'session-index.json') -Raw | ConvertFrom-Json

--- a/tools/Update-SessionIndexBranchProtection.ps1
+++ b/tools/Update-SessionIndexBranchProtection.ps1
@@ -122,6 +122,54 @@ function Test-ContextMatch {
   return $false
 }
 
+function Resolve-BranchExpectedContexts {
+  param(
+    [psobject]$Branches,
+    [string]$BranchName
+  )
+
+  if (-not $Branches) {
+    return @()
+  }
+
+  foreach ($prop in $Branches.PSObject.Properties) {
+    if ($prop.Name -eq $BranchName) {
+      return @($prop.Value)
+    }
+  }
+
+  $bestMatch = $null
+  $bestSpecificity = -1
+  foreach ($prop in $Branches.PSObject.Properties) {
+    $pattern = $prop.Name
+    if ($pattern -eq 'default') {
+      continue
+    }
+    if ($pattern -notmatch '[\*\?]') {
+      continue
+    }
+    if ($BranchName -like $pattern) {
+      $specificity = ($pattern -replace '[\*\?]', '').Length
+      if ($specificity -gt $bestSpecificity) {
+        $bestSpecificity = $specificity
+        $bestMatch = @($prop.Value)
+      }
+    }
+  }
+
+  if ($null -ne $bestMatch -and $bestMatch.Count -gt 0) {
+    return $bestMatch
+  }
+
+  foreach ($prop in $Branches.PSObject.Properties) {
+    if ($prop.Name -eq 'default') {
+      return @($prop.Value)
+    }
+  }
+
+  return @()
+}
+
 $rawBranch = $Branch
 if ([string]::IsNullOrWhiteSpace($rawBranch)) {
   $Branch = 'unknown'
@@ -168,21 +216,7 @@ if (-not $branches) {
   throw "Policy file '$PolicyPath' does not contain a 'branches' object."
 }
 
-$expectedRaw = @()
-foreach ($prop in $branches.PSObject.Properties) {
-  if ($prop.Name -eq $Branch) {
-    $expectedRaw = @($prop.Value)
-    break
-  }
-}
-if ($expectedRaw.Count -eq 0) {
-  foreach ($prop in $branches.PSObject.Properties) {
-    if ($prop.Name -eq 'default') {
-      $expectedRaw = @($prop.Value)
-      break
-    }
-  }
-}
+$expectedRaw = @(Resolve-BranchExpectedContexts -Branches $branches -BranchName $Branch)
 $expected = @($expectedRaw | Where-Object { $_ } | Sort-Object -Unique)
 
 $producedRaw = if ($PSBoundParameters.ContainsKey('ProducedContexts')) {

--- a/tools/policy/branch-required-checks.json
+++ b/tools/policy/branch-required-checks.json
@@ -13,12 +13,14 @@
       "vi-history-scenarios-linux"
     ],
     "main": [
+      "lint",
       "pester",
       "vi-binary-check",
       "vi-compare",
       "Policy Guard (Upstream) / policy-guard"
     ],
-    "release/v0.5.2": [
+    "release/*": [
+      "lint",
       "pester",
       "publish",
       "vi-binary-check",

--- a/tools/priority/__tests__/check-policy-apply.test.mjs
+++ b/tools/priority/__tests__/check-policy-apply.test.mjs
@@ -31,12 +31,14 @@ test('priority:policy --apply updates rulesets for develop/main/release', async 
     'vi-history-scenarios-linux'
   ];
   const expectedMainChecks = [
+    'lint',
     'pester',
     'vi-binary-check',
     'vi-compare',
     'Policy Guard (Upstream) / policy-guard'
   ];
   const expectedReleaseChecks = [
+    'lint',
     'pester',
     'publish',
     'vi-binary-check',
@@ -141,6 +143,7 @@ test('priority:policy --apply updates rulesets for develop/main/release', async 
           strict_required_status_checks_policy: true,
           do_not_enforce_on_create: false,
           required_status_checks: [
+            { context: 'lint', integration_id: 15368 },
             { context: 'pester', integration_id: 15368 },
             { context: 'vi-binary-check', integration_id: 15368 },
             { context: 'vi-compare', integration_id: 15368 },
@@ -183,6 +186,7 @@ test('priority:policy --apply updates rulesets for develop/main/release', async 
           strict_required_status_checks_policy: true,
           do_not_enforce_on_create: false,
           required_status_checks: [
+            { context: 'lint', integration_id: 15368 },
             { context: 'pester', integration_id: 15368 },
             { context: 'publish', integration_id: 15368 },
             { context: 'vi-binary-check', integration_id: 15368 },
@@ -197,7 +201,6 @@ test('priority:policy --apply updates rulesets for develop/main/release', async 
 
   const branchDevelopUrl = `${repoUrl}/branches/develop/protection`;
   const branchMainUrl = `${repoUrl}/branches/main/protection`;
-  const branchReleaseUrl = `${repoUrl}/branches/release%2Fv0.5.2/protection`;
 
   let branchDevelopProtection = {
     required_status_checks: {
@@ -230,35 +233,12 @@ test('priority:policy --apply updates rulesets for develop/main/release', async 
   let branchMainProtection = {
     required_status_checks: {
       strict: true,
-      contexts: ['pester', 'vi-binary-check', 'vi-compare'],
+      contexts: ['pester', 'vi-binary-check', 'vi-compare', 'Policy Guard (Upstream) / policy-guard'],
       checks: [
         { context: 'pester', app_id: 15368 },
-        { context: 'vi-binary-check', app_id: 15368 },
-        { context: 'vi-compare', app_id: 15368 }
-      ]
-    },
-    enforce_admins: { enabled: false },
-    required_pull_request_reviews: null,
-    restrictions: null,
-    required_linear_history: { enabled: false },
-    allow_force_pushes: { enabled: false },
-    allow_deletions: { enabled: false },
-    block_creations: { enabled: false },
-    required_conversation_resolution: { enabled: false },
-    lock_branch: { enabled: false },
-    allow_fork_syncing: { enabled: false }
-  };
-
-  let branchReleaseProtection = {
-    required_status_checks: {
-      strict: true,
-      contexts: ['pester', 'publish', 'vi-binary-check', 'vi-compare', 'mock-cli'],
-      checks: [
-        { context: 'pester', app_id: 15368 },
-        { context: 'publish', app_id: 15368 },
         { context: 'vi-binary-check', app_id: 15368 },
         { context: 'vi-compare', app_id: 15368 },
-        { context: 'mock-cli', app_id: 15368 }
+        { context: 'Policy Guard (Upstream) / policy-guard' }
       ]
     },
     enforce_admins: { enabled: false },
@@ -336,34 +316,6 @@ test('priority:policy --apply updates rulesets for develop/main/release', async 
           allow_fork_syncing: wrapEnabled(payload.allow_fork_syncing)
         };
         return createResponse(branchMainProtection);
-      }
-    }
-
-    if (url === branchReleaseUrl) {
-      if (method === 'GET') {
-        return createResponse(branchReleaseProtection);
-      }
-      if (method === 'PUT') {
-        const payload = JSON.parse(options.body);
-        const contexts = payload.required_status_checks?.contexts ?? [];
-        branchReleaseProtection = {
-          enforce_admins: wrapEnabled(payload.enforce_admins),
-          required_pull_request_reviews: payload.required_pull_request_reviews,
-          restrictions: payload.restrictions,
-          required_status_checks: {
-            strict: payload.required_status_checks?.strict ?? true,
-            contexts,
-            checks: contexts.map((context) => ({ context }))
-          },
-          required_linear_history: wrapEnabled(payload.required_linear_history),
-          allow_force_pushes: wrapEnabled(payload.allow_force_pushes),
-          allow_deletions: wrapEnabled(payload.allow_deletions),
-          block_creations: wrapEnabled(payload.block_creations),
-          required_conversation_resolution: wrapEnabled(payload.required_conversation_resolution),
-          lock_branch: wrapEnabled(payload.lock_branch),
-          allow_fork_syncing: wrapEnabled(payload.allow_fork_syncing)
-        };
-        return createResponse(branchReleaseProtection);
       }
     }
 
@@ -445,7 +397,7 @@ test('priority:policy --apply updates rulesets for develop/main/release', async 
   const statusRule = rulesetMain.rules.find((rule) => rule.type === 'required_status_checks');
   assert.deepEqual(
     statusRule.parameters.required_status_checks.map((check) => check.context).sort(),
-    ['pester', 'vi-binary-check', 'vi-compare', 'Policy Guard (Upstream) / policy-guard'].sort()
+    expectedMainChecks.slice().sort()
   );
 
   const pullRule = rulesetMain.rules.find((rule) => rule.type === 'pull_request');
@@ -455,7 +407,7 @@ test('priority:policy --apply updates rulesets for develop/main/release', async 
   const statusRuleRelease = rulesetRelease.rules.find((rule) => rule.type === 'required_status_checks');
   assert.deepEqual(
     statusRuleRelease.parameters.required_status_checks.map((check) => check.context).sort(),
-    ['Policy Guard (Upstream) / policy-guard', 'mock-cli', 'pester', 'publish', 'vi-binary-check', 'vi-compare'].sort()
+    expectedReleaseChecks.slice().sort()
   );
   assert.ok(
     !statusRuleRelease.parameters.required_status_checks.some(
@@ -480,11 +432,6 @@ test('priority:policy --apply updates rulesets for develop/main/release', async 
     requests.some((entry) => entry.method === 'PUT' && entry.url === branchMainUrl),
     'main branch protection put call expected'
   );
-  assert.ok(
-    requests.some((entry) => entry.method === 'PUT' && entry.url === branchReleaseUrl),
-    'release branch protection put call expected'
-  );
-
   const developApplied = branchDevelopProtection.required_status_checks.checks.map((check) => check.context).sort();
   assert.deepEqual(
     developApplied,
@@ -499,12 +446,6 @@ test('priority:policy --apply updates rulesets for develop/main/release', async 
     'main branch contexts should match expectations'
   );
 
-  const releaseApplied = branchReleaseProtection.required_status_checks.checks.map((check) => check.context).sort();
-  assert.deepEqual(
-    releaseApplied,
-    expectedReleaseChecks.slice().sort(),
-    'release branch contexts should match expectations'
-  );
   assert.deepEqual(errorMessages, []);
   assert.ok(
     logMessages.includes('Merge policy apply completed successfully.'),

--- a/tools/priority/check-policy.mjs
+++ b/tools/priority/check-policy.mjs
@@ -78,6 +78,10 @@ function parseRemoteUrl(url) {
   return { owner, repo };
 }
 
+function isBranchPattern(branch) {
+  return /[*?[\]]/.test(branch);
+}
+
 function getRepoFromEnv(env = process.env, execSyncFn = execSync) {
   const envRepo = env.GITHUB_REPOSITORY;
   if (envRepo && envRepo.includes('/')) {
@@ -607,7 +611,12 @@ async function collectState(manifest, repoUrl, token, fetchFn) {
 
   const branchStates = [];
   for (const [branch, expectations] of Object.entries(manifest.branches ?? {})) {
-    const state = { branch, expectations, protection: null, error: null };
+    const state = { branch, expectations, protection: null, error: null, skipReason: null };
+    if (isBranchPattern(branch)) {
+      state.skipReason = 'pattern';
+      branchStates.push(state);
+      continue;
+    }
     try {
       const protectionUrl = `${repoUrl}/branches/${encodeURIComponent(branch)}/protection`;
       state.protection = await fetchJson(protectionUrl, token, fetchFn);
@@ -624,14 +633,14 @@ async function collectState(manifest, repoUrl, token, fetchFn) {
     if (Number.isNaN(numericId)) {
       state.error = new Error('invalid id');
       rulesetStates.push(state);
-    continue;
-  }
-  try {
-    const rulesetUrl = `${repoUrl}/rulesets/${numericId}`;
-    state.ruleset = await fetchJson(rulesetUrl, token, fetchFn);
-  } catch (error) {
-    state.error = error;
-  }
+      continue;
+    }
+    try {
+      const rulesetUrl = `${repoUrl}/rulesets/${numericId}`;
+      state.ruleset = await fetchJson(rulesetUrl, token, fetchFn);
+    } catch (error) {
+      state.error = error;
+    }
     rulesetStates.push(state);
   }
 
@@ -643,6 +652,9 @@ function evaluateDiffs(manifest, state) {
 
   const branchDiffs = [];
   for (const entry of state.branchStates) {
+    if (entry.skipReason === 'pattern') {
+      continue;
+    }
     if (entry.error) {
       branchDiffs.push(`branch ${entry.branch}: failed to load protection -> ${entry.error.message}`);
       continue;
@@ -799,6 +811,9 @@ export async function run({
 
   if (options.apply) {
     const branchStatesNeedingUpdates = initialState.branchStates.filter((entry, index) => {
+      if (entry.skipReason === 'pattern') {
+        return false;
+      }
       if (entry.error) {
         return isNotFoundError(entry.error);
       }

--- a/tools/priority/policy.json
+++ b/tools/priority/policy.json
@@ -22,6 +22,7 @@
     },
     "main": {
       "required_status_checks": [
+        "lint",
         "pester",
         "vi-binary-check",
         "vi-compare",
@@ -29,8 +30,9 @@
       ],
       "required_linear_history": true
     },
-    "release/v0.5.2": {
+    "release/*": {
       "required_status_checks": [
+        "lint",
         "pester",
         "publish",
         "vi-binary-check",
@@ -77,6 +79,7 @@
         "refs/heads/main"
       ],
       "required_status_checks": [
+        "lint",
         "pester",
         "vi-binary-check",
         "vi-compare",
@@ -105,6 +108,7 @@
         "refs/heads/release/*"
       ],
       "required_status_checks": [
+        "lint",
         "pester",
         "publish",
         "vi-binary-check",
@@ -126,4 +130,3 @@
     }
   }
 }
-


### PR DESCRIPTION
## Summary
- align the canonical branch required-check mapping for `main` and `release/*` by requiring `lint`
- remove stale `release/v0.5.2` hardcoding in policy manifests and switch to `release/*`
- update branch-protection policy tooling to treat wildcard branch keys as patterns and resolve `release/*` correctly for session-index checks
- reconcile feature-branch policy documentation with the canonical contract

Closes #283

## Testing
- `node --test tools/priority/__tests__/check-policy-apply.test.mjs`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Path 'tests/SessionIndex.BranchProtection.Tests.ps1' -Output Detailed"`
- `node tools/npm/run-script.mjs priority:test`
- `node tools/npm/run-script.mjs lint:md:changed`
