### PR TITLE
#301 Mark raw artifact download paths as legacy surfaces

### DIFF
--- a/docs/ICON_EDITOR_PACKAGE.md
+++ b/docs/ICON_EDITOR_PACKAGE.md
@@ -215,6 +215,11 @@ carries the actual LabVIEW payload.
     --name icon-editor-vi-comparison-report --dir artifacts/icon-editor/report
   ```
 
+  Historical compatibility note:
+  This example remains a raw `gh run download` snippet because this icon-editor package document is a historical
+  compatibility surface. For maintained future-agent/operator retrieval in this repository, prefer
+  `node tools/npm/run-script.mjs priority:artifact:download -- --repo <owner/repo> --run-id <id> --artifact <name>`.
+
   The Markdown file includes a status table (same/different/error) and links back to the capture artifact.
 
 ## Building overlays from icon-editor commits

--- a/tools/OneButton-CI.ps1
+++ b/tools/OneButton-CI.ps1
@@ -126,6 +126,10 @@ function Download-RunArtifacts {
     [Parameter(Mandatory=$true)][string]$RunId,
     [Parameter(Mandatory=$true)][string]$TargetDir
   )
+  Write-Warning (
+    'Download-RunArtifacts uses legacy all-artifact gh download behavior for the historical one-button flow. ' +
+    'For maintained future-agent triage, prefer "node tools/npm/run-script.mjs priority:artifact:download -- --repo <owner/repo> --run-id <id> --artifact <name>".'
+  )
   New-Item -ItemType Directory -Force -Path $TargetDir | Out-Null
   gh run download $RunId -R $Repo -D $TargetDir | Out-Null
 }

--- a/tools/icon-editor/Replay-BuildVipJob.ps1
+++ b/tools/icon-editor/Replay-BuildVipJob.ps1
@@ -42,9 +42,11 @@
     Invoke the Close_LabVIEW.ps1 helper after the build.
 
 .PARAMETER DownloadArtifacts
-    When supplied, downloads the run's artifacts (via gh run download) into a
-    temporary directory and copies any lv_icon_*.lvlibp files into the expected
-    resource/plugins folder.
+    When supplied, downloads the run's artifacts (via legacy gh run download)
+    into a temporary directory and copies any lv_icon_*.lvlibp files into the
+    expected resource/plugins folder. For maintained future-agent triage, prefer
+    the checked-in priority:artifact:download helper when you only need named
+    artifacts.
 
 .PARAMETER BuildToolchain
     Toolchain used to rebuild the VIP. Defaults to 'gcli'; pass 'vipm' to route
@@ -198,6 +200,11 @@ if ($RunId) {
         }
         New-Item -ItemType Directory -Path $artifactDest | Out-Null
 
+        Write-Warning (
+            'Replay-BuildVipJob -DownloadArtifacts uses a legacy all-artifact gh download for historical icon-editor replay. ' +
+            'Prefer "node tools/npm/run-script.mjs priority:artifact:download -- --repo <owner/repo> --run-id <id> --artifact <name>" ' +
+            'for maintained future-agent named-artifact retrieval.'
+        )
         Write-Verbose "Downloading artifacts to $artifactDest"
         $downloadArgs = @('run', 'download', $RunId, '--dir', $artifactDest)
         Invoke-GitHubCli -Arguments $downloadArgs | Out-Null


### PR DESCRIPTION
## Summary
Marks the remaining raw artifact-download entrypoints on the personal fork lane as legacy/historical surfaces so future agents are steered toward the checked-in `priority:artifact:download` helper.

This does not change the helper itself. It narrows the maintained guidance around the remaining raw `gh run download` paths while upstream PR #975 finishes the helper epic root slice.

## Change Surface
- adds legacy-path warnings to `tools/OneButton-CI.ps1`
- adds legacy-path warnings to `tools/icon-editor/Replay-BuildVipJob.ps1`
- reframes the `docs/ICON_EDITOR_PACKAGE.md` raw download example as historical compatibility guidance

## Testing
- PowerShell parser validation for `tools/OneButton-CI.ps1` and `tools/icon-editor/Replay-BuildVipJob.ps1`
- `node tools/npm/run-script.mjs lint:md:changed`

Refs svelderrainruiz/compare-vi-cli-action#301
Refs LabVIEW-Community-CI-CD/compare-vi-cli-action#976
