### PR TITLE
Make both compare evidence flows blocking (#288)

### DIFF
--- a/TAG_PREP_CHECKLIST.md
+++ b/TAG_PREP_CHECKLIST.md
@@ -8,7 +8,7 @@ standing-priority issue (#273). Update or archive once the tag is live.
 
 - [ ] Work from the release branch (`release/v0.5.2-rc1`, or latest RC) and ensure it contains all changes targeted for
       0.5.2 (history suite, branch guard, release tooling updates).
-- [ ] CI is green on the RC branch (Validate, fixtures, session-index, `vi-compare-refs`, and any integration workflows).
+- [ ] CI is green on the RC branch (Validate, fixtures, session-index, `vi-compare-refs`, `vi-staging-smoke`, and any integration workflows).
 - [ ] `node tools/npm/run-script.mjs lint` completes without errors (markdownlint + docs checks) on the RC branch.
 - [ ] Optional: run `pwsh -File tools/PrePush-Checks.ps1` locally for early actionlint / YAML parity.
 - [ ] Verify a clean working tree (`git status`).
@@ -73,14 +73,14 @@ Suggested outline:
 1. Summary: history suite telemetry, branch-policy guard + release automation, auto-publish refs, Docker parity helper.
 2. Upgrade notes: history manifests + Dev Dashboard samples, release tooling scripts (`tools/priority/*`), branch guard
    expectations for `develop`.
-3. Validation snapshot: mention required checks (Validate, fixtures, session-index, vi-compare-refs) and guard outcomes.
+3. Validation snapshot: mention required checks (Validate, fixtures, session-index, `vi-compare-refs`, `vi-staging-smoke`) and guard outcomes.
 4. Known issues / follow-ups: monitor history ingestion dashboards, finalize release branch merger back to `develop`.
 5. Rollback: link to `ROLLBACK_PLAN.md`.
 
 ## 8. Post-Tag Actions
 
 - [ ] Merge the release branch back to `develop` (keep CHANGELOG/readme updates in sync).
-- [ ] Dispatch `vi-compare-refs.yml` on `develop` to confirm auto-publish outputs with the tagged code.
+- [ ] Dispatch `vi-compare-refs.yml` and `vi-staging-smoke.yml` on `develop` to confirm both compare evidence flows stay green with artifacts.
 - [ ] Update `POST_RELEASE_FOLLOWUPS.md` with completed vs pending items for the 0.5.2 roadmap.
 - [ ] Dispatch the orchestrated watcher or `node tools/npm/run-script.mjs ci:watch:rest --branch main` to monitor the
       first runs on the tagged commit.
@@ -98,7 +98,7 @@ Suggested outline:
 
 - [ ] Announce the release (internal channel/community notes) calling out the history suite, branch-policy guard, and
       release automation improvements.
-- [ ] Remind consumers of the new manifests/telemetry and the expectation that `vi-compare-refs` auto-publish stays
-      green for tagged builds.
+- [ ] Remind consumers of the new manifests/telemetry and the expectation that both `vi-compare-refs` and
+      `vi-staging-smoke` evidence flows stay green for tagged builds.
 
 --- Updated: 2025-10-23 (revamped for the v0.5.2 release cycle).

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -271,6 +271,10 @@ For Docker/Desktop VI history validation, run fast-loop lanes explicitly:
   - requires `tests/results/session-index.json` with `status=ok` and zero failed/error counts.
   - runs `tools/Detect-RogueLV.ps1` and blocks if rogue LabVIEW/LVCompare processes are detected.
   - set `RELEASE_FINALIZE_SKIP_HYGIENE=1` only for emergency operator overrides.
+- `release:finalize` also blocks when pre-tag compare evidence is incomplete:
+  - requires latest successful `vi-compare-refs.yml` and `vi-staging-smoke.yml` runs for the release branch.
+  - requires both runs to publish artifacts (manifest/staging bundles) before tag cut.
+  - set `RELEASE_FINALIZE_SKIP_COMPARE_EVIDENCE=1` only for emergency operator overrides.
 - `tools/priority/verify-release-branch.mjs` enforces release-doc consistency before tag cut by requiring
   `PR_NOTES.md`, `TAG_PREP_CHECKLIST.md`, and `RELEASE_NOTES_<tag>.md` to reference the current release tag.
 - `priority:sync` surfaces the most recent artifact in the standing-priority step summary and exposes it to downstream

--- a/docs/knowledgebase/VICompare-Refs-Workflow.md
+++ b/docs/knowledgebase/VICompare-Refs-Workflow.md
@@ -9,6 +9,9 @@
   alongside per-mode manifests inside `<results>/<mode-slug>/`.
 - Artifacts only include detailed LVCompare output when a difference is detected; runs with no diffs upload the lightweight
   manifest and JSON summaries.
+- Pre-tag release readiness treats both compare evidence lanes as blocking: the latest
+  `vi-compare-refs.yml` and `vi-staging-smoke.yml` runs must both be green and publish artifacts before
+  `release:finalize` can proceed.
 
 ## Pull request staging helper
 

--- a/tools/priority/__tests__/release-compare-evidence.test.mjs
+++ b/tools/priority/__tests__/release-compare-evidence.test.mjs
@@ -1,0 +1,125 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { collectBlockingCompareEvidence } from '../lib/release-compare-evidence.mjs';
+
+test('collectBlockingCompareEvidence requires both compare workflows to be green with artifacts', async () => {
+  const calls = [];
+  const ghJsonFn = async (args) => {
+    calls.push(args.join(' '));
+    const cmd = args.join(' ');
+    if (cmd.includes('run list') && cmd.includes('vi-compare-refs.yml')) {
+      return [
+        {
+          databaseId: 101,
+          status: 'completed',
+          conclusion: 'success',
+          url: 'https://example.com/runs/101',
+          headBranch: 'release/v1.2.3',
+          createdAt: '2026-03-05T00:00:00Z'
+        }
+      ];
+    }
+    if (cmd.includes('run list') && cmd.includes('vi-staging-smoke.yml')) {
+      return [
+        {
+          databaseId: 102,
+          status: 'completed',
+          conclusion: 'success',
+          url: 'https://example.com/runs/102',
+          headBranch: 'release/v1.2.3',
+          createdAt: '2026-03-05T00:01:00Z'
+        }
+      ];
+    }
+    if (cmd.includes('run view 101')) {
+      return { url: 'https://example.com/runs/101', artifacts: [{ name: 'vi-compare-manifest', sizeInBytes: 1234 }] };
+    }
+    if (cmd.includes('run view 102')) {
+      return { url: 'https://example.com/runs/102', artifacts: [{ name: 'vi-stage-smoke', sizeInBytes: 5678 }] };
+    }
+    throw new Error(`Unexpected gh args: ${cmd}`);
+  };
+
+  const evidence = await collectBlockingCompareEvidence({
+    repoSlug: 'owner/repo',
+    branch: 'release/v1.2.3',
+    ghJsonFn
+  });
+
+  assert.equal(evidence.length, 2);
+  assert.equal(evidence[0].workflow, 'vi-compare-refs.yml');
+  assert.equal(evidence[1].workflow, 'vi-staging-smoke.yml');
+  assert.equal(calls.length, 4);
+});
+
+test('collectBlockingCompareEvidence fails when a workflow run is missing', async () => {
+  const ghJsonFn = async (args) => {
+    if (args.includes('vi-compare-refs.yml')) {
+      return [];
+    }
+    return [];
+  };
+
+  await assert.rejects(
+    () =>
+      collectBlockingCompareEvidence({
+        repoSlug: 'owner/repo',
+        branch: 'release/v1.2.3',
+        ghJsonFn
+      }),
+    /Missing required compare evidence run/i
+  );
+});
+
+test('collectBlockingCompareEvidence fails when a workflow is not successful', async () => {
+  const ghJsonFn = async (args) => {
+    if (args.includes('vi-compare-refs.yml')) {
+      return [
+        {
+          databaseId: 101,
+          status: 'completed',
+          conclusion: 'failure'
+        }
+      ];
+    }
+    return [];
+  };
+
+  await assert.rejects(
+    () =>
+      collectBlockingCompareEvidence({
+        repoSlug: 'owner/repo',
+        branch: 'release/v1.2.3',
+        ghJsonFn
+      }),
+    /not green/i
+  );
+});
+
+test('collectBlockingCompareEvidence fails when artifacts are missing', async () => {
+  const ghJsonFn = async (args) => {
+    if (args.includes('vi-compare-refs.yml')) {
+      return [
+        {
+          databaseId: 101,
+          status: 'completed',
+          conclusion: 'success'
+        }
+      ];
+    }
+    if (args.includes('run view')) {
+      return { artifacts: [] };
+    }
+    return [];
+  };
+
+  await assert.rejects(
+    () =>
+      collectBlockingCompareEvidence({
+        repoSlug: 'owner/repo',
+        branch: 'release/v1.2.3',
+        ghJsonFn
+      }),
+    /has no artifacts/i
+  );
+});

--- a/tools/priority/finalize-release.mjs
+++ b/tools/priority/finalize-release.mjs
@@ -29,6 +29,7 @@ import {
   parseRogueScanOutput,
   ensureRogueScanClean
 } from './lib/release-hygiene.mjs';
+import { collectBlockingCompareEvidence } from './lib/release-compare-evidence.mjs';
 
 const USAGE_LINES = [
   'Usage: node tools/npm/run-script.mjs release:finalize -- <version>',
@@ -235,6 +236,37 @@ function collectReleaseHygiene(repoRoot) {
   };
 }
 
+function ghJson(repoRoot, args) {
+  const out = run('gh', args, { cwd: repoRoot });
+  try {
+    return JSON.parse(out || 'null');
+  } catch (error) {
+    throw new Error(`Failed to parse gh JSON output for "gh ${args.join(' ')}": ${error.message}`);
+  }
+}
+
+async function collectCompareEvidenceGate(repoRoot, upstream, releaseBranch) {
+  if (process.env.RELEASE_FINALIZE_SKIP_COMPARE_EVIDENCE === '1') {
+    console.warn('[release:finalize] skipping compare evidence gate (RELEASE_FINALIZE_SKIP_COMPARE_EVIDENCE=1)');
+    return {
+      skipped: true,
+      reason: 'RELEASE_FINALIZE_SKIP_COMPARE_EVIDENCE=1'
+    };
+  }
+
+  const repoSlug = `${upstream.owner}/${upstream.repo}`;
+  const evidence = await collectBlockingCompareEvidence({
+    repoSlug,
+    branch: releaseBranch,
+    ghJsonFn: (args) => ghJson(repoRoot, args)
+  });
+  return {
+    skipped: false,
+    repository: repoSlug,
+    workflows: evidence
+  };
+}
+
 async function main() {
   const versionInput = parseSingleValueArg(process.argv, {
     usageLines: USAGE_LINES,
@@ -255,6 +287,7 @@ async function main() {
   ensureGhCli();
   const upstream = resolveUpstream(repoRoot);
   ensureOriginFork(repoRoot, upstream);
+  const compareEvidence = await collectCompareEvidenceGate(repoRoot, upstream, releaseBranch);
 
   const prInfo = ensureReleasePrReady(repoRoot, releaseBranch);
 
@@ -357,6 +390,7 @@ async function main() {
       draftedRelease: tag,
       pullRequest: prInfo,
       hygiene,
+      compareEvidence,
       completedAt: new Date().toISOString()
     };
 

--- a/tools/priority/lib/release-compare-evidence.mjs
+++ b/tools/priority/lib/release-compare-evidence.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+
+const DEFAULT_WORKFLOWS = [
+  { file: 'vi-compare-refs.yml', key: 'vi-compare-refs' },
+  { file: 'vi-staging-smoke.yml', key: 'vi-staging-smoke' }
+];
+
+export async function collectBlockingCompareEvidence({
+  repoSlug,
+  branch,
+  ghJsonFn,
+  workflows = DEFAULT_WORKFLOWS
+}) {
+  if (!repoSlug) {
+    throw new Error('Repository slug is required for compare-evidence checks.');
+  }
+  if (!branch) {
+    throw new Error('Branch is required for compare-evidence checks.');
+  }
+  if (typeof ghJsonFn !== 'function') {
+    throw new Error('ghJsonFn is required for compare-evidence checks.');
+  }
+
+  const evidence = [];
+  for (const workflow of workflows) {
+    const runs = await ghJsonFn([
+      'run',
+      'list',
+      '--repo',
+      repoSlug,
+      '--workflow',
+      workflow.file,
+      '--branch',
+      branch,
+      '--limit',
+      '1',
+      '--json',
+      'databaseId,status,conclusion,url,displayTitle,headBranch,createdAt'
+    ]);
+
+    if (!Array.isArray(runs) || runs.length === 0) {
+      throw new Error(`Missing required compare evidence run for ${workflow.file} on ${branch}.`);
+    }
+
+    const latest = runs[0] ?? {};
+    const status = String(latest.status ?? '').toLowerCase();
+    const conclusion = String(latest.conclusion ?? '').toLowerCase();
+    if (status !== 'completed' || conclusion !== 'success') {
+      throw new Error(
+        `Compare evidence workflow ${workflow.file} is not green (status=${latest.status ?? 'unknown'}, conclusion=${latest.conclusion ?? 'unknown'}).`
+      );
+    }
+
+    const runId = Number(latest.databaseId);
+    if (!Number.isFinite(runId) || runId <= 0) {
+      throw new Error(`Compare evidence workflow ${workflow.file} returned invalid run id.`);
+    }
+
+    const runView = await ghJsonFn([
+      'run',
+      'view',
+      String(runId),
+      '--repo',
+      repoSlug,
+      '--json',
+      'artifacts,url'
+    ]);
+
+    const artifacts = Array.isArray(runView?.artifacts) ? runView.artifacts : [];
+    if (artifacts.length === 0) {
+      throw new Error(`Compare evidence workflow ${workflow.file} has no artifacts attached.`);
+    }
+
+    evidence.push({
+      key: workflow.key,
+      workflow: workflow.file,
+      runId,
+      runUrl: runView?.url ?? latest.url ?? null,
+      headBranch: latest.headBranch ?? null,
+      createdAt: latest.createdAt ?? null,
+      artifacts: artifacts.map((artifact) => ({
+        name: artifact?.name ?? null,
+        sizeInBytes: Number(artifact?.sizeInBytes ?? 0)
+      }))
+    });
+  }
+
+  return evidence;
+}


### PR DESCRIPTION
## Summary
- enforce pre-tag compare evidence as blocking in `release:finalize`
- require latest successful artifact-producing runs for both `vi-compare-refs.yml` and `vi-staging-smoke.yml` on the release branch
- persist compare-evidence run/artifact links in finalize metadata
- align release runbook/checklist wording to remove advisory ambiguity between the two compare evidence lanes

Closes #288

## Testing
- `node --test tools/priority/__tests__/release-compare-evidence.test.mjs`
- `node --test tools/priority/__tests__/release-hygiene.test.mjs`
- `node tools/npm/run-script.mjs priority:test`
- `node tools/npm/run-script.mjs lint:md:changed`
