### PR TITLE
Runtime daemon: attach ready worker checkouts onto deterministic lane branches (#998)

### DIFF
--- a/docs/knowledgebase/External-Agent-Runtime.md
+++ b/docs/knowledgebase/External-Agent-Runtime.md
@@ -132,7 +132,9 @@ Worker bootstrap sequence:
    `node tools/npm/run-script.mjs priority:develop:sync -- --fork-remote <remote>`
 3. check out or reattach the lane branch
 4. run `pwsh -NoLogo -NoProfile -File tools/priority/bootstrap.ps1`
-5. refresh local handoff and standing-priority artifacts
+5. record the worker as `ready`
+6. attach the ready checkout onto the deterministic lane branch
+7. refresh local handoff and standing-priority artifacts
 
 ## Model Turn Contract
 
@@ -345,6 +347,10 @@ Initial extraction note:
 - the next worker lifecycle seam now bootstraps an allocated checkout into a
   ready lane state and persists `worker-ready.json` plus
   `workers-ready/*.json` metadata for resumed daemon turns
+- the next daemon seam now also attaches that ready checkout onto the lane's
+  deterministic issue branch and persists `worker-branch.json` plus
+  `workers-branch/*.json` metadata so later turns can resume from a real lane
+  workspace instead of a detached checkout
 - the compare-vi repository wrapper remains at
   `tools/priority/runtime-supervisor.mjs`
 - that wrapper now includes the first compare-vi scheduler cut: when no manual

--- a/packages/runtime-harness/README.md
+++ b/packages/runtime-harness/README.md
@@ -55,6 +55,8 @@ Adapters may also provide:
   for the selected lane before the worker step runs
 - `bootstrapWorker(context)` to bootstrap that allocated checkout into a ready
   lane state before later worker cycles reuse it
+- `activateWorker(context)` to attach that ready checkout onto its deterministic
+  lane branch before real repo-native work runs
 
 The observer persists scheduler evidence under the runtime directory:
 
@@ -65,6 +67,8 @@ The observer persists scheduler evidence under the runtime directory:
 - `workers/*.json` for per-lane worker checkout state
 - `worker-ready.json` for the latest worker readiness state
 - `workers-ready/*.json` for per-lane worker readiness history
+- `worker-branch.json` for the latest worker branch-activation state
+- `workers-branch/*.json` for per-lane worker branch attachment history
 
 The compare-vi repository is the first adapter implementation.
 

--- a/packages/runtime-harness/index.mjs
+++ b/packages/runtime-harness/index.mjs
@@ -15,6 +15,7 @@ export const BLOCKER_SCHEMA = 'priority/runtime-blocker@v1';
 export const SCHEDULER_DECISION_SCHEMA = 'priority/runtime-scheduler-decision@v1';
 export const WORKER_CHECKOUT_SCHEMA = 'priority/runtime-worker-checkout@v1';
 export const WORKER_READY_SCHEMA = 'priority/runtime-worker-ready@v1';
+export const WORKER_BRANCH_SCHEMA = 'priority/runtime-worker-branch@v1';
 export const DEFAULT_RUNTIME_DIR = path.join('tests', 'results', '_agent', 'runtime');
 export const DEFAULT_LEASE_SCOPE = 'workspace';
 export const ACTIONS = new Set(['status', 'step', 'stop', 'resume']);
@@ -282,6 +283,7 @@ export function createRuntimeAdapter(adapter = {}) {
     planStep: typeof adapter.planStep === 'function' ? adapter.planStep : null,
     prepareWorker: typeof adapter.prepareWorker === 'function' ? adapter.prepareWorker : null,
     bootstrapWorker: typeof adapter.bootstrapWorker === 'function' ? adapter.bootstrapWorker : null,
+    activateWorker: typeof adapter.activateWorker === 'function' ? adapter.activateWorker : null,
     resolveRepository:
       typeof adapter.resolveRepository === 'function'
         ? adapter.resolveRepository
@@ -321,6 +323,19 @@ function summarizeWorkerReady(workerReadyRecord) {
     preparedAt: workerReadyRecord.preparedAt,
     readyAt: workerReadyRecord.readyAt,
     refreshed: Boolean(workerReadyRecord.refreshed)
+  };
+}
+
+function summarizeWorkerBranch(workerBranchRecord) {
+  if (!workerBranchRecord) return null;
+  return {
+    laneId: workerBranchRecord.laneId,
+    checkoutPath: workerBranchRecord.checkoutPath,
+    branch: workerBranchRecord.branch,
+    status: workerBranchRecord.status,
+    trackingRef: workerBranchRecord.trackingRef,
+    activatedAt: workerBranchRecord.activatedAt,
+    reused: Boolean(workerBranchRecord.reused)
   };
 }
 
@@ -382,6 +397,42 @@ function normalizeWorkerReadyRecord(workerReady, now) {
   };
 }
 
+function normalizeWorkerBranchRecord(workerBranch, now) {
+  if (!workerBranch || typeof workerBranch !== 'object') return null;
+  const laneId = normalizeText(workerBranch.laneId) || null;
+  const checkoutPath = normalizeText(workerBranch.checkoutPath) || null;
+  const branch = normalizeText(workerBranch.branch) || null;
+  const forkRemote = normalizeText(workerBranch.forkRemote) || null;
+  const status = normalizeText(workerBranch.status).toLowerCase() || 'attached';
+  const source = normalizeText(workerBranch.source) || null;
+  const reason = normalizeText(workerBranch.reason) || null;
+  const baseRef = normalizeText(workerBranch.baseRef) || null;
+  const trackingRef = normalizeText(workerBranch.trackingRef) || null;
+  const fetchedRemotes = Array.isArray(workerBranch.fetchedRemotes)
+    ? workerBranch.fetchedRemotes.map((entry) => normalizeText(entry)).filter(Boolean)
+    : [];
+  const readyAt = normalizeText(workerBranch.readyAt) || null;
+  const activatedAt = normalizeText(workerBranch.activatedAt) || toIso(now);
+  const artifacts = workerBranch.artifacts && typeof workerBranch.artifacts === 'object' ? workerBranch.artifacts : {};
+  return {
+    schema: WORKER_BRANCH_SCHEMA,
+    laneId,
+    checkoutPath,
+    branch,
+    forkRemote,
+    status,
+    source,
+    reason,
+    baseRef,
+    trackingRef,
+    fetchedRemotes,
+    readyAt,
+    activatedAt,
+    reused: workerBranch.reused === true || status === 'reused',
+    artifacts
+  };
+}
+
 function buildActiveLaneSummary(laneRecord) {
   if (!laneRecord) return null;
   return {
@@ -394,6 +445,7 @@ function buildActiveLaneSummary(laneRecord) {
     blockerClass: laneRecord.blocker?.blockerClass ?? 'none',
     worker: summarizeWorker(laneRecord.worker),
     workerReady: summarizeWorkerReady(laneRecord.workerReady),
+    workerBranch: summarizeWorkerBranch(laneRecord.workerBranch),
     updatedAt: laneRecord.updatedAt
   };
 }
@@ -481,6 +533,7 @@ function buildLaneRecord(options, now) {
   const blockerClass = options.blockerClass || 'none';
   const worker = normalizeWorkerRecord(options.worker, now);
   const workerReady = normalizeWorkerReadyRecord(options.workerReady, now);
+  const workerBranch = normalizeWorkerBranchRecord(options.workerBranch, now);
   return {
     schema: LANE_SCHEMA,
     laneId,
@@ -500,6 +553,7 @@ function buildLaneRecord(options, now) {
           },
     worker,
     workerReady,
+    workerBranch,
     createdAt: toIso(now),
     updatedAt: toIso(now)
   };
@@ -732,6 +786,8 @@ async function runStepAction(context) {
         workerArtifactPath: laneRecord?.worker?.artifacts?.lanePath ?? null,
         workerReadyPath: laneRecord?.workerReady?.artifacts?.latestPath ?? null,
         workerReadyArtifactPath: laneRecord?.workerReady?.artifacts?.lanePath ?? null,
+        workerBranchPath: laneRecord?.workerBranch?.artifacts?.latestPath ?? null,
+        workerBranchArtifactPath: laneRecord?.workerBranch?.artifacts?.lanePath ?? null,
         statePath: runtimePaths.statePath,
         eventsPath: runtimePaths.eventsPath
       }
@@ -756,6 +812,7 @@ async function runStepAction(context) {
     report.turnPath = turnPath;
     report.worker = summarizeWorker(laneRecord?.worker);
     report.workerReady = summarizeWorkerReady(laneRecord?.workerReady);
+    report.workerBranch = summarizeWorkerBranch(laneRecord?.workerBranch);
     report.state = state;
   } finally {
     const leaseId = report.lease?.acquire?.leaseId ?? null;

--- a/packages/runtime-harness/observer.mjs
+++ b/packages/runtime-harness/observer.mjs
@@ -8,6 +8,7 @@ import {
   createRuntimeAdapter,
   DEFAULT_RUNTIME_DIR,
   SCHEDULER_DECISION_SCHEMA,
+  WORKER_BRANCH_SCHEMA,
   WORKER_CHECKOUT_SCHEMA,
   WORKER_READY_SCHEMA
 } from './index.mjs';
@@ -125,7 +126,9 @@ function resolveWorkerPaths(options, repoRoot) {
     latestPath: path.join(runtimeDir, 'worker-checkout.json'),
     workersDir: path.join(runtimeDir, 'workers'),
     readyLatestPath: path.join(runtimeDir, 'worker-ready.json'),
-    readyDir: path.join(runtimeDir, 'workers-ready')
+    readyDir: path.join(runtimeDir, 'workers-ready'),
+    branchLatestPath: path.join(runtimeDir, 'worker-branch.json'),
+    branchDir: path.join(runtimeDir, 'workers-branch')
   };
 }
 
@@ -262,6 +265,50 @@ async function writeWorkerReady(workerPaths, workerReady) {
   await writeJson(lanePath, workerReady);
   return {
     latestPath: workerPaths.readyLatestPath,
+    lanePath
+  };
+}
+
+function normalizeWorkerBranch(rawWorkerBranch, decision, workerReady, now, adapter, repository) {
+  if (!rawWorkerBranch || typeof rawWorkerBranch !== 'object') return null;
+  const laneId =
+    normalizeText(rawWorkerBranch.laneId) || workerReady?.laneId || decision?.activeLane?.laneId || null;
+  const checkoutPath = normalizeText(rawWorkerBranch.checkoutPath) || workerReady?.checkoutPath || null;
+  const branch = normalizeText(rawWorkerBranch.branch) || decision?.activeLane?.branch || null;
+  const status = normalizeText(rawWorkerBranch.status).toLowerCase() || 'attached';
+  const fetchedRemotes = Array.isArray(rawWorkerBranch.fetchedRemotes)
+    ? rawWorkerBranch.fetchedRemotes.map((entry) => String(entry))
+    : [];
+  return {
+    schema: WORKER_BRANCH_SCHEMA,
+    generatedAt: toIso(now),
+    runtimeAdapter: adapter.name,
+    repository,
+    laneId,
+    issue: decision?.activeLane?.issue ?? null,
+    epic: decision?.activeLane?.epic ?? null,
+    forkRemote: normalizeText(rawWorkerBranch.forkRemote) || decision?.activeLane?.forkRemote || null,
+    branch,
+    checkoutPath,
+    status,
+    source: normalizeText(rawWorkerBranch.source) || adapter.name,
+    reason: normalizeText(rawWorkerBranch.reason) || null,
+    baseRef: normalizeText(rawWorkerBranch.baseRef) || null,
+    trackingRef: normalizeText(rawWorkerBranch.trackingRef) || null,
+    fetchedRemotes,
+    readyAt: normalizeText(rawWorkerBranch.readyAt) || workerReady?.readyAt || null,
+    activatedAt: normalizeText(rawWorkerBranch.activatedAt) || toIso(now),
+    reused: rawWorkerBranch.reused === true || status === 'reused'
+  };
+}
+
+async function writeWorkerBranch(workerPaths, workerBranch) {
+  await mkdir(workerPaths.branchDir, { recursive: true });
+  await writeJson(workerPaths.branchLatestPath, workerBranch);
+  const lanePath = path.join(workerPaths.branchDir, `${sanitizeSegment(workerBranch.laneId || 'runtime')}.json`);
+  await writeJson(lanePath, workerBranch);
+  return {
+    latestPath: workerPaths.branchLatestPath,
     lanePath
   };
 }
@@ -536,7 +583,9 @@ export async function runRuntimeObserverLoop(options = {}, deps = {}) {
       latestPath: workerPaths.latestPath,
       workersDir: workerPaths.workersDir,
       readyLatestPath: workerPaths.readyLatestPath,
-      readyDir: workerPaths.readyDir
+      readyDir: workerPaths.readyDir,
+      branchLatestPath: workerPaths.branchLatestPath,
+      branchDir: workerPaths.branchDir
     },
     status: 'pass',
     outcome: 'idle',
@@ -603,6 +652,8 @@ export async function runRuntimeObserverLoop(options = {}, deps = {}) {
           workerLanePath: null,
           workerReadyPath: null,
           workerReadyLanePath: null,
+          workerBranchPath: null,
+          workerBranchLanePath: null,
           schedulerDecisionPath: schedulerArtifacts.latestPath,
           schedulerDecisionHistoryPath: schedulerArtifacts.historyPath
         }
@@ -619,6 +670,11 @@ export async function runRuntimeObserverLoop(options = {}, deps = {}) {
     };
     let workerReady = null;
     let workerReadyArtifacts = {
+      latestPath: null,
+      lanePath: null
+    };
+    let workerBranch = null;
+    let workerBranchArtifacts = {
       latestPath: null,
       lanePath: null
     };
@@ -686,6 +742,8 @@ export async function runRuntimeObserverLoop(options = {}, deps = {}) {
             workerLanePath: workerArtifacts.lanePath,
             workerReadyPath: null,
             workerReadyLanePath: null,
+            workerBranchPath: null,
+            workerBranchLanePath: null,
             schedulerDecisionPath: schedulerArtifacts.latestPath,
             schedulerDecisionHistoryPath: schedulerArtifacts.historyPath
           }
@@ -805,6 +863,8 @@ export async function runRuntimeObserverLoop(options = {}, deps = {}) {
             workerLanePath: workerArtifacts.lanePath,
             workerReadyPath: workerReadyArtifacts.latestPath,
             workerReadyLanePath: workerReadyArtifacts.lanePath,
+            workerBranchPath: null,
+            workerBranchLanePath: null,
             schedulerDecisionPath: schedulerArtifacts.latestPath,
             schedulerDecisionHistoryPath: schedulerArtifacts.historyPath
           }
@@ -823,11 +883,102 @@ export async function runRuntimeObserverLoop(options = {}, deps = {}) {
       }
     }
 
+    const activateWorkerFn =
+      typeof deps.activateWorkerFn === 'function'
+        ? deps.activateWorkerFn
+        : (typeof adapter.activateWorker === 'function' ? (context) => adapter.activateWorker(context) : null);
+    if (activateWorkerFn && workerReady?.status && workerReady.status !== 'blocked') {
+      try {
+        workerBranch = normalizeWorkerBranch(
+          await activateWorkerFn({
+            options,
+            env: process.env,
+            repoRoot,
+            deps,
+            adapter,
+            repository: report.repository,
+            cycle,
+            heartbeatPath,
+            schedulerPaths,
+            workerPaths,
+            schedulerDecision,
+            preparedWorker,
+            workerReady,
+            previousDecision,
+            previousStep
+          }),
+          schedulerDecision,
+          workerReady,
+          stepNow,
+          adapter,
+          report.repository
+        );
+      } catch (error) {
+        report.status = 'blocked';
+        report.outcome = 'worker-activate-failed';
+        report.message = error?.message || String(error);
+        return { exitCode: 15, report };
+      }
+      if (workerBranch) {
+        workerBranchArtifacts = await writeWorkerBranch(workerPaths, workerBranch);
+        workerBranch.artifacts = {
+          latestPath: workerBranchArtifacts.latestPath,
+          lanePath: workerBranchArtifacts.lanePath
+        };
+      }
+      if (workerBranch?.status === 'blocked') {
+        const heartbeatNow = nowFactory();
+        await writeJson(heartbeatPath, {
+          schema: OBSERVER_HEARTBEAT_SCHEMA,
+          generatedAt: toIso(heartbeatNow),
+          runtimeAdapter: adapter.name,
+          repository: report.repository,
+          platform,
+          cyclesCompleted: report.cyclesCompleted,
+          outcome: 'worker-branch-blocked',
+          stopRequested: false,
+          activeLane: {
+            ...(schedulerDecision.activeLane ?? {}),
+            worker: preparedWorker,
+            workerReady,
+            workerBranch
+          },
+          schedulerDecision: report.lastDecision,
+          artifacts: {
+            statePath: null,
+            eventsPath: null,
+            stopRequestPath: null,
+            workerCheckoutPath: workerArtifacts.latestPath,
+            workerLanePath: workerArtifacts.lanePath,
+            workerReadyPath: workerReadyArtifacts.latestPath,
+            workerReadyLanePath: workerReadyArtifacts.lanePath,
+            workerBranchPath: workerBranchArtifacts.latestPath,
+            workerBranchLanePath: workerBranchArtifacts.lanePath,
+            schedulerDecisionPath: schedulerArtifacts.latestPath,
+            schedulerDecisionHistoryPath: schedulerArtifacts.historyPath
+          }
+        });
+        report.status = 'blocked';
+        report.outcome = 'worker-branch-blocked';
+        report.lastStep = {
+          exitCode: 15,
+          outcome: 'worker-branch-blocked',
+          statePath: null,
+          turnPath: null,
+          worker: preparedWorker,
+          workerReady,
+          workerBranch
+        };
+        return { exitCode: 15, report };
+      }
+    }
+
     const stepResult = await runRuntimeWorkerStep(
       {
         ...buildWorkerStepOptions(options, schedulerDecision),
         worker: preparedWorker,
-        workerReady
+        workerReady,
+        workerBranch
       },
       {
         ...deps,
@@ -844,7 +995,8 @@ export async function runRuntimeObserverLoop(options = {}, deps = {}) {
       statePath: stepResult.report.runtime?.statePath ?? null,
       turnPath: stepResult.report.turnPath ?? null,
       worker: stepResult.report.worker ?? preparedWorker,
-      workerReady: stepResult.report.workerReady ?? workerReady
+      workerReady: stepResult.report.workerReady ?? workerReady,
+      workerBranch: stepResult.report.workerBranch ?? workerBranch
     };
     previousDecision = schedulerDecision;
     previousStep = report.lastStep;
@@ -869,6 +1021,8 @@ export async function runRuntimeObserverLoop(options = {}, deps = {}) {
         workerLanePath: workerArtifacts.lanePath,
         workerReadyPath: workerReadyArtifacts.latestPath,
         workerReadyLanePath: workerReadyArtifacts.lanePath,
+        workerBranchPath: workerBranchArtifacts.latestPath,
+        workerBranchLanePath: workerBranchArtifacts.lanePath,
         schedulerDecisionPath: schedulerArtifacts.latestPath,
         schedulerDecisionHistoryPath: schedulerArtifacts.historyPath
       }

--- a/packages/runtime-harness/test/runtime-harness.test.mjs
+++ b/packages/runtime-harness/test/runtime-harness.test.mjs
@@ -98,6 +98,14 @@ test('runRuntimeSupervisor executes through an injected adapter', async () => {
         status: 'ready',
         bootstrapCommand: ['pwsh', '-NoLogo', '-NoProfile', '-File', 'tools/priority/bootstrap.ps1']
       },
+      workerBranch: {
+        laneId: 'origin-977',
+        checkoutPath: path.join(repoRoot, 'workers', 'origin-977'),
+        branch: 'issue/origin-977-fork-policy-portability',
+        forkRemote: 'origin',
+        status: 'attached',
+        trackingRef: 'origin/issue/origin-977-fork-policy-portability'
+      },
       blockerClass: 'ci',
       reason: 'hosted checks are red'
     },
@@ -115,6 +123,8 @@ test('runRuntimeSupervisor executes through an injected adapter', async () => {
   assert.equal(result.report.worker.status, 'created');
   assert.equal(state.activeLane.workerReady.status, 'ready');
   assert.equal(result.report.workerReady.status, 'ready');
+  assert.equal(state.activeLane.workerBranch.status, 'attached');
+  assert.equal(result.report.workerBranch.branch, 'issue/origin-977-fork-policy-portability');
   assert.deepEqual(
     adapterCalls.map((entry) => entry.type),
     ['acquire', 'release']

--- a/packages/runtime-harness/test/runtime-observer.test.mjs
+++ b/packages/runtime-harness/test/runtime-observer.test.mjs
@@ -62,6 +62,16 @@ function makeAdapter(repoRoot, calls, options = {}) {
         bootstrapCommand: ['pwsh', '-NoLogo', '-NoProfile', '-File', 'tools/priority/bootstrap.ps1']
       };
     },
+    activateWorker: async ({ workerReady, schedulerDecision }) => ({
+      laneId: schedulerDecision.activeLane?.laneId,
+      checkoutPath: workerReady.checkoutPath,
+      branch: schedulerDecision.activeLane?.branch,
+      forkRemote: schedulerDecision.activeLane?.forkRemote,
+      status: 'attached',
+      source: 'test-adapter',
+      trackingRef: `${schedulerDecision.activeLane?.forkRemote}/${schedulerDecision.activeLane?.branch}`,
+      fetchedRemotes: ['upstream', 'origin']
+    }),
     acquireLease: async (leaseOptions) => {
       calls.push({ type: 'acquire', leaseOptions });
       return {
@@ -203,6 +213,8 @@ test('runRuntimeObserverLoop writes heartbeat and state across bounded linux cyc
   const workerHistory = await readdir(path.join(runtimeDir, 'workers'));
   const workerReady = await readJson(path.join(runtimeDir, 'worker-ready.json'));
   const workerReadyHistory = await readdir(path.join(runtimeDir, 'workers-ready'));
+  const workerBranch = await readJson(path.join(runtimeDir, 'worker-branch.json'));
+  const workerBranchHistory = await readdir(path.join(runtimeDir, 'workers-branch'));
   const state = await readJson(path.join(runtimeDir, 'runtime-state.json'));
 
   assert.equal(result.exitCode, 0);
@@ -226,15 +238,22 @@ test('runRuntimeObserverLoop writes heartbeat and state across bounded linux cyc
   assert.equal(workerReady.schema, 'priority/runtime-worker-ready@v1');
   assert.equal(workerReady.status, 'ready');
   assert.equal(workerReadyHistory.length, 1);
+  assert.equal(workerBranch.schema, 'priority/runtime-worker-branch@v1');
+  assert.equal(workerBranch.status, 'attached');
+  assert.equal(workerBranch.branch, 'issue/origin-977-fork-policy-portability');
+  assert.equal(workerBranchHistory.length, 1);
   assert.equal(heartbeat.activeLane.issue, 977);
   assert.equal(heartbeat.activeLane.worker.status, 'created');
   assert.equal(heartbeat.activeLane.workerReady.status, 'ready');
+  assert.equal(heartbeat.activeLane.workerBranch.status, 'attached');
   assert.equal(state.lifecycle.cycle, 2);
   assert.equal(state.activeLane.issue, 977);
   assert.equal(state.activeLane.worker.status, 'created');
   assert.equal(state.activeLane.workerReady.status, 'ready');
+  assert.equal(state.activeLane.workerBranch.status, 'attached');
   assert.equal(result.report.lastStep.worker.status, 'created');
   assert.equal(result.report.lastStep.workerReady.status, 'ready');
+  assert.equal(result.report.lastStep.workerBranch.status, 'attached');
   assert.equal(sleepCalls, 1);
   assert.deepEqual(
     calls.map((entry) => entry.type),

--- a/tools/priority/__tests__/runtime-daemon.test.mjs
+++ b/tools/priority/__tests__/runtime-daemon.test.mjs
@@ -49,14 +49,37 @@ function makeLeaseDeps() {
 
 function makeExecDeps() {
   const calls = [];
+  const currentBranches = new Map();
   return {
     calls,
     execFileFn: async (command, args, options) => {
       calls.push({ command, args, options });
       if (command === 'git') {
-        const checkoutPath = args[3];
-        await mkdir(checkoutPath, { recursive: true });
-        await writeFile(path.join(checkoutPath, '.git'), 'gitdir: mocked\n', 'utf8');
+        if (args[0] === 'worktree' && args[1] === 'add') {
+          const checkoutPath = args[3];
+          await mkdir(checkoutPath, { recursive: true });
+          await writeFile(path.join(checkoutPath, '.git'), 'gitdir: mocked\n', 'utf8');
+          return { stdout: '', stderr: '' };
+        }
+        if (args[0] === 'remote') {
+          return { stdout: 'upstream\norigin\npersonal\n', stderr: '' };
+        }
+        if (args[0] === 'fetch') {
+          return { stdout: '', stderr: '' };
+        }
+        if (args[0] === 'branch' && args[1] === '--show-current') {
+          return { stdout: currentBranches.get(options.cwd) ?? '', stderr: '' };
+        }
+        if (args[0] === 'show-ref') {
+          return { stdout: '', stderr: '' };
+        }
+        if (args[0] === 'checkout' && args[1] === '-B') {
+          currentBranches.set(options.cwd, args[2]);
+          return { stdout: '', stderr: '' };
+        }
+        if (args[0] === 'branch' && args[1] === '--set-upstream-to') {
+          return { stdout: '', stderr: '' };
+        }
       }
       return { stdout: '', stderr: '' };
     }
@@ -76,6 +99,7 @@ test('runtime-daemon wrapper defaults to the comparevi adapter', async () => {
       lane: 'origin-977',
       issue: 977,
       forkRemote: 'origin',
+      branch: 'issue/origin-977-fork-policy-portability',
       owner: 'agent@example',
       pollIntervalSeconds: 0,
       maxCycles: 1
@@ -101,7 +125,10 @@ test('runtime-daemon wrapper defaults to the comparevi adapter', async () => {
   assert.equal(heartbeat.cyclesCompleted, 1);
   assert.equal(heartbeat.activeLane.worker.status, 'created');
   assert.equal(heartbeat.activeLane.workerReady.status, 'ready');
-  assert.equal(execDeps.calls.length, 2);
+  assert.equal(heartbeat.activeLane.workerBranch.status, 'attached');
+  assert.equal(heartbeat.activeLane.workerBranch.branch, 'issue/origin-977-fork-policy-portability');
+  assert.ok(execDeps.calls.some((entry) => entry.command === 'pwsh'));
+  assert.ok(execDeps.calls.some((entry) => entry.command === 'git' && entry.args[0] === 'checkout'));
   assert.deepEqual(
     deps.calls.map((entry) => entry.type),
     ['acquire', 'release']
@@ -119,6 +146,7 @@ test('runtime-daemon wrapper schedules from the comparevi standing-priority cach
     `${JSON.stringify(
       {
         number: 2,
+        title: 'Human go/no-go workflow',
         repository: 'LabVIEW-Community-CI-CD/compare-vi-cli-action-fork',
         url: 'https://github.com/LabVIEW-Community-CI-CD/compare-vi-cli-action-fork/issues/2',
         state: 'open',
@@ -161,12 +189,15 @@ test('runtime-daemon wrapper schedules from the comparevi standing-priority cach
   assert.equal(result.report.outcome, 'max-cycles-reached');
   assert.equal(result.report.lastDecision.source, 'comparevi-standing-priority-cache');
   assert.equal(result.report.lastDecision.activeLane.issue, 982);
+  assert.equal(result.report.lastDecision.activeLane.branch, 'issue/origin-982-human-go-no-go-workflow');
   assert.equal(heartbeat.schedulerDecision.source, 'comparevi-standing-priority-cache');
   assert.equal(heartbeat.activeLane.issue, 982);
   assert.equal(heartbeat.activeLane.forkRemote, 'origin');
+  assert.equal(heartbeat.activeLane.branch, 'issue/origin-982-human-go-no-go-workflow');
   assert.equal(heartbeat.activeLane.worker.status, 'created');
   assert.equal(heartbeat.activeLane.workerReady.status, 'ready');
-  assert.equal(execDeps.calls.length, 2);
+  assert.equal(heartbeat.activeLane.workerBranch.status, 'attached');
+  assert.ok(execDeps.calls.some((entry) => entry.command === 'git' && entry.args[0] === 'checkout'));
   assert.deepEqual(
     deps.calls.map((entry) => entry.type),
     ['acquire', 'release']
@@ -283,4 +314,83 @@ test('comparevi worker bootstrap includes stderr in blocked bootstrap diagnostic
   assert.equal(blocked.bootstrapExitCode, 7);
   assert.match(blocked.reason, /bootstrap failed/);
   assert.match(blocked.reason, /bootstrap stderr/);
+});
+
+test('comparevi worker activation attaches a ready checkout onto the deterministic lane branch', async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'runtime-daemon-worker-branch-'));
+  const { checkoutPath } = compareviRuntimeTest.resolveCompareviWorkerCheckoutPath({
+    repoRoot,
+    repository: 'example/repo',
+    laneId: 'personal-998'
+  });
+  await mkdir(checkoutPath, { recursive: true });
+  await writeFile(path.join(checkoutPath, '.git'), 'gitdir: mocked\n', 'utf8');
+
+  const calls = [];
+  const attached = await compareviRuntimeTest.activateCompareviWorkerLane({
+    schedulerDecision: {
+      activeLane: {
+        laneId: 'personal-998',
+        forkRemote: 'personal',
+        branch: 'issue/personal-998-runtime-worker-branch-activation'
+      },
+      stepOptions: {
+        branch: 'issue/personal-998-runtime-worker-branch-activation'
+      }
+    },
+    preparedWorker: {
+      checkoutPath
+    },
+    workerReady: {
+      readyAt: '2026-03-10T18:30:00.000Z',
+      checkoutPath
+    },
+    deps: {
+      execFileFn: async (command, args, options) => {
+        calls.push({ command, args, options });
+        if (command !== 'git') {
+          return { stdout: '', stderr: '' };
+        }
+        if (args[0] === 'remote') {
+          return { stdout: 'upstream\norigin\npersonal\n', stderr: '' };
+        }
+        if (args[0] === 'branch' && args[1] === '--show-current') {
+          return { stdout: '', stderr: '' };
+        }
+        return { stdout: '', stderr: '' };
+      }
+    }
+  });
+
+  assert.equal(attached.status, 'attached');
+  assert.equal(attached.branch, 'issue/personal-998-runtime-worker-branch-activation');
+  assert.equal(attached.trackingRef, 'personal/issue/personal-998-runtime-worker-branch-activation');
+  assert.deepEqual(attached.fetchedRemotes, ['upstream', 'origin', 'personal']);
+  assert.ok(calls.some((entry) => entry.command === 'git' && entry.args[0] === 'checkout'));
+});
+
+test('comparevi worker activation blocks when the scheduler does not resolve a branch name', async () => {
+  const blocked = await compareviRuntimeTest.activateCompareviWorkerLane({
+    schedulerDecision: {
+      activeLane: {
+        laneId: 'origin-998',
+        forkRemote: 'origin'
+      },
+      stepOptions: {}
+    },
+    preparedWorker: {
+      checkoutPath: 'D:/tmp/runtime-worker'
+    },
+    workerReady: {
+      checkoutPath: 'D:/tmp/runtime-worker'
+    },
+    deps: {
+      execFileFn: async () => {
+        throw new Error('git should not run without a branch name');
+      }
+    }
+  });
+
+  assert.equal(blocked.status, 'blocked');
+  assert.match(blocked.reason, /branch name/i);
 });

--- a/tools/priority/__tests__/runtime-supervisor.test.mjs
+++ b/tools/priority/__tests__/runtime-supervisor.test.mjs
@@ -5,7 +5,7 @@ import assert from 'node:assert/strict';
 import { mkdtemp, readFile, stat } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import { parseArgs, runRuntimeSupervisor } from '../runtime-supervisor.mjs';
+import { compareviRuntimeTest, parseArgs, runRuntimeSupervisor } from '../runtime-supervisor.mjs';
 
 async function readJson(filePath) {
   return JSON.parse(await readFile(filePath, 'utf8'));
@@ -103,6 +103,16 @@ test('parseArgs accepts runtime action, lane metadata, and lease options', () =>
   assert.equal(parsed.leaseScope, 'workspace');
   assert.equal(parsed.leaseRoot, '.tmp/leases');
   assert.equal(parsed.owner, 'agent@example');
+});
+
+test('comparevi branch resolver matches the repo issue branch naming contract', () => {
+  const branch = compareviRuntimeTest.resolveCompareviIssueBranchName({
+    issueNumber: 998,
+    title: 'Attach ready worker checkouts onto deterministic lane branches',
+    forkRemote: 'personal'
+  });
+
+  assert.equal(branch, 'issue/personal-998-attach-ready-worker-checkouts-onto-deterministic-lane-branches');
 });
 
 test('runRuntimeSupervisor step writes runtime state, lane, turn, event, and blocker artifacts', async () => {

--- a/tools/priority/runtime-supervisor.mjs
+++ b/tools/priority/runtime-supervisor.mjs
@@ -28,6 +28,7 @@ import { acquireWriterLease, defaultOwner, releaseWriterLease } from './agent-wr
 import { getRepoRoot } from './lib/branch-utils.mjs';
 import {
   bootstrapCompareviWorkerCheckout,
+  activateCompareviWorkerLane,
   prepareCompareviWorkerCheckout,
   resolveCompareviWorkerCheckoutPath
 } from './runtime-worker-checkout.mjs';
@@ -58,6 +59,24 @@ const PRIORITY_ISSUE_DIR = path.join('tests', 'results', '_agent', 'issue');
 function normalizeText(value) {
   if (value == null) return '';
   return String(value).trim();
+}
+
+function resolveCompareviIssueSlug(title) {
+  const normalized = normalizeText(title)
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^A-Za-z0-9]+/g, ' ')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .toLowerCase()
+    .trim();
+  return normalized.replace(/^-+|-+$/g, '') || 'work';
+}
+
+function resolveCompareviIssueBranchName({ issueNumber, title, forkRemote, branchPrefix = 'issue' }) {
+  const slug = resolveCompareviIssueSlug(title);
+  const remotePrefix = normalizeText(forkRemote) ? `${normalizeText(forkRemote).toLowerCase()}-` : '';
+  return `${branchPrefix}/${remotePrefix}${issueNumber}-${slug}`;
 }
 
 async function readJsonIfPresent(filePath) {
@@ -126,6 +145,11 @@ function buildSchedulerDecisionFromSnapshot({
 
   const forkRemote = resolveForkRemoteForRepository(standingRepository, upstreamRepository);
   const laneId = [forkRemote, selectedIssue].filter(Boolean).join('-') || `issue-${selectedIssue}`;
+  const branch = resolveCompareviIssueBranchName({
+    issueNumber: selectedIssue,
+    title: snapshot.title,
+    forkRemote
+  });
   const reason =
     Number.isInteger(snapshot.mirrorOf?.number) && snapshot.mirrorOf.number !== snapshot.number
       ? `standing mirror #${snapshot.number} routes to upstream issue #${snapshot.mirrorOf.number}`
@@ -138,7 +162,8 @@ function buildSchedulerDecisionFromSnapshot({
     stepOptions: {
       lane: laneId,
       issue: selectedIssue,
-      forkRemote
+      forkRemote,
+      branch
     },
     artifacts: artifactPaths
   };
@@ -204,14 +229,17 @@ export const compareviRuntimeAdapter = createRuntimeAdapter({
   releaseLease: (leaseOptions) => releaseWriterLease(leaseOptions),
   planStep: (context) => planCompareviRuntimeStep(context),
   prepareWorker: (context) => prepareCompareviWorkerCheckout(context),
-  bootstrapWorker: (context) => bootstrapCompareviWorkerCheckout(context)
+  bootstrapWorker: (context) => bootstrapCompareviWorkerCheckout(context),
+  activateWorker: (context) => activateCompareviWorkerLane(context)
 });
 
 export const compareviRuntimeTest = {
+  activateCompareviWorkerLane,
   buildSchedulerDecisionFromSnapshot,
   bootstrapCompareviWorkerCheckout,
   planCompareviRuntimeStep,
   prepareCompareviWorkerCheckout,
+  resolveCompareviIssueBranchName,
   resolveCompareviWorkerCheckoutPath,
   resolveForkRemoteForRepository
 };

--- a/tools/priority/runtime-worker-checkout.mjs
+++ b/tools/priority/runtime-worker-checkout.mjs
@@ -8,6 +8,7 @@ import { promisify } from 'node:util';
 const execFileAsync = promisify(execFile);
 const DEFAULT_WORKER_REF = 'upstream/develop';
 const BOOTSTRAP_RELATIVE_PATH = path.join('tools', 'priority', 'bootstrap.ps1');
+const ATTACHABLE_REMOTES = ['upstream', 'origin', 'personal'];
 
 function normalizeText(value) {
   if (value == null) return '';
@@ -43,6 +44,32 @@ function formatBootstrapFailure(error) {
     return message;
   }
   return `${message}\n\nstderr:\n${stderr}`;
+}
+
+function formatExecError(error) {
+  return normalizeText(error?.stderr) || normalizeText(error?.message) || String(error);
+}
+
+async function readGitStdout(execFileFn, args, options = {}) {
+  const result = await execFileFn('git', args, options);
+  return normalizeText(result?.stdout);
+}
+
+async function tryReadGitStdout(execFileFn, args, options = {}) {
+  try {
+    return await readGitStdout(execFileFn, args, options);
+  } catch {
+    return '';
+  }
+}
+
+async function gitRefExists(execFileFn, cwd, ref) {
+  try {
+    await execFileFn('git', ['show-ref', '--verify', '--quiet', ref], { cwd });
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 export function resolveCompareviWorkerCheckoutRoot({ repoRoot, repository }) {
@@ -158,7 +185,92 @@ export async function bootstrapCompareviWorkerCheckout({
   };
 }
 
+export async function activateCompareviWorkerLane({
+  schedulerDecision,
+  preparedWorker,
+  workerReady,
+  deps = {}
+}) {
+  const activeLane = schedulerDecision?.activeLane ?? null;
+  const laneId = normalizeText(activeLane?.laneId);
+  const checkoutPath = normalizeText(workerReady?.checkoutPath) || normalizeText(preparedWorker?.checkoutPath);
+  const branch = normalizeText(schedulerDecision?.stepOptions?.branch) || normalizeText(activeLane?.branch);
+  if (!laneId || !checkoutPath) {
+    return null;
+  }
+
+  if (!branch) {
+    return {
+      laneId,
+      checkoutPath,
+      branch: null,
+      forkRemote: normalizeText(activeLane?.forkRemote) || null,
+      status: 'blocked',
+      source: 'comparevi-branch',
+      reason: 'selected lane does not resolve a deterministic branch name',
+      baseRef: DEFAULT_WORKER_REF,
+      trackingRef: null,
+      fetchedRemotes: []
+    };
+  }
+
+  const execFileFn = deps.execFileFn ?? execFileAsync;
+  const forkRemote = normalizeText(activeLane?.forkRemote) || 'upstream';
+  const availableRemotes = (await tryReadGitStdout(execFileFn, ['remote'], { cwd: checkoutPath }))
+    .split(/\r?\n/)
+    .map((entry) => normalizeText(entry))
+    .filter(Boolean);
+  const fetchedRemotes = [];
+  try {
+    for (const remote of ATTACHABLE_REMOTES) {
+      if (!availableRemotes.includes(remote)) {
+        continue;
+      }
+      await execFileFn('git', ['fetch', remote, '--prune'], { cwd: checkoutPath });
+      fetchedRemotes.push(remote);
+    }
+    const currentBranch = await tryReadGitStdout(execFileFn, ['branch', '--show-current'], { cwd: checkoutPath });
+    const trackingRef = `${forkRemote}/${branch}`;
+    const trackingExists = await gitRefExists(execFileFn, checkoutPath, `refs/remotes/${trackingRef}`);
+    if (currentBranch !== branch) {
+      const checkoutTarget = trackingExists ? trackingRef : DEFAULT_WORKER_REF;
+      await execFileFn('git', ['checkout', '-B', branch, checkoutTarget], { cwd: checkoutPath });
+      if (trackingExists) {
+        await execFileFn('git', ['branch', '--set-upstream-to', trackingRef, branch], { cwd: checkoutPath });
+      }
+    }
+
+    return {
+      laneId,
+      checkoutPath,
+      branch,
+      forkRemote,
+      status: currentBranch === branch ? 'reused' : trackingExists ? 'attached' : 'created',
+      source: 'comparevi-branch',
+      reason: null,
+      baseRef: DEFAULT_WORKER_REF,
+      trackingRef: trackingExists ? trackingRef : null,
+      fetchedRemotes,
+      readyAt: workerReady?.readyAt ?? null
+    };
+  } catch (error) {
+    return {
+      laneId,
+      checkoutPath,
+      branch,
+      forkRemote,
+      status: 'blocked',
+      source: 'comparevi-branch',
+      reason: formatExecError(error),
+      baseRef: DEFAULT_WORKER_REF,
+      trackingRef: `${forkRemote}/${branch}`,
+      fetchedRemotes
+    };
+  }
+}
+
 export const __test = {
+  ATTACHABLE_REMOTES,
   BOOTSTRAP_RELATIVE_PATH,
   DEFAULT_WORKER_REF
 };


### PR DESCRIPTION
# Summary

Attach runtime worker checkouts that are already prepared and ready onto deterministic lane branches so the daemon can advance from `worker-ready` into an executable lane without re-allocating the checkout.

Closes #998

## Agent Metadata (required for automation-authored PRs)

- Agent-ID: `agent/copilot-codex-a`
- Operator: `@svelderrainruiz`
- Reviewer-Required: `@svelderrainruiz`
- Emergency-Bypass-Label: `AllowCIBypass`

> Keep this block for automation-authored PRs. Human-authored PRs should switch to
> `.github/PULL_REQUEST_TEMPLATE/human-change.md` or delete this section before requesting review.

## Change Surface

- Primary issue or standing-priority context: `#998` under daemon epic `#958`
- Files, tools, workflows, or policies touched: `packages/runtime-harness/*`, `tools/priority/runtime-supervisor.mjs`, `tools/priority/runtime-worker-checkout.mjs`, runtime daemon tests, runtime docs
- Cross-repo or external-consumer impact: none yet; this is still a repo-local daemon slice
- Required checks, merge-queue behavior, or approval flows affected: hosted fork CI is rerunning on the clean post-#999 daemon head before upstream promotion

## Validation Evidence

- Commands run:
  - `node --test packages/runtime-harness/test/runtime-harness.test.mjs packages/runtime-harness/test/runtime-observer.test.mjs tools/priority/__tests__/runtime-daemon.test.mjs tools/priority/__tests__/runtime-supervisor.test.mjs`
  - `node tools/npm/run-script.mjs runtime-harness:test`
- Key artifacts, logs, or workflow runs:
  - `tests/results/_agent/runtime/`
- Risk-based checks not run:
  - no extra hosted reruns beyond the normal fork PR surface yet

## Risks and Follow-ups

- Residual risks: worker execution and control-plane wakeups still follow in later daemon slices
- Follow-up issues or deferred work: later daemon slices will still need worker execution and control-plane wakeups
- Deployment, approval, or rollback notes: no deployment surface; rollback is a normal PR revert

## Reviewer Focus

- Please verify: ready worker checkouts attach onto deterministic issue branches without breaking the scheduler/observer contract
- Areas where the reasoning is subtle: branch activation has to preserve the reusable checkout path while moving the lane onto its canonical branch name
- Manual spot checks requested: confirm the refreshed fork lane no longer depends on the already-merged #997 branch state
