### PR TITLE
Require release metadata + docs freeze gates (#290)

### DIFF
--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -234,13 +234,16 @@ For Docker/Desktop VI history validation, run fast-loop lanes explicitly:
     pushes the branch to your fork, and opens a PR targeting `main`. Use `node tools/npm/run-script.mjs release:branch:dry`
      when you want to rehearse the flow without touching remotes.
   2. Finish release-only work on feature branches targeting `release/<version>`.
-  3. Merge the release branch into `main`, create the draft release, then fast-forward `develop`
-    with `node tools/npm/run-script.mjs release:finalize -- <version>`. The helper fast-forwards `main`, creates a draft
-     GitHub release, fast-forwards `develop`, and records metadata under `tests/results/_agent/release/`.
-    Use `node tools/npm/run-script.mjs release:finalize:dry` to rehearse the flow without pushing.
-     - The finalize helper blocks if the release PR has pending or failing checks; set
-       `RELEASE_FINALIZE_SKIP_CHECKS=1` (or `RELEASE_FINALIZE_ALLOW_MERGED=1` / `RELEASE_FINALIZE_ALLOW_DIRTY=1`)
-       to override in emergencies.
+   3. Merge the release branch into `main`, create the draft release, then fast-forward `develop`
+     with `node tools/npm/run-script.mjs release:finalize -- <version>`. The helper fast-forwards `main`, creates a draft
+      GitHub release, fast-forwards `develop`, and records metadata under `tests/results/_agent/release/`.
+     Use `node tools/npm/run-script.mjs release:finalize:dry` to rehearse the flow without pushing.
+      - Finalize now requires the release branch metadata artifact (`release-<tag>-branch.json`) to be present before it
+        cuts a draft tag, and it verifies both branch/finalize artifacts are retained under
+        `tests/results/_agent/release/`.
+      - The finalize helper blocks if the release PR has pending or failing checks; set
+        `RELEASE_FINALIZE_SKIP_CHECKS=1` (or `RELEASE_FINALIZE_ALLOW_MERGED=1` / `RELEASE_FINALIZE_ALLOW_DIRTY=1`)
+        to override in emergencies.
      - If `main` and the release branch no longer share history (for example, after cutting over to a new repository
        baseline), rerun the helper with `RELEASE_FINALIZE_ALLOW_RESET=1` so it can reset `main` to the release tip and
        push with `--force-with-lease`. Leave the variable unset during normal releases so unintended history rewrites are blocked.
@@ -264,6 +267,8 @@ For Docker/Desktop VI history validation, run fast-loop lanes explicitly:
 - Running the live helpers writes JSON snapshots under `tests/results/_agent/release/`:
   - `release-<tag>-branch.json` captures the release branch base, commits, and linked PR.
   - `release-<tag>-finalize.json` records the fast-forward results and the GitHub release draft.
+- `tools/priority/verify-release-branch.mjs` enforces release-doc consistency before tag cut by requiring
+  `PR_NOTES.md`, `TAG_PREP_CHECKLIST.md`, and `RELEASE_NOTES_<tag>.md` to reference the current release tag.
 - `priority:sync` surfaces the most recent artifact in the standing-priority step summary and exposes it to downstream
   automation via `snapshot.releaseArtifacts`.
 - `priority:parity` reports origin/upstream parity using two metrics:

--- a/tools/priority/__tests__/release-utils.test.mjs
+++ b/tools/priority/__tests__/release-utils.test.mjs
@@ -8,7 +8,9 @@ import path from 'node:path';
 import {
   normalizeVersionInput,
   writeReleaseMetadata,
-  summarizeStatusCheckRollup
+  summarizeStatusCheckRollup,
+  getReleaseMetadataPath,
+  assertReleaseMetadataExists
 } from '../lib/release-utils.mjs';
 
 test('normalizeVersionInput handles tagged and untagged semver', () => {
@@ -45,4 +47,31 @@ test('summarizeStatusCheckRollup normalizes check data', () => {
     conclusion: 'SUCCESS',
     url: 'https://example.com/lint'
   });
+});
+
+test('getReleaseMetadataPath returns deterministic release artifact path', () => {
+  const actual = getReleaseMetadataPath('/repo', 'v1.2.3', 'branch');
+  assert.equal(actual, path.join('/repo', 'tests', 'results', '_agent', 'release', 'release-v1.2.3-branch.json'));
+});
+
+test('assertReleaseMetadataExists throws when release artifact is missing', async (t) => {
+  const repoDir = await mkdtemp(path.join(tmpdir(), 'release-utils-'));
+  t.after(() => rm(repoDir, { recursive: true, force: true }));
+
+  await assert.rejects(
+    () => assertReleaseMetadataExists(repoDir, 'v9.9.9', 'branch'),
+    /Missing required artifact/i
+  );
+});
+
+test('assertReleaseMetadataExists succeeds after writing release metadata', async (t) => {
+  const repoDir = await mkdtemp(path.join(tmpdir(), 'release-utils-present-'));
+  t.after(() => rm(repoDir, { recursive: true, force: true }));
+
+  await writeReleaseMetadata(repoDir, 'v1.0.0', 'branch', { schema: 'release/branch@v1' });
+  const artifactPath = await assertReleaseMetadataExists(repoDir, 'v1.0.0', 'branch');
+  assert.equal(
+    artifactPath,
+    path.join(repoDir, 'tests', 'results', '_agent', 'release', 'release-v1.0.0-branch.json')
+  );
 });

--- a/tools/priority/__tests__/verify-release-branch.test.mjs
+++ b/tools/priority/__tests__/verify-release-branch.test.mjs
@@ -15,6 +15,26 @@ function runGit(cwd, args) {
   return result.stdout.trim();
 }
 
+async function writeReleaseDocs(repoDir, tag, { includeReleaseNotes = true, notesTag = tag } = {}) {
+  await writeFile(
+    path.join(repoDir, 'PR_NOTES.md'),
+    `# Release ${notesTag} Notes\n\nPrepared for ${notesTag}.\n`,
+    'utf8'
+  );
+  await writeFile(
+    path.join(repoDir, 'TAG_PREP_CHECKLIST.md'),
+    `# ${notesTag} Tag Checklist\n\n- [ ] Verify ${notesTag} changelog and release notes.\n`,
+    'utf8'
+  );
+  if (includeReleaseNotes) {
+    await writeFile(
+      path.join(repoDir, `RELEASE_NOTES_${tag}.md`),
+      `# Release Notes ${notesTag}\n\nThis release ships ${notesTag}.\n`,
+      'utf8'
+    );
+  }
+}
+
 test('verify-release-branch succeeds when version/changelog updated', async (t) => {
   const repoDir = await mkdtemp(path.join(tmpdir(), 'verify-release-'));
   t.after(() => rm(repoDir, { recursive: true, force: true }));
@@ -30,6 +50,7 @@ test('verify-release-branch succeeds when version/changelog updated', async (t) 
     JSON.stringify({ name: 'test', version: '0.1.0' }, null, 2) + '\n',
     'utf8'
   );
+  await writeReleaseDocs(repoDir, 'v0.1.0');
 
   runGit(repoDir, ['init']);
   runGit(repoDir, ['config', 'user.name', 'Test']);
@@ -49,6 +70,7 @@ test('verify-release-branch succeeds when version/changelog updated', async (t) 
     '# Changelog\n\n## v0.2.0 - Next\n- Updates\n\n## v0.1.0 - Initial\n- First release\n',
     'utf8'
   );
+  await writeReleaseDocs(repoDir, 'v0.2.0');
   runGit(repoDir, ['commit', '-am', 'prepare v0.2.0']);
 
   const script = path.resolve('tools', 'priority', 'verify-release-branch.mjs');
@@ -72,6 +94,7 @@ test('verify-release-branch fails when changelog missing update', async (t) => {
     JSON.stringify({ name: 'test', version: '0.1.0' }, null, 2) + '\n',
     'utf8'
   );
+  await writeReleaseDocs(repoDir, 'v0.1.0');
 
   runGit(repoDir, ['init']);
   runGit(repoDir, ['config', 'user.name', 'Test']);
@@ -86,6 +109,7 @@ test('verify-release-branch fails when changelog missing update', async (t) => {
     JSON.stringify({ name: 'test', version: '0.3.0' }, null, 2) + '\n',
     'utf8'
   );
+  await writeReleaseDocs(repoDir, 'v0.3.0');
   runGit(repoDir, ['commit', '-am', 'prepare v0.3.0']);
 
   const script = path.resolve('tools', 'priority', 'verify-release-branch.mjs');
@@ -93,4 +117,49 @@ test('verify-release-branch fails when changelog missing update', async (t) => {
   const result = spawnSync(process.execPath, [script], { cwd: repoDir, env, encoding: 'utf8' });
   assert.notEqual(result.status, 0);
   assert.match(result.stderr ?? result.stdout, /CHANGELOG\.md missing entry/i);
+});
+
+test('verify-release-branch fails when release docs are inconsistent', async (t) => {
+  const repoDir = await mkdtemp(path.join(tmpdir(), 'verify-release-docs-fail-'));
+  t.after(() => rm(repoDir, { recursive: true, force: true }));
+
+  await mkdir(path.join(repoDir, 'docs'), { recursive: true });
+  await writeFile(
+    path.join(repoDir, 'docs', 'CHANGELOG.md'),
+    '# Changelog\n\n## v0.1.0 - Initial\n- First release\n',
+    'utf8'
+  );
+  await writeFile(
+    path.join(repoDir, 'package.json'),
+    JSON.stringify({ name: 'test', version: '0.1.0' }, null, 2) + '\n',
+    'utf8'
+  );
+  await writeReleaseDocs(repoDir, 'v0.1.0');
+
+  runGit(repoDir, ['init']);
+  runGit(repoDir, ['config', 'user.name', 'Test']);
+  runGit(repoDir, ['config', 'user.email', 'test@example.com']);
+  runGit(repoDir, ['add', '.']);
+  runGit(repoDir, ['commit', '-m', 'initial release']);
+  runGit(repoDir, ['branch', 'develop']);
+
+  runGit(repoDir, ['checkout', '-b', 'release/v0.4.0']);
+  await writeFile(
+    path.join(repoDir, 'package.json'),
+    JSON.stringify({ name: 'test', version: '0.4.0' }, null, 2) + '\n',
+    'utf8'
+  );
+  await writeFile(
+    path.join(repoDir, 'docs', 'CHANGELOG.md'),
+    '# Changelog\n\n## v0.4.0 - Next\n- Updates\n\n## v0.1.0 - Initial\n- First release\n',
+    'utf8'
+  );
+  await writeReleaseDocs(repoDir, 'v0.4.0', { notesTag: 'v0.3.9' });
+  runGit(repoDir, ['commit', '-am', 'prepare v0.4.0']);
+
+  const script = path.resolve('tools', 'priority', 'verify-release-branch.mjs');
+  const env = { ...process.env, GITHUB_HEAD_REF: 'release/v0.4.0', RELEASE_VALIDATE_BASE: 'HEAD~1' };
+  const result = spawnSync(process.execPath, [script], { cwd: repoDir, env, encoding: 'utf8' });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr ?? result.stdout, /does not reference release tag/i);
 });

--- a/tools/priority/finalize-release.mjs
+++ b/tools/priority/finalize-release.mjs
@@ -21,7 +21,8 @@ import {
 import {
   normalizeVersionInput,
   writeReleaseMetadata,
-  summarizeStatusChecks
+  summarizeStatusChecks,
+  assertReleaseMetadataExists
 } from './lib/release-utils.mjs';
 
 const USAGE_LINES = [
@@ -205,6 +206,7 @@ async function main() {
   const repoRoot = getRepoRoot();
   process.chdir(repoRoot);
   ensureCleanWorkingTree(run, 'Working tree not clean. Commit or stash changes before finalizing the release.');
+  await assertReleaseMetadataExists(repoRoot, tag, 'branch');
 
   const releaseBranch = `release/${tag}`;
   ensureBranchExists(releaseBranch);
@@ -337,6 +339,8 @@ async function main() {
 
   if (finalizeMetadata) {
     await writeReleaseMetadata(repoRoot, tag, 'finalize', finalizeMetadata);
+    await assertReleaseMetadataExists(repoRoot, tag, 'branch');
+    await assertReleaseMetadataExists(repoRoot, tag, 'finalize');
     console.log(`[release:finalize] Draft release created for ${tag}. Main and develop fast-forwarded.`);
   }
 }

--- a/tools/priority/lib/release-utils.mjs
+++ b/tools/priority/lib/release-utils.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { mkdir, writeFile } from 'node:fs/promises';
+import { mkdir, writeFile, access } from 'node:fs/promises';
 import path from 'node:path';
 
 const SEMVER_REGEX =
@@ -23,6 +23,22 @@ export async function writeReleaseMetadata(repoRoot, tag, kind, payload) {
   const filePath = path.join(dir, `release-${tag}-${kind}.json`);
   await writeFile(filePath, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
   return filePath;
+}
+
+export function getReleaseMetadataPath(repoRoot, tag, kind) {
+  return path.join(repoRoot, 'tests', 'results', '_agent', 'release', `release-${tag}-${kind}.json`);
+}
+
+export async function assertReleaseMetadataExists(repoRoot, tag, kind) {
+  const artifactPath = getReleaseMetadataPath(repoRoot, tag, kind);
+  try {
+    await access(artifactPath);
+    return artifactPath;
+  } catch {
+    throw new Error(
+      `[release:metadata] Missing required artifact ${path.relative(repoRoot, artifactPath)}. Run the matching release helper first and retain tests/results/_agent/release/*.`
+    );
+  }
 }
 
 export function summarizeStatusCheckRollup(rollup = []) {

--- a/tools/priority/verify-release-branch.mjs
+++ b/tools/priority/verify-release-branch.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
 import { run, getRepoRoot } from './lib/branch-utils.mjs';
@@ -43,6 +43,30 @@ function ensureChangelogDiff(repoRoot, baseRef) {
   }
 }
 
+function fileContainsTag(contents, tag) {
+  const semver = tag.replace(/^v/, '');
+  return contents.includes(tag) || contents.includes(semver);
+}
+
+function ensureReleaseDocsConsistency(repoRoot, tag) {
+  const docs = [
+    { relPath: 'PR_NOTES.md', label: 'PR notes' },
+    { relPath: 'TAG_PREP_CHECKLIST.md', label: 'tag checklist' },
+    { relPath: `RELEASE_NOTES_${tag}.md`, label: 'release notes' }
+  ];
+
+  for (const doc of docs) {
+    const fullPath = path.join(repoRoot, doc.relPath);
+    if (!existsSync(fullPath)) {
+      throw new Error(`Missing ${doc.label} file for ${tag}: ${doc.relPath}`);
+    }
+    const contents = readFileSync(fullPath, 'utf8');
+    if (!fileContainsTag(contents, tag)) {
+      throw new Error(`${doc.relPath} does not reference release tag ${tag}`);
+    }
+  }
+}
+
 function main() {
   const repoRoot = getRepoRoot();
   const headBranch = getHeadBranch();
@@ -52,6 +76,7 @@ function main() {
   const packageJson = JSON.parse(readFileSync(path.join(repoRoot, 'package.json'), 'utf8'));
   ensureVersionMatches(branchTag, packageJson.version);
   ensureChangelogContains(repoRoot, branchTag);
+  ensureReleaseDocsConsistency(repoRoot, branchTag);
 
   const baseRef = process.env.RELEASE_VALIDATE_BASE || 'origin/develop';
   ensureChangelogDiff(repoRoot, baseRef);


### PR DESCRIPTION
## Summary
- require retained release metadata artifacts by blocking `release:finalize` when `tests/results/_agent/release/release-<tag>-branch.json` is missing
- add release metadata path/assertion helpers and expand release utility tests
- harden `verify-release-branch` to enforce release-doc consistency (`PR_NOTES.md`, `TAG_PREP_CHECKLIST.md`, `RELEASE_NOTES_<tag>.md`) against the active release tag
- document the release metadata retention + docs-freeze gate behavior in the developer guide

Closes #290

## Testing
- `node --test tools/priority/__tests__/release-utils.test.mjs tools/priority/__tests__/verify-release-branch.test.mjs`
- `node tools/npm/run-script.mjs priority:test`
- `node tools/npm/run-script.mjs lint:md:changed`
