### PR TITLE
Close required release PR checks before finalize (#287)

### DIFF
--- a/TAG_PREP_CHECKLIST.md
+++ b/TAG_PREP_CHECKLIST.md
@@ -9,6 +9,8 @@ standing-priority issue (#273). Update or archive once the tag is live.
 - [ ] Work from the release branch (`release/v0.5.2-rc1`, or latest RC) and ensure it contains all changes targeted for
       0.5.2 (history suite, branch guard, release tooling updates).
 - [ ] CI is green on the RC branch (Validate, fixtures, session-index, `vi-compare-refs`, `vi-staging-smoke`, and any integration workflows).
+- [ ] Release PR required contexts are all `COMPLETED/SUCCESS` before finalize: `lint`, `pester`, `publish`,
+      `vi-binary-check`, `vi-compare`, `mock-cli`, and `Policy Guard (Upstream) / policy-guard`.
 - [ ] `node tools/npm/run-script.mjs lint` completes without errors (markdownlint + docs checks) on the RC branch.
 - [ ] Optional: run `pwsh -File tools/PrePush-Checks.ps1` locally for early actionlint / YAML parity.
 - [ ] Verify a clean working tree (`git status`).

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -275,6 +275,8 @@ For Docker/Desktop VI history validation, run fast-loop lanes explicitly:
   - requires latest successful `vi-compare-refs.yml` and `vi-staging-smoke.yml` runs for the release branch.
   - requires both runs to publish artifacts (manifest/staging bundles) before tag cut.
   - set `RELEASE_FINALIZE_SKIP_COMPARE_EVIDENCE=1` only for emergency operator overrides.
+- `release:finalize` validates required release PR contexts from `tools/policy/branch-required-checks.json`
+  (`release/*`) and blocks on missing/pending/failing required checks.
 - `tools/priority/verify-release-branch.mjs` enforces release-doc consistency before tag cut by requiring
   `PR_NOTES.md`, `TAG_PREP_CHECKLIST.md`, and `RELEASE_NOTES_<tag>.md` to reference the current release tag.
 - `priority:sync` surfaces the most recent artifact in the standing-priority step summary and exposes it to downstream

--- a/tools/priority/__tests__/release-pr-checks.test.mjs
+++ b/tools/priority/__tests__/release-pr-checks.test.mjs
@@ -1,0 +1,63 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import {
+  loadReleaseRequiredChecks,
+  evaluateRequiredReleaseChecks,
+  assertRequiredReleaseChecksClean
+} from '../lib/release-pr-checks.mjs';
+
+test('loadReleaseRequiredChecks reads release/* contexts from policy file', async (t) => {
+  const repoDir = await mkdtemp(path.join(tmpdir(), 'release-pr-checks-'));
+  t.after(() => rm(repoDir, { recursive: true, force: true }));
+  await mkdir(path.join(repoDir, 'tools', 'policy'), { recursive: true });
+  await writeFile(
+    path.join(repoDir, 'tools', 'policy', 'branch-required-checks.json'),
+    `${JSON.stringify({
+      branches: {
+        'release/*': ['lint', 'pester']
+      }
+    })}\n`,
+    'utf8'
+  );
+
+  const checks = loadReleaseRequiredChecks(repoDir);
+  assert.deepEqual(checks, ['lint', 'pester']);
+});
+
+test('evaluateRequiredReleaseChecks accepts prefixed workflow check names', () => {
+  const evaluation = evaluateRequiredReleaseChecks(
+    ['lint', 'session-index'],
+    [
+      { name: 'Validate / lint', status: 'COMPLETED', conclusion: 'SUCCESS' },
+      { name: 'Validate / session-index', status: 'COMPLETED', conclusion: 'SUCCESS' }
+    ]
+  );
+  assert.deepEqual(evaluation, { missing: [], unresolved: [] });
+});
+
+test('evaluateRequiredReleaseChecks reports missing and unresolved contexts', () => {
+  const evaluation = evaluateRequiredReleaseChecks(
+    ['lint', 'pester', 'session-index'],
+    [
+      { name: 'Validate / lint', status: 'COMPLETED', conclusion: 'SUCCESS' },
+      { name: 'Validate / pester', status: 'IN_PROGRESS', conclusion: null }
+    ]
+  );
+  assert.deepEqual(evaluation.missing, ['session-index']);
+  assert.equal(evaluation.unresolved.length, 1);
+  assert.equal(evaluation.unresolved[0].context, 'pester');
+});
+
+test('assertRequiredReleaseChecksClean throws when required checks are not satisfied', () => {
+  assert.throws(
+    () =>
+      assertRequiredReleaseChecksClean(
+        ['lint', 'pester'],
+        [{ name: 'Validate / lint', status: 'COMPLETED', conclusion: 'SUCCESS' }]
+      ),
+    /not satisfied/i
+  );
+});

--- a/tools/priority/finalize-release.mjs
+++ b/tools/priority/finalize-release.mjs
@@ -30,6 +30,10 @@ import {
   ensureRogueScanClean
 } from './lib/release-hygiene.mjs';
 import { collectBlockingCompareEvidence } from './lib/release-compare-evidence.mjs';
+import {
+  loadReleaseRequiredChecks,
+  assertRequiredReleaseChecksClean
+} from './lib/release-pr-checks.mjs';
 
 const USAGE_LINES = [
   'Usage: node tools/npm/run-script.mjs release:finalize -- <version>',
@@ -61,7 +65,7 @@ function buildReleaseNotes(tag) {
   return `Draft release for ${tag}`;
 }
 
-function ensureReleasePrReady(repoRoot, branch) {
+function ensureReleasePrReady(repoRoot, branch, requiredChecks = []) {
   if (process.env.RELEASE_FINALIZE_SKIP_CHECKS === '1') {
     console.warn('[release:finalize] skipping PR status checks (RELEASE_FINALIZE_SKIP_CHECKS=1)');
     return null;
@@ -157,21 +161,22 @@ function ensureReleasePrReady(repoRoot, branch) {
     );
   }
 
-  const failingChecks = (info.statusCheckRollup || []).filter(
-    (check) => check.status !== 'COMPLETED' || check.conclusion !== 'SUCCESS'
-  );
-  if (failingChecks.length > 0 && process.env.RELEASE_FINALIZE_ALLOW_DIRTY !== '1') {
-    const detail = failingChecks
-      .map((check) => `${check.name} (${check.conclusion ?? check.status ?? 'unknown'})`)
-      .join(', ');
-    throw new Error(`Release PR has failing or pending checks: ${detail}.`);
+  let requiredEvaluation = null;
+  if (process.env.RELEASE_FINALIZE_ALLOW_DIRTY !== '1') {
+    requiredEvaluation = assertRequiredReleaseChecksClean(requiredChecks, info.statusCheckRollup ?? []);
+  } else if (requiredChecks.length > 0) {
+    requiredEvaluation = {
+      skipped: true,
+      reason: 'RELEASE_FINALIZE_ALLOW_DIRTY=1'
+    };
   }
 
   return {
     number: info.number ?? null,
     url: info.url ?? null,
     mergeStateStatus,
-    checks: summarizeStatusChecks(info.statusCheckRollup ?? [])
+    checks: summarizeStatusChecks(info.statusCheckRollup ?? []),
+    requiredChecks: requiredEvaluation
   };
 }
 
@@ -283,13 +288,14 @@ async function main() {
 
   const releaseBranch = `release/${tag}`;
   ensureBranchExists(releaseBranch);
+  const requiredReleaseChecks = loadReleaseRequiredChecks(repoRoot);
 
   ensureGhCli();
   const upstream = resolveUpstream(repoRoot);
   ensureOriginFork(repoRoot, upstream);
   const compareEvidence = await collectCompareEvidenceGate(repoRoot, upstream, releaseBranch);
 
-  const prInfo = ensureReleasePrReady(repoRoot, releaseBranch);
+  const prInfo = ensureReleasePrReady(repoRoot, releaseBranch, requiredReleaseChecks);
 
   run('git', ['fetch', 'origin'], { cwd: repoRoot });
   run('git', ['fetch', 'upstream'], { cwd: repoRoot });

--- a/tools/priority/lib/release-pr-checks.mjs
+++ b/tools/priority/lib/release-pr-checks.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+function contextAliases(context) {
+  const normalized = String(context ?? '').trim();
+  if (!normalized) {
+    return [];
+  }
+  const aliases = new Set([normalized.toLowerCase()]);
+  const divider = ' / ';
+  const idx = normalized.indexOf(divider);
+  if (idx !== -1) {
+    const suffix = normalized.slice(idx + divider.length).trim();
+    if (suffix) {
+      aliases.add(suffix.toLowerCase());
+    }
+  }
+  return [...aliases];
+}
+
+function contextsMatch(requiredContext, actualContext) {
+  const requiredAliases = contextAliases(requiredContext);
+  const actualAliases = contextAliases(actualContext);
+  return requiredAliases.some((alias) => actualAliases.includes(alias));
+}
+
+export function loadReleaseRequiredChecks(
+  repoRoot,
+  policyRelativePath = path.join('tools', 'policy', 'branch-required-checks.json')
+) {
+  const policyPath = path.join(repoRoot, policyRelativePath);
+  let policy = null;
+  try {
+    policy = JSON.parse(readFileSync(policyPath, 'utf8'));
+  } catch (error) {
+    throw new Error(`Unable to read required-check policy at ${policyPath}: ${error.message}`);
+  }
+
+  const required = policy?.branches?.['release/*'];
+  if (!Array.isArray(required) || required.length === 0) {
+    throw new Error(`Required-check policy is missing branches["release/*"] in ${policyPath}.`);
+  }
+  return [...new Set(required.map((item) => String(item ?? '').trim()).filter(Boolean))];
+}
+
+export function evaluateRequiredReleaseChecks(requiredChecks, statusCheckRollup = []) {
+  const checks = Array.isArray(statusCheckRollup) ? statusCheckRollup : [];
+  const missing = [];
+  const unresolved = [];
+
+  for (const required of requiredChecks) {
+    const match = checks.find((check) => contextsMatch(required, check?.name));
+    if (!match) {
+      missing.push(required);
+      continue;
+    }
+    const status = String(match.status ?? '').toUpperCase();
+    const conclusion = String(match.conclusion ?? '').toUpperCase();
+    if (status !== 'COMPLETED' || conclusion !== 'SUCCESS') {
+      unresolved.push({
+        context: required,
+        observedName: match.name ?? null,
+        status: match.status ?? null,
+        conclusion: match.conclusion ?? null
+      });
+    }
+  }
+
+  return { missing, unresolved };
+}
+
+export function assertRequiredReleaseChecksClean(requiredChecks, statusCheckRollup = []) {
+  const evaluation = evaluateRequiredReleaseChecks(requiredChecks, statusCheckRollup);
+  if (evaluation.missing.length === 0 && evaluation.unresolved.length === 0) {
+    return evaluation;
+  }
+
+  const parts = [];
+  if (evaluation.missing.length > 0) {
+    parts.push(`missing contexts: ${evaluation.missing.join(', ')}`);
+  }
+  if (evaluation.unresolved.length > 0) {
+    const details = evaluation.unresolved
+      .map((entry) => `${entry.context} (${entry.status ?? 'unknown'}/${entry.conclusion ?? 'unknown'})`)
+      .join(', ');
+    parts.push(`unresolved contexts: ${details}`);
+  }
+
+  throw new Error(`Release PR required checks are not satisfied: ${parts.join('; ')}`);
+}


### PR DESCRIPTION
## Summary
- enforce required release PR check contexts in `release:finalize` using `tools/policy/branch-required-checks.json` (`release/*`)
- block finalize on missing/pending/failing required contexts with explicit diagnostics
- add alias-aware required-check matching (`Validate / lint` == `lint`) for stable contract enforcement
- align release checklist and developer guidance to the same required-check contract used by finalize

Closes #287

## Testing
- `node --test tools/priority/__tests__/release-pr-checks.test.mjs`
- `node --test tools/priority/__tests__/release-compare-evidence.test.mjs tools/priority/__tests__/release-hygiene.test.mjs`
- `node tools/npm/run-script.mjs priority:test`
- `node tools/npm/run-script.mjs lint:md:changed`
