### PR TITLE
Fork self-hosted Windows jobs: classify runner admission starvation (#991)

### DIFF
--- a/tools/Watch-PRChecksSafe.ps1
+++ b/tools/Watch-PRChecksSafe.ps1
@@ -4,6 +4,7 @@ param(
   [Parameter()][int]$IntervalSeconds = 20,
   [Parameter()][int]$HeartbeatPolls = 6,
   [Parameter()][int]$MaxPolls = 0,
+  [Parameter()][int]$RunnerAdmissionQueueThresholdMinutes = 20,
   [Parameter()][switch]$RequiredOnly,
   [Parameter()][switch]$FailFast
 )
@@ -57,6 +58,31 @@ function Invoke-GhJson {
   return @($parsed)
 }
 
+function Invoke-GhText {
+  param(
+    [Parameter(Mandatory)][string]$GhPath,
+    [Parameter(Mandatory)][string[]]$Arguments,
+    [Parameter()][string]$AllowedErrorPattern = ''
+  )
+
+  $output = & $GhPath @Arguments 2>&1
+  $text = ($output -join "`n").Trim()
+  $matchedAllowedError = $false
+  if (-not [string]::IsNullOrWhiteSpace($AllowedErrorPattern) -and -not [string]::IsNullOrWhiteSpace($text)) {
+    $matchedAllowedError = $text -match $AllowedErrorPattern
+  }
+
+  if ($LASTEXITCODE -ne 0 -and -not $matchedAllowedError) {
+    throw ("gh command failed (exit {0}): gh {1}`n{2}" -f $LASTEXITCODE, ($Arguments -join ' '), $text)
+  }
+
+  [pscustomobject]@{
+    ExitCode = $LASTEXITCODE
+    Output = $text
+    MatchedAllowedError = $matchedAllowedError
+  }
+}
+
 function Resolve-PullRequestNumber {
   param(
     [Parameter(Mandatory)][string]$GhPath,
@@ -97,16 +123,164 @@ function Get-PrChecksSnapshot {
     $args += @('--repo', $Repository)
   }
 
-  $checks = Invoke-GhJson -GhPath $GhPath -Arguments $args
-  return @($checks | ForEach-Object {
-      [pscustomobject]@{
-        Workflow = [string]$_.workflow
-        Name = [string]$_.name
-        Bucket = [string]$_.bucket
-        State = [string]$_.state
-        Link = [string]$_.link
+  $response = Invoke-GhText -GhPath $GhPath -Arguments $args -AllowedErrorPattern 'no checks reported'
+  if ($response.ExitCode -ne 0 -and $response.MatchedAllowedError) {
+    return [pscustomobject]@{
+      NoChecksReported = $true
+      Checks = @()
+    }
+  }
+
+  $checks = @()
+  if (-not [string]::IsNullOrWhiteSpace($response.Output)) {
+    $parsed = $response.Output | ConvertFrom-Json -Depth 20
+    if ($parsed -is [System.Array]) {
+      $checks = @($parsed)
+    } elseif ($null -ne $parsed) {
+      $checks = @($parsed)
+    }
+  }
+
+  return [pscustomobject]@{
+    NoChecksReported = $false
+    Checks = @($checks | ForEach-Object {
+        [pscustomobject]@{
+          Workflow = [string]$_.workflow
+          Name = [string]$_.name
+          Bucket = [string]$_.bucket
+          State = [string]$_.state
+          Link = [string]$_.link
+        }
+      })
+  }
+}
+
+function Get-PollDelayMilliseconds {
+  param([Parameter(Mandatory)][int]$IntervalSeconds)
+
+  $override = $env:WATCH_PR_CHECKS_POLL_DELAY_MILLISECONDS
+  if (-not [string]::IsNullOrWhiteSpace($override)) {
+    $parsedOverride = 0
+    if ([int]::TryParse($override, [ref]$parsedOverride) -and $parsedOverride -ge 0) {
+      return $parsedOverride
+    }
+  }
+
+  return ($IntervalSeconds * 1000)
+}
+
+function Resolve-JobDescriptor {
+  param(
+    [Parameter()][string]$Repository,
+    [Parameter()][string]$Link
+  )
+
+  if ([string]::IsNullOrWhiteSpace($Link)) {
+    return $null
+  }
+
+  if ($Link -match '^https://github\.com/(?<repo>[^/]+/[^/]+)/actions/runs/(?<run>\d+)/job/(?<job>\d+)$') {
+    return [pscustomobject]@{
+      Repository = if (-not [string]::IsNullOrWhiteSpace($Repository)) { $Repository } else { $Matches.repo }
+      RunId = [int64]$Matches.run
+      JobId = [int64]$Matches.job
+    }
+  }
+
+  return $null
+}
+
+function Get-QueuedSelfHostedAdmissionBlockers {
+  param(
+    [Parameter(Mandatory)][string]$GhPath,
+    [Parameter(Mandatory)][System.Collections.IEnumerable]$Checks,
+    [Parameter()][string]$Repository,
+    [Parameter(Mandatory)][int]$ThresholdMinutes
+  )
+
+  $now = [DateTimeOffset]::UtcNow
+  $runnerInventoryCache = @{}
+  $blockers = @()
+  foreach ($check in @($Checks | Where-Object { $_.Bucket -eq 'pending' -and $_.State -eq 'QUEUED' })) {
+    $descriptor = Resolve-JobDescriptor -Repository $Repository -Link $check.Link
+    if ($null -eq $descriptor) {
+      continue
+    }
+
+    $jobResponse = Invoke-GhJson -GhPath $GhPath -Arguments @('api', "repos/$($descriptor.Repository)/actions/jobs/$($descriptor.JobId)")
+    $job = @($jobResponse)[0]
+    if ($null -eq $job) {
+      continue
+    }
+
+    $labels = @($job.labels | ForEach-Object { [string]$_ })
+    $isSelfHosted = $labels -contains 'self-hosted'
+    $runnerId = 0
+    if ($null -ne $job.runner_id) {
+      $runnerId = [int64]$job.runner_id
+    }
+    $runnerAssigned = ($runnerId -gt 0) -or -not [string]::IsNullOrWhiteSpace([string]$job.runner_name)
+    $queuedAt = $null
+    if (-not [string]::IsNullOrWhiteSpace([string]$job.started_at)) {
+      $queuedAt = [DateTimeOffset]::Parse([string]$job.started_at)
+    } elseif (-not [string]::IsNullOrWhiteSpace([string]$job.created_at)) {
+      $queuedAt = [DateTimeOffset]::Parse([string]$job.created_at)
+    }
+
+    $queueAgeMinutes = $null
+    if ($null -ne $queuedAt) {
+      $queueAgeMinutes = [int][math]::Floor(($now - $queuedAt).TotalMinutes)
+      if ($queueAgeMinutes -lt 0) {
+        $queueAgeMinutes = $null
       }
-    })
+    }
+
+    $runnerInventory = $null
+    if (-not $runnerInventoryCache.ContainsKey($descriptor.Repository)) {
+      try {
+        $runnerInventoryResponse = Invoke-GhJson -GhPath $GhPath -Arguments @('api', "repos/$($descriptor.Repository)/actions/runners")
+        $runnerInventoryPayload = @($runnerInventoryResponse)[0]
+        $runnerInventory = [pscustomobject]@{
+          Accessible = $true
+          TotalCount = if ($null -ne $runnerInventoryPayload.total_count) { [int]$runnerInventoryPayload.total_count } else { @($runnerInventoryPayload.runners).Count }
+          Error = $null
+        }
+      } catch {
+        $runnerInventory = [pscustomobject]@{
+          Accessible = $false
+          TotalCount = $null
+          Error = $_.Exception.Message
+        }
+      }
+      $runnerInventoryCache[$descriptor.Repository] = $runnerInventory
+    } else {
+      $runnerInventory = $runnerInventoryCache[$descriptor.Repository]
+    }
+
+    $queueThresholdMet = $null -ne $queueAgeMinutes -and $queueAgeMinutes -ge $ThresholdMinutes
+    $repoHasNoRunners = $runnerInventory.Accessible -and $runnerInventory.TotalCount -eq 0
+    if ($isSelfHosted -and -not $runnerAssigned -and [string]$job.status -eq 'queued' -and ($queueThresholdMet -or $repoHasNoRunners)) {
+      $blockers += [pscustomobject]@{
+        Repository = $descriptor.Repository
+        Workflow = [string]$check.Workflow
+        Name = [string]$check.Name
+        RunId = [int64]$descriptor.RunId
+        JobId = [int64]$descriptor.JobId
+        QueueAgeMinutes = $queueAgeMinutes
+        Status = [string]$job.status
+        Labels = $labels
+        RunnerId = $runnerId
+        RunnerName = [string]$job.runner_name
+        RunnerGroupId = if ($null -ne $job.runner_group_id) { [int64]$job.runner_group_id } else { 0 }
+        RunnerGroupName = [string]$job.runner_group_name
+        RepositoryRunnerCount = $runnerInventory.TotalCount
+        RepositoryRunnerInventoryAccessible = $runnerInventory.Accessible
+        ClassificationReason = if ($repoHasNoRunners) { 'repo-runners-zero' } else { 'queue-age-threshold' }
+      }
+    }
+  }
+
+  return @($blockers)
 }
 
 function Get-BucketCount {
@@ -132,8 +306,15 @@ function Get-CheckMap {
 function Write-SummaryLine {
   param(
     [Parameter(Mandatory)][int]$Iteration,
-    [Parameter(Mandatory)][System.Collections.IEnumerable]$Checks
+    [Parameter(Mandatory)][System.Collections.IEnumerable]$Checks,
+    [Parameter()][switch]$NoChecksReported
   )
+
+  if ($NoChecksReported) {
+    $stamp = (Get-Date).ToString('u')
+    Write-Host ("[{0}] poll={1} checks=none-yet" -f $stamp, $Iteration)
+    return
+  }
 
   $items = @($Checks)
   $pass = Get-BucketCount -Checks $items -Bucket 'pass'
@@ -146,6 +327,25 @@ function Write-SummaryLine {
   Write-Host ("[{0}] poll={1} pass={2} fail={3} pending={4} skip={5} cancel={6}" -f $stamp, $Iteration, $pass, $fail, $pending, $skipping, $cancel)
 }
 
+function Write-RunnerAdmissionBlockerSummary {
+  param([Parameter(Mandatory)][System.Collections.IEnumerable]$Blockers)
+
+  $items = @(
+    $Blockers |
+      Sort-Object -Property @(
+        @{ Expression = 'QueueAgeMinutes'; Descending = $true },
+        @{ Expression = 'Workflow'; Descending = $false },
+        @{ Expression = 'Name'; Descending = $false }
+      )
+  )
+  Write-Host ("Blocked: self-hosted runner admission starvation detected on {0} queued check(s)." -f $items.Count)
+  foreach ($item in $items) {
+    $queuedLabel = if ($null -ne $item.QueueAgeMinutes) { '{0}m' -f $item.QueueAgeMinutes } else { 'unknown' }
+    $repoRunnerCount = if ($null -ne $item.RepositoryRunnerCount) { $item.RepositoryRunnerCount } else { 'unknown' }
+    Write-Host ("  - {0}/{1}: queued={2} repo={3} run={4} job={5} labels={6} runner_id={7} repo_runners={8} reason={9}" -f $item.Workflow, $item.Name, $queuedLabel, $item.Repository, $item.RunId, $item.JobId, ($item.Labels -join ','), $item.RunnerId, $repoRunnerCount, $item.ClassificationReason)
+  }
+}
+
 if ($IntervalSeconds -lt 5) {
   throw '-IntervalSeconds must be >= 5 to avoid excessive polling.'
 }
@@ -155,9 +355,13 @@ if ($HeartbeatPolls -lt 1) {
 if ($MaxPolls -lt 0) {
   throw '-MaxPolls must be >= 0.'
 }
+if ($RunnerAdmissionQueueThresholdMinutes -lt 1) {
+  throw '-RunnerAdmissionQueueThresholdMinutes must be >= 1.'
+}
 
 $ghPath = Resolve-GhPath
 $targetPr = Resolve-PullRequestNumber -GhPath $ghPath -ExplicitPullRequest $PullRequest -Repository $Repository
+$pollDelayMilliseconds = Get-PollDelayMilliseconds -IntervalSeconds $IntervalSeconds
 
 Write-Host ("Monitoring PR #{0} with snapshot polling (interval={1}s, requiredOnly={2}, failFast={3})." -f $targetPr, $IntervalSeconds, [bool]$RequiredOnly, [bool]$FailFast)
 Write-Host 'Using gh pr checks --json snapshots (no --watch).'
@@ -167,11 +371,12 @@ $poll = 0
 
 while ($true) {
   $poll += 1
-  $checks = @(Get-PrChecksSnapshot -GhPath $ghPath -PullRequest $targetPr -Repository $Repository -RequiredOnly:$RequiredOnly)
+  $snapshot = Get-PrChecksSnapshot -GhPath $ghPath -PullRequest $targetPr -Repository $Repository -RequiredOnly:$RequiredOnly
+  $checks = @($snapshot.Checks)
   $currentMap = Get-CheckMap -Checks $checks
 
   if ($null -eq $previousMap) {
-    Write-SummaryLine -Iteration $poll -Checks $checks
+    Write-SummaryLine -Iteration $poll -Checks $checks -NoChecksReported:$snapshot.NoChecksReported
   } else {
     $changed = @()
     foreach ($key in $currentMap.Keys) {
@@ -186,7 +391,7 @@ while ($true) {
     }
 
     if ($changed.Count -gt 0) {
-      Write-SummaryLine -Iteration $poll -Checks $checks
+      Write-SummaryLine -Iteration $poll -Checks $checks -NoChecksReported:$snapshot.NoChecksReported
       foreach ($entry in ($changed | Sort-Object Key | Select-Object -First 12)) {
         Write-Host ("  - {0} => {1}" -f $entry.Key, $entry.Bucket)
       }
@@ -194,13 +399,35 @@ while ($true) {
         Write-Host ("  - ... {0} additional change(s)" -f ($changed.Count - 12))
       }
     } elseif (($poll % $HeartbeatPolls) -eq 0) {
-      Write-SummaryLine -Iteration $poll -Checks $checks
-      Write-Host '  (no state changes since last poll)'
+      Write-SummaryLine -Iteration $poll -Checks $checks -NoChecksReported:$snapshot.NoChecksReported
+      if ($snapshot.NoChecksReported) {
+        Write-Host '  (still waiting for initial check publication)'
+      } else {
+        Write-Host '  (no state changes since last poll)'
+      }
     }
+  }
+
+  if ($snapshot.NoChecksReported) {
+    if ($MaxPolls -gt 0 -and $poll -ge $MaxPolls) {
+      Write-Host ("Reached MaxPolls={0} with no checks reported yet." -f $MaxPolls)
+      exit 8
+    }
+
+    $previousMap = $currentMap
+    Start-Sleep -Milliseconds $pollDelayMilliseconds
+    continue
   }
 
   $failCount = Get-BucketCount -Checks $checks -Bucket 'fail'
   $pendingCount = Get-BucketCount -Checks $checks -Bucket 'pending'
+  if ($pendingCount -gt 0) {
+    $runnerAdmissionBlockers = @(Get-QueuedSelfHostedAdmissionBlockers -GhPath $ghPath -Checks $checks -Repository $Repository -ThresholdMinutes $RunnerAdmissionQueueThresholdMinutes)
+    if ($runnerAdmissionBlockers.Count -gt 0) {
+      Write-RunnerAdmissionBlockerSummary -Blockers $runnerAdmissionBlockers
+      exit 9
+    }
+  }
 
   if ($FailFast -and $failCount -gt 0) {
     Write-Host 'Fail-fast: at least one check failed.'
@@ -222,5 +449,5 @@ while ($true) {
   }
 
   $previousMap = $currentMap
-  Start-Sleep -Seconds $IntervalSeconds
+  Start-Sleep -Milliseconds $pollDelayMilliseconds
 }

--- a/tools/priority/__tests__/watch-pr-checks-safe.test.mjs
+++ b/tools/priority/__tests__/watch-pr-checks-safe.test.mjs
@@ -1,0 +1,183 @@
+#!/usr/bin/env node
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+const watcherPath = path.join(repoRoot, 'tools', 'Watch-PRChecksSafe.ps1');
+
+function writeGhShim(tempDir, mode) {
+  const statePath = path.join(tempDir, 'state.json');
+  const shimPath = path.join(tempDir, 'gh-shim.mjs');
+  writeFileSync(statePath, JSON.stringify({ mode, checksCalls: 0, jobApiCalls: 0 }, null, 2), 'utf8');
+  writeFileSync(
+    shimPath,
+    `#!/usr/bin/env node
+import { readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+const statePath = path.join(${JSON.stringify(tempDir)}, 'state.json');
+const state = JSON.parse(readFileSync(statePath, 'utf8'));
+const args = process.argv.slice(2);
+
+function persist() {
+  writeFileSync(statePath, JSON.stringify(state, null, 2));
+}
+
+if (args[0] === 'pr' && args[1] === 'checks') {
+  state.checksCalls += 1;
+  persist();
+
+  if (state.mode === 'transient-no-checks') {
+    if (state.checksCalls === 1) {
+      process.stderr.write("no checks reported on the 'test-branch' branch\\n");
+      process.exit(1);
+    }
+    if (state.checksCalls === 2) {
+      process.stdout.write(JSON.stringify([{ workflow: 'Validate', name: 'lint', bucket: 'pending', state: 'IN_PROGRESS', link: 'https://example.invalid/check/1' }]));
+      process.exit(0);
+    }
+    process.stdout.write(JSON.stringify([{ workflow: 'Validate', name: 'lint', bucket: 'pass', state: 'COMPLETED', link: 'https://example.invalid/check/1' }]));
+    process.exit(0);
+  }
+
+  if (state.mode === 'self-hosted-starvation') {
+    process.stdout.write(JSON.stringify([{
+      workflow: 'Validate',
+      name: 'fixtures',
+      bucket: 'pending',
+      state: 'QUEUED',
+      link: 'https://github.com/example/repo/actions/runs/123/job/777'
+    }]));
+    process.exit(0);
+  }
+
+  process.stderr.write("no checks reported on the 'test-branch' branch\\n");
+  process.exit(1);
+}
+
+if (args[0] === 'api' && args[1] === 'repos/example/repo/actions/jobs/777') {
+  state.jobApiCalls += 1;
+  persist();
+  process.stdout.write(JSON.stringify({
+    id: 777,
+    run_id: 123,
+    workflow_name: 'Validate',
+    status: 'queued',
+    created_at: '2020-01-01T00:00:00Z',
+    started_at: '2020-01-01T00:00:00Z',
+    labels: ['self-hosted', 'Windows', 'X64'],
+    runner_id: 0,
+    runner_name: '',
+    runner_group_id: 0,
+    runner_group_name: ''
+  }));
+  process.exit(0);
+}
+
+process.stderr.write(\`unexpected gh invocation: \${args.join(' ')}\\n\`);
+process.exit(1);
+`,
+    'utf8'
+  );
+
+  const launcherPosix = path.join(tempDir, 'gh');
+  writeFileSync(
+    launcherPosix,
+    `#!/usr/bin/env bash
+"${process.execPath.replace(/\\/g, '/')}" "$(dirname "$0")/gh-shim.mjs" "$@"
+`,
+    'utf8'
+  );
+  chmodSync(launcherPosix, 0o755);
+
+  const launcherWindows = path.join(tempDir, 'gh.cmd');
+  writeFileSync(
+    launcherWindows,
+    `@echo off\r\n"${process.execPath}" "%~dp0gh-shim.mjs" %*\r\n`,
+    'utf8'
+  );
+
+  return statePath;
+}
+
+function runWatcherScenario(mode, maxPolls, extraArgs = []) {
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), 'watch-pr-checks-safe-'));
+  const statePath = writeGhShim(tempDir, mode);
+  const env = {
+    ...process.env,
+    PATH: `${tempDir}${path.delimiter}${process.env.PATH ?? ''}`,
+    WATCH_PR_CHECKS_POLL_DELAY_MILLISECONDS: '1'
+  };
+
+  try {
+    const result = spawnSync(
+      'pwsh',
+      [
+        '-NoLogo',
+        '-NoProfile',
+        '-File',
+        watcherPath,
+        '-PullRequest',
+        '5',
+        '-Repository',
+        'example/repo',
+        '-IntervalSeconds',
+        '5',
+        '-HeartbeatPolls',
+        '1',
+        '-MaxPolls',
+        String(maxPolls),
+        '-RequiredOnly',
+        ...extraArgs
+      ],
+      {
+        cwd: repoRoot,
+        env,
+        encoding: 'utf8'
+      }
+    );
+
+    return {
+      result,
+      state: JSON.parse(readFileSync(statePath, 'utf8'))
+    };
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+test('Watch-PRChecksSafe tolerates a transient no-check state before checks appear', () => {
+  const { result, state } = runWatcherScenario('transient-no-checks', 4);
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.equal(state.checksCalls, 3);
+  assert.match(result.stdout, /checks=none-yet/);
+  assert.match(result.stdout, /All tracked checks completed successfully\./);
+});
+
+test('Watch-PRChecksSafe does not false-pass when no checks ever appear', () => {
+  const { result, state } = runWatcherScenario('persistent-no-checks', 2);
+
+  assert.equal(result.status, 8, result.stderr || result.stdout);
+  assert.equal(state.checksCalls, 2);
+  assert.match(result.stdout, /Reached MaxPolls=2 with no checks reported yet\./);
+});
+
+test('Watch-PRChecksSafe classifies aged queued self-hosted jobs without runner assignment as a blocker', () => {
+  const { result, state } = runWatcherScenario('self-hosted-starvation', 2, [
+    '-RunnerAdmissionQueueThresholdMinutes',
+    '1'
+  ]);
+
+  assert.equal(result.status, 9, result.stderr || result.stdout);
+  assert.equal(state.checksCalls, 1);
+  assert.equal(state.jobApiCalls, 1);
+  assert.match(result.stdout, /self-hosted runner admission starvation detected/);
+  assert.match(result.stdout, /Validate\/fixtures: queued=/);
+});


### PR DESCRIPTION
## Issue Linkage

- Primary issue: #991
- Issue title: Fork self-hosted Windows jobs can remain queued without eligible runner admission
- Issue URL: https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action/issues/991
- Fork mirror issue: #306
- Base branch: `develop`
- Head branch: `issue/personal-991-runner-admission-watcher`
- Template variant: `workflow-policy`
- Auto-close intent: upstream issue closes only from the canonical repo.

# Summary

Classify queued self-hosted runner starvation in the safe PR watcher instead of leaving those lanes in generic pending state.
The watcher now handles transient no-check publication, resolves queued job details through the Actions API, and exits with an explicit blocker when self-hosted jobs have no admitted runner.

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

## Workflow and Policy Impact

- Workflows, jobs, or tasks touched:
  - `tools/Watch-PRChecksSafe.ps1`
- Check names, required-status contracts, or merge-queue behavior affected:
  - Safe PR watch now reports `self-hosted runner admission starvation` as an explicit blocker.
- Permissions, rulesets, labels, reviewer routing, or approval surfaces changed:
  - None.
- Manual dispatch, comment command, or branch-protection effects:
  - None.

## Validation Evidence

- Commands run:
  - `node --test tools/priority/__tests__/watch-pr-checks-safe.test.mjs`
- Contract, schema, or guard tests:
  - `tools/priority/__tests__/watch-pr-checks-safe.test.mjs`
- Live workflow or dry-run evidence:
  - `pwsh -NoLogo -NoProfile -File tools/Watch-PRChecksSafe.ps1 -PullRequest 3 -Repository LabVIEW-Community-CI-CD/compare-vi-cli-action-fork -RequiredOnly -IntervalSeconds 5 -HeartbeatPolls 1 -MaxPolls 1 -RunnerAdmissionQueueThresholdMinutes 20`

## Rollout and Rollback

- Rollout notes:
  - Land watcher classification first; it does not mutate GitHub state.
- Rollback path:
  - Revert this branch.
- Residual risks:
  - The watcher can classify starvation, but it does not provision runners.

## Reviewer Focus

- Please verify:
  - The new blocker exit path only trips on self-hosted queued jobs with no runner assignment.
- Policy assumptions to double-check:
  - Repo-level runner inventory is a safe fallback signal when local wall-clock age is skewed.
- Follow-up issues or guardrails:
  - Canonical blocker remains upstream issue #991.
