### PR TITLE
Harden release branch semver/integrity gates (#286)

### DIFF
--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -279,6 +279,9 @@ For Docker/Desktop VI history validation, run fast-loop lanes explicitly:
   (`release/*`) and blocks on missing/pending/failing required checks.
 - `tools/priority/verify-release-branch.mjs` enforces release-doc consistency before tag cut by requiring
   `PR_NOTES.md`, `TAG_PREP_CHECKLIST.md`, and `RELEASE_NOTES_<tag>.md` to reference the current release tag.
+  It also requires both `package.json` and `docs/CHANGELOG.md` to change relative to the configured release base ref.
+- `tools/priority/validate-semver.mjs` now performs branch-aware integrity checks: on `release/<tag>` heads it enforces
+  `package.json` SemVer parity with the branch tag.
 - `priority:sync` surfaces the most recent artifact in the standing-priority step summary and exposes it to downstream
   automation via `snapshot.releaseArtifacts`.
 - `priority:parity` reports origin/upstream parity using two metrics:

--- a/tools/priority/__tests__/validate-semver.test.mjs
+++ b/tools/priority/__tests__/validate-semver.test.mjs
@@ -1,0 +1,33 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { evaluateVersionIntegrity, parseArgs } from '../validate-semver.mjs';
+
+test('evaluateVersionIntegrity accepts valid semver without branch context', () => {
+  const result = evaluateVersionIntegrity('1.2.3');
+  assert.equal(result.valid, true);
+  assert.deepEqual(result.issues, []);
+});
+
+test('evaluateVersionIntegrity rejects invalid semver version', () => {
+  const result = evaluateVersionIntegrity('1.2');
+  assert.equal(result.valid, false);
+  assert.match(result.issues[0], /does not comply/i);
+});
+
+test('evaluateVersionIntegrity enforces release branch/version match', () => {
+  const mismatch = evaluateVersionIntegrity('1.2.3', 'release/v1.2.4');
+  assert.equal(mismatch.valid, false);
+  assert.match(mismatch.issues.join(' '), /does not match release branch tag/i);
+
+  const match = evaluateVersionIntegrity('1.2.3', 'release/v1.2.3');
+  assert.equal(match.valid, true);
+});
+
+test('parseArgs resolves branch from cli flag or github env', () => {
+  const cli = parseArgs(['--version', '1.2.3', '--branch', 'release/v1.2.3'], {});
+  assert.equal(cli.versionArg, '1.2.3');
+  assert.equal(cli.branch, 'release/v1.2.3');
+
+  const env = parseArgs([], { GITHUB_HEAD_REF: 'release/v2.0.0' });
+  assert.equal(env.branch, 'release/v2.0.0');
+});

--- a/tools/priority/__tests__/verify-release-branch.test.mjs
+++ b/tools/priority/__tests__/verify-release-branch.test.mjs
@@ -163,3 +163,43 @@ test('verify-release-branch fails when release docs are inconsistent', async (t)
   assert.notEqual(result.status, 0);
   assert.match(result.stderr ?? result.stdout, /does not reference release tag/i);
 });
+
+test('verify-release-branch fails when package.json is not updated relative to base', async (t) => {
+  const repoDir = await mkdtemp(path.join(tmpdir(), 'verify-release-package-diff-fail-'));
+  t.after(() => rm(repoDir, { recursive: true, force: true }));
+
+  await mkdir(path.join(repoDir, 'docs'), { recursive: true });
+  await writeFile(
+    path.join(repoDir, 'docs', 'CHANGELOG.md'),
+    '# Changelog\n\n## v0.1.0 - Initial\n- First release\n',
+    'utf8'
+  );
+  await writeFile(
+    path.join(repoDir, 'package.json'),
+    JSON.stringify({ name: 'test', version: '0.1.0' }, null, 2) + '\n',
+    'utf8'
+  );
+  await writeReleaseDocs(repoDir, 'v0.1.0');
+
+  runGit(repoDir, ['init']);
+  runGit(repoDir, ['config', 'user.name', 'Test']);
+  runGit(repoDir, ['config', 'user.email', 'test@example.com']);
+  runGit(repoDir, ['add', '.']);
+  runGit(repoDir, ['commit', '-m', 'initial release']);
+  runGit(repoDir, ['branch', 'develop']);
+
+  runGit(repoDir, ['checkout', '-b', 'release/v0.1.0']);
+  await writeFile(
+    path.join(repoDir, 'docs', 'CHANGELOG.md'),
+    '# Changelog\n\n## v0.1.0 - Refresh\n- Notes updated\n',
+    'utf8'
+  );
+  await writeReleaseDocs(repoDir, 'v0.1.0');
+  runGit(repoDir, ['commit', '-am', 'docs only']);
+
+  const script = path.resolve('tools', 'priority', 'verify-release-branch.mjs');
+  const env = { ...process.env, GITHUB_HEAD_REF: 'release/v0.1.0', RELEASE_VALIDATE_BASE: 'HEAD~1' };
+  const result = spawnSync(process.execPath, [script], { cwd: repoDir, env, encoding: 'utf8' });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr ?? result.stdout, /package\.json not updated relative to/i);
+});

--- a/tools/priority/validate-semver.mjs
+++ b/tools/priority/validate-semver.mjs
@@ -7,6 +7,8 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const repoRoot = path.resolve(__dirname, '..', '..');
 
+const semverRegex = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-(?:0|[1-9A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9A-Za-z-][0-9A-Za-z-]*))*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+
 function readPackageVersion() {
   const pkgPath = path.join(repoRoot, 'package.json');
   const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
@@ -16,47 +18,99 @@ function readPackageVersion() {
   return String(pkg.version);
 }
 
-const args = process.argv.slice(2);
-let versionArg = null;
-for (let i = 0; i < args.length; i += 1) {
-  const arg = args[i];
-  if (arg === '--version' && args[i + 1]) {
-    versionArg = args[i + 1];
-    i += 1;
-  } else if (!arg.startsWith('--') && !versionArg) {
-    versionArg = arg;
+export function parseArgs(args = process.argv.slice(2), env = process.env) {
+  let versionArg = null;
+  let branchArg = null;
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === '--version' && args[i + 1]) {
+      versionArg = args[i + 1];
+      i += 1;
+      continue;
+    }
+    if (arg === '--branch' && args[i + 1]) {
+      branchArg = args[i + 1];
+      i += 1;
+      continue;
+    }
+    if (!arg.startsWith('--') && !versionArg) {
+      versionArg = arg;
+    }
   }
+
+  const branch =
+    branchArg ||
+    env.GITHUB_HEAD_REF ||
+    env.GITHUB_REF_NAME ||
+    null;
+
+  return {
+    versionArg,
+    branch
+  };
 }
 
-let version = null;
-try {
-  version = versionArg ?? readPackageVersion();
-} catch (err) {
-  console.error(JSON.stringify({
-    schema: 'priority/semver-check@v1',
-    version: null,
-    valid: false,
-    issues: [err.message],
-    checkedAt: new Date().toISOString()
-  }, null, 2));
-  process.exit(1);
+export function evaluateVersionIntegrity(version, branch = null) {
+  const issues = [];
+  const valid = semverRegex.test(version);
+  if (!valid) {
+    issues.push(`Version "${version}" does not comply with SemVer 2.0.0`);
+  }
+
+  if (branch && branch.startsWith('release/')) {
+    const branchTag = branch.slice('release/'.length);
+    const branchSemver = branchTag.startsWith('v') ? branchTag.slice(1) : branchTag;
+    if (!semverRegex.test(branchSemver)) {
+      issues.push(`Release branch tag "${branchTag}" is not a SemVer version.`);
+    } else if (version !== branchSemver) {
+      issues.push(`Version "${version}" does not match release branch tag "${branchTag}".`);
+    }
+  }
+
+  return {
+    valid: issues.length === 0,
+    issues
+  };
 }
 
-const semverRegex = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-(?:0|[1-9A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9A-Za-z-][0-9A-Za-z-]*))*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
-const valid = semverRegex.test(version);
-const issues = [];
+export function run({ args = process.argv.slice(2), env = process.env } = {}) {
+  const parsed = parseArgs(args, env);
+  let version = null;
 
-if (!valid) {
-  issues.push(`Version "${version}" does not comply with SemVer 2.0.0`);
+  try {
+    version = parsed.versionArg ?? readPackageVersion();
+  } catch (err) {
+    return {
+      code: 1,
+      output: {
+        schema: 'priority/semver-check@v1',
+        version: null,
+        branch: parsed.branch,
+        valid: false,
+        issues: [err.message],
+        checkedAt: new Date().toISOString()
+      }
+    };
+  }
+
+  const evaluated = evaluateVersionIntegrity(version, parsed.branch);
+  return {
+    code: evaluated.valid ? 0 : 1,
+    output: {
+      schema: 'priority/semver-check@v1',
+      version,
+      branch: parsed.branch,
+      valid: evaluated.valid,
+      issues: evaluated.issues,
+      checkedAt: new Date().toISOString()
+    }
+  };
 }
 
-const output = {
-  schema: 'priority/semver-check@v1',
-  version,
-  valid,
-  issues,
-  checkedAt: new Date().toISOString()
-};
-
-console.log(JSON.stringify(output, null, 2));
-process.exit(valid ? 0 : 1);
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : null;
+if (invokedPath && invokedPath === __filename) {
+  const result = run();
+  console.log(JSON.stringify(result.output, null, 2));
+  process.exit(result.code);
+}

--- a/tools/priority/verify-release-branch.mjs
+++ b/tools/priority/verify-release-branch.mjs
@@ -43,6 +43,13 @@ function ensureChangelogDiff(repoRoot, baseRef) {
   }
 }
 
+function ensurePackageVersionDiff(repoRoot, baseRef) {
+  const diff = run('git', ['diff', `${baseRef}`, '--', 'package.json'], { cwd: repoRoot });
+  if (!diff.trim()) {
+    throw new Error(`package.json not updated relative to ${baseRef}`);
+  }
+}
+
 function fileContainsTag(contents, tag) {
   const semver = tag.replace(/^v/, '');
   return contents.includes(tag) || contents.includes(semver);
@@ -79,6 +86,7 @@ function main() {
   ensureReleaseDocsConsistency(repoRoot, branchTag);
 
   const baseRef = process.env.RELEASE_VALIDATE_BASE || 'origin/develop';
+  ensurePackageVersionDiff(repoRoot, baseRef);
   ensureChangelogDiff(repoRoot, baseRef);
 
   console.log(`[release:verify] Release branch ${headBranch} validated successfully.`);


### PR DESCRIPTION
## Summary
- harden release branch integrity checks by requiring `package.json` and `docs/CHANGELOG.md` changes relative to the release base
- add branch-aware semver validation so `release/<tag>` heads must match `package.json` SemVer
- improve deterministic mismatch diagnostics for branch/tag/version/changelog drift paths
- extend release verification and semver test coverage for these mismatch scenarios

Closes #286

## Testing
- `node --test tools/priority/__tests__/validate-semver.test.mjs tools/priority/__tests__/verify-release-branch.test.mjs`
- `node --test tools/priority/__tests__/release-pr-checks.test.mjs`
- `node tools/npm/run-script.mjs priority:test`
- `node tools/npm/run-script.mjs lint:md:changed`
