### PR TITLE
[P1][onboarding] add downstream compare-vi consumer workflow

### DIFF
--- a/.github/workflows/downstream-comparevi-consumer.yml
+++ b/.github/workflows/downstream-comparevi-consumer.yml
@@ -1,0 +1,19 @@
+name: Downstream CompareVI Consumer
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  consume-upstream-comparevi:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Consume upstream compare-vi action (stable pin)
+        uses: LabVIEW-Community-CI-CD/compare-vi-cli-action@v0.6.3
+        with:
+          base: fixtures/downstream/base.vi
+          head: fixtures/downstream/head.vi
+          loop-enabled: true
+          fail-on-diff: false


### PR DESCRIPTION
## Summary
- adds a dedicated downstream consumer workflow referencing upstream compare-vi action
- pins to stable upstream tag: `LabVIEW-Community-CI-CD/compare-vi-cli-action@v0.6.3`
- runs in loop/simulated mode for deterministic hosted validation without LabVIEW runtime coupling

## Why
Addresses missing `workflow-reference-present` hardening gap tracked in:
- LabVIEW-Community-CI-CD/compare-vi-cli-action#767

## Validation
- workflow file added under `.github/workflows/downstream-comparevi-consumer.yml`
- reference is immutable stable semver tag

Refs LabVIEW-Community-CI-CD/compare-vi-cli-action#767
