### PR TITLE
Enforce release hygiene blockers before finalize (#289)

### DIFF
--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -267,6 +267,10 @@ For Docker/Desktop VI history validation, run fast-loop lanes explicitly:
 - Running the live helpers writes JSON snapshots under `tests/results/_agent/release/`:
   - `release-<tag>-branch.json` captures the release branch base, commits, and linked PR.
   - `release-<tag>-finalize.json` records the fast-forward results and the GitHub release draft.
+- `release:finalize` now blocks when release hygiene evidence is not clean:
+  - requires `tests/results/session-index.json` with `status=ok` and zero failed/error counts.
+  - runs `tools/Detect-RogueLV.ps1` and blocks if rogue LabVIEW/LVCompare processes are detected.
+  - set `RELEASE_FINALIZE_SKIP_HYGIENE=1` only for emergency operator overrides.
 - `tools/priority/verify-release-branch.mjs` enforces release-doc consistency before tag cut by requiring
   `PR_NOTES.md`, `TAG_PREP_CHECKLIST.md`, and `RELEASE_NOTES_<tag>.md` to reference the current release tag.
 - `priority:sync` surfaces the most recent artifact in the standing-priority step summary and exposes it to downstream

--- a/tools/priority/__tests__/release-hygiene.test.mjs
+++ b/tools/priority/__tests__/release-hygiene.test.mjs
@@ -1,0 +1,73 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import {
+  readSessionIndexHygiene,
+  parseRogueScanOutput,
+  ensureRogueScanClean
+} from '../lib/release-hygiene.mjs';
+
+test('readSessionIndexHygiene accepts clean session index evidence', async (t) => {
+  const repoDir = await mkdtemp(path.join(tmpdir(), 'release-hygiene-ok-'));
+  t.after(() => rm(repoDir, { recursive: true, force: true }));
+  const resultsDir = path.join(repoDir, 'tests', 'results');
+  await mkdir(resultsDir, { recursive: true });
+  await writeFile(
+    path.join(resultsDir, 'session-index.json'),
+    `${JSON.stringify({
+      status: 'ok',
+      summary: { failed: 0, errors: 0, total: 3, skipped: 0 },
+      branchProtection: { result: { status: 'ok' } }
+    })}\n`,
+    'utf8'
+  );
+
+  const summary = readSessionIndexHygiene(repoDir);
+  assert.equal(summary.status, 'ok');
+  assert.equal(summary.summary.failed, 0);
+  assert.equal(summary.summary.errors, 0);
+});
+
+test('readSessionIndexHygiene rejects failing session index evidence', async (t) => {
+  const repoDir = await mkdtemp(path.join(tmpdir(), 'release-hygiene-fail-'));
+  t.after(() => rm(repoDir, { recursive: true, force: true }));
+  const resultsDir = path.join(repoDir, 'tests', 'results');
+  await mkdir(resultsDir, { recursive: true });
+  await writeFile(
+    path.join(resultsDir, 'session-index.json'),
+    `${JSON.stringify({
+      status: 'warn',
+      summary: { failed: 1, errors: 0 }
+    })}\n`,
+    'utf8'
+  );
+
+  assert.throws(() => readSessionIndexHygiene(repoDir), /status must be "ok"/i);
+});
+
+test('parseRogueScanOutput and ensureRogueScanClean accept clean rogue report', () => {
+  const report = parseRogueScanOutput(
+    JSON.stringify({
+      generatedAt: '2026-03-05T00:00:00Z',
+      lookbackSeconds: 900,
+      rogue: { lvcompare: [], labview: [] },
+      noticed: { lvcompare: [123], labview: [] }
+    })
+  );
+  const summary = ensureRogueScanClean(report);
+  assert.equal(summary.rogue.lvcompare.length, 0);
+  assert.equal(summary.rogue.labview.length, 0);
+});
+
+test('ensureRogueScanClean rejects rogue process findings', () => {
+  assert.throws(
+    () =>
+      ensureRogueScanClean({
+        rogue: { lvcompare: [111], labview: [] },
+        noticed: { lvcompare: [], labview: [] }
+      }),
+    /Rogue process detection must be clean/i
+  );
+});

--- a/tools/priority/finalize-release.mjs
+++ b/tools/priority/finalize-release.mjs
@@ -24,6 +24,11 @@ import {
   summarizeStatusChecks,
   assertReleaseMetadataExists
 } from './lib/release-utils.mjs';
+import {
+  readSessionIndexHygiene,
+  parseRogueScanOutput,
+  ensureRogueScanClean
+} from './lib/release-hygiene.mjs';
 
 const USAGE_LINES = [
   'Usage: node tools/npm/run-script.mjs release:finalize -- <version>',
@@ -195,6 +200,41 @@ function hasSharedHistory(repoRoot, refA, refB) {
   return result.status === 0 && Boolean((result.stdout ?? '').trim());
 }
 
+function collectReleaseHygiene(repoRoot) {
+  if (process.env.RELEASE_FINALIZE_SKIP_HYGIENE === '1') {
+    console.warn('[release:finalize] skipping session-index/rogue hygiene checks (RELEASE_FINALIZE_SKIP_HYGIENE=1)');
+    return {
+      skipped: true,
+      reason: 'RELEASE_FINALIZE_SKIP_HYGIENE=1'
+    };
+  }
+
+  const sessionIndex = readSessionIndexHygiene(repoRoot);
+  const lookbackSeconds = process.env.RELEASE_ROGUE_LOOKBACK_SECONDS ?? '900';
+  const rogueScan = spawnSync(
+    'pwsh',
+    ['-NoLogo', '-NoProfile', '-File', 'tools/Detect-RogueLV.ps1', '-ResultsDir', 'tests/results', '-LookBackSeconds', lookbackSeconds, '-Quiet'],
+    {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe']
+    }
+  );
+
+  if (rogueScan.status !== 0) {
+    const details = (rogueScan.stderr || rogueScan.stdout || '').trim();
+    throw new Error(`Rogue scan execution failed before finalize (exit ${rogueScan.status}). ${details}`);
+  }
+
+  const rogueReport = parseRogueScanOutput(rogueScan.stdout);
+  const rogueSummary = ensureRogueScanClean(rogueReport);
+  return {
+    skipped: false,
+    sessionIndex,
+    rogueScan: rogueSummary
+  };
+}
+
 async function main() {
   const versionInput = parseSingleValueArg(process.argv, {
     usageLines: USAGE_LINES,
@@ -207,6 +247,7 @@ async function main() {
   process.chdir(repoRoot);
   ensureCleanWorkingTree(run, 'Working tree not clean. Commit or stash changes before finalizing the release.');
   await assertReleaseMetadataExists(repoRoot, tag, 'branch');
+  const hygiene = collectReleaseHygiene(repoRoot);
 
   const releaseBranch = `release/${tag}`;
   ensureBranchExists(releaseBranch);
@@ -315,6 +356,7 @@ async function main() {
       developCommit,
       draftedRelease: tag,
       pullRequest: prInfo,
+      hygiene,
       completedAt: new Date().toISOString()
     };
 

--- a/tools/priority/lib/release-hygiene.mjs
+++ b/tools/priority/lib/release-hygiene.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+
+export function readSessionIndexHygiene(repoRoot, relativePath = path.join('tests', 'results', 'session-index.json')) {
+  const sessionPath = path.join(repoRoot, relativePath);
+  if (!existsSync(sessionPath)) {
+    throw new Error(`Session-index hygiene evidence is missing: ${path.relative(repoRoot, sessionPath)}`);
+  }
+
+  let payload = null;
+  try {
+    payload = JSON.parse(readFileSync(sessionPath, 'utf8'));
+  } catch (error) {
+    throw new Error(`Session-index hygiene evidence is invalid JSON (${sessionPath}): ${error.message}`);
+  }
+
+  const status = String(payload?.status ?? '').toLowerCase();
+  const failed = Number(payload?.summary?.failed ?? 0);
+  const errors = Number(payload?.summary?.errors ?? 0);
+  const branchProtectionStatus = String(payload?.branchProtection?.result?.status ?? '').toLowerCase();
+
+  if (status !== 'ok') {
+    throw new Error(`Session-index status must be "ok" before finalize (actual: ${payload?.status ?? 'missing'}).`);
+  }
+  if (failed > 0 || errors > 0) {
+    throw new Error(`Session-index summary must be clean before finalize (failed=${failed}, errors=${errors}).`);
+  }
+  if (branchProtectionStatus === 'fail') {
+    throw new Error('Session-index branch protection hygiene reported fail.');
+  }
+
+  return {
+    path: path.relative(repoRoot, sessionPath),
+    status: payload.status,
+    summary: {
+      failed,
+      errors,
+      skipped: Number(payload?.summary?.skipped ?? 0),
+      total: Number(payload?.summary?.total ?? 0)
+    },
+    branchProtectionStatus: payload?.branchProtection?.result?.status ?? null
+  };
+}
+
+export function parseRogueScanOutput(raw) {
+  const trimmed = String(raw ?? '').trim();
+  if (!trimmed) {
+    throw new Error('Rogue scan did not emit JSON output.');
+  }
+  try {
+    return JSON.parse(trimmed);
+  } catch (error) {
+    throw new Error(`Rogue scan output is not valid JSON: ${error.message}`);
+  }
+}
+
+export function ensureRogueScanClean(report) {
+  const rogueLvcompare = Array.isArray(report?.rogue?.lvcompare) ? report.rogue.lvcompare : [];
+  const rogueLabview = Array.isArray(report?.rogue?.labview) ? report.rogue.labview : [];
+
+  if (rogueLvcompare.length > 0 || rogueLabview.length > 0) {
+    throw new Error(
+      `Rogue process detection must be clean before finalize (LVCompare=${rogueLvcompare.join(',') || 'none'}; LabVIEW=${rogueLabview.join(',') || 'none'}).`
+    );
+  }
+
+  return {
+    generatedAt: report?.generatedAt ?? null,
+    lookbackSeconds: Number(report?.lookbackSeconds ?? 0),
+    rogue: {
+      lvcompare: rogueLvcompare,
+      labview: rogueLabview
+    },
+    noticed: {
+      lvcompare: Array.isArray(report?.noticed?.lvcompare) ? report.noticed.lvcompare : [],
+      labview: Array.isArray(report?.noticed?.labview) ? report.noticed.labview : []
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- gate `release:finalize` on clean session-index hygiene evidence (`tests/results/session-index.json` must be present and healthy)
- run `tools/Detect-RogueLV.ps1` during finalize and block release when rogue LabVIEW/LVCompare processes are detected
- attach hygiene evidence summary to release finalize metadata
- document the new hygiene gate and add dedicated unit coverage for release hygiene parsing/validation

Closes #289

## Testing
- `node --test tools/priority/__tests__/release-hygiene.test.mjs`
- `node --test tools/priority/__tests__/release-utils.test.mjs tools/priority/__tests__/verify-release-branch.test.mjs`
- `node tools/npm/run-script.mjs priority:test`
- `node tools/npm/run-script.mjs lint:md:changed`
