### PR TITLE
Runtime daemon: consume task packets through a bounded worker-turn receipt seam (#1004)

### DIFF
--- a/docs/knowledgebase/External-Agent-Runtime.md
+++ b/docs/knowledgebase/External-Agent-Runtime.md
@@ -351,6 +351,10 @@ Initial extraction note:
   deterministic issue branch and persists `worker-branch.json` plus
   `workers-branch/*.json` metadata so later turns can resume from a real lane
   workspace instead of a detached checkout
+- the worker/observer seam now also compiles a bounded per-cycle task packet
+  from durable runtime state, persists `task-packet.json` plus
+  `task-packets/*.json`, and leaves an adapter hook for repo-specific
+  objective/helper context before the execution layer is added
 - the compare-vi repository wrapper remains at
   `tools/priority/runtime-supervisor.mjs`
 - that wrapper now includes the first compare-vi scheduler cut: when no manual

--- a/docs/knowledgebase/External-Agent-Runtime.md
+++ b/docs/knowledgebase/External-Agent-Runtime.md
@@ -354,7 +354,10 @@ Initial extraction note:
 - the worker/observer seam now also compiles a bounded per-cycle task packet
   from durable runtime state, persists `task-packet.json` plus
   `task-packets/*.json`, and leaves an adapter hook for repo-specific
-  objective/helper context before the execution layer is added
+  objective/helper context
+- the next execution seam now consumes that packet through an adapter hook,
+  persists `worker-receipt.json` plus `worker-receipts/*.json`, and records the
+  bounded execution outcome before repo-native worker steps continue
 - the compare-vi repository wrapper remains at
   `tools/priority/runtime-supervisor.mjs`
 - that wrapper now includes the first compare-vi scheduler cut: when no manual

--- a/packages/runtime-harness/README.md
+++ b/packages/runtime-harness/README.md
@@ -11,6 +11,7 @@ It is intentionally not the `compare-vi-cli-action` adapter. The core owns:
 - worker step/status/stop/resume execution
 - observer/daemon loop orchestration
 - scheduler decision artifacts and planner handoff
+- bounded worker task-packet artifacts and adapter handoff
 - lease-aware turn execution
 - deterministic event, lane, blocker, and turn artifacts
 
@@ -57,6 +58,8 @@ Adapters may also provide:
   lane state before later worker cycles reuse it
 - `activateWorker(context)` to attach that ready checkout onto its deterministic
   lane branch before real repo-native work runs
+- `buildTaskPacket(context)` to compile the one-turn worker packet that the next
+  execution seam should consume from durable runtime state
 
 The observer persists scheduler evidence under the runtime directory:
 
@@ -69,6 +72,8 @@ The observer persists scheduler evidence under the runtime directory:
 - `workers-ready/*.json` for per-lane worker readiness history
 - `worker-branch.json` for the latest worker branch-activation state
 - `workers-branch/*.json` for per-lane worker branch attachment history
+- `task-packet.json` for the latest bounded worker packet
+- `task-packets/*.json` for per-cycle task-packet history
 
 The compare-vi repository is the first adapter implementation.
 

--- a/packages/runtime-harness/README.md
+++ b/packages/runtime-harness/README.md
@@ -12,6 +12,7 @@ It is intentionally not the `compare-vi-cli-action` adapter. The core owns:
 - observer/daemon loop orchestration
 - scheduler decision artifacts and planner handoff
 - bounded worker task-packet artifacts and adapter handoff
+- bounded worker receipt artifacts and adapter execution handoff
 - lease-aware turn execution
 - deterministic event, lane, blocker, and turn artifacts
 
@@ -60,6 +61,8 @@ Adapters may also provide:
   lane branch before real repo-native work runs
 - `buildTaskPacket(context)` to compile the one-turn worker packet that the next
   execution seam should consume from durable runtime state
+- `executeTaskPacket(context)` to consume that packet and emit a deterministic
+  worker receipt before repo-native worker execution resumes
 
 The observer persists scheduler evidence under the runtime directory:
 
@@ -74,6 +77,9 @@ The observer persists scheduler evidence under the runtime directory:
 - `workers-branch/*.json` for per-lane worker branch attachment history
 - `task-packet.json` for the latest bounded worker packet
 - `task-packets/*.json` for per-cycle task-packet history
+- `worker-receipt.json` for the latest execution receipt emitted from that
+  packet
+- `worker-receipts/*.json` for per-cycle worker receipt history
 
 The compare-vi repository is the first adapter implementation.
 

--- a/packages/runtime-harness/index.mjs
+++ b/packages/runtime-harness/index.mjs
@@ -16,6 +16,7 @@ export const SCHEDULER_DECISION_SCHEMA = 'priority/runtime-scheduler-decision@v1
 export const WORKER_CHECKOUT_SCHEMA = 'priority/runtime-worker-checkout@v1';
 export const WORKER_READY_SCHEMA = 'priority/runtime-worker-ready@v1';
 export const WORKER_BRANCH_SCHEMA = 'priority/runtime-worker-branch@v1';
+export const TASK_PACKET_SCHEMA = 'priority/runtime-worker-task-packet@v1';
 export const DEFAULT_RUNTIME_DIR = path.join('tests', 'results', '_agent', 'runtime');
 export const DEFAULT_LEASE_SCOPE = 'workspace';
 export const ACTIONS = new Set(['status', 'step', 'stop', 'resume']);
@@ -284,6 +285,7 @@ export function createRuntimeAdapter(adapter = {}) {
     prepareWorker: typeof adapter.prepareWorker === 'function' ? adapter.prepareWorker : null,
     bootstrapWorker: typeof adapter.bootstrapWorker === 'function' ? adapter.bootstrapWorker : null,
     activateWorker: typeof adapter.activateWorker === 'function' ? adapter.activateWorker : null,
+    buildTaskPacket: typeof adapter.buildTaskPacket === 'function' ? adapter.buildTaskPacket : null,
     resolveRepository:
       typeof adapter.resolveRepository === 'function'
         ? adapter.resolveRepository
@@ -336,6 +338,41 @@ function summarizeWorkerBranch(workerBranchRecord) {
     trackingRef: workerBranchRecord.trackingRef,
     activatedAt: workerBranchRecord.activatedAt,
     reused: Boolean(workerBranchRecord.reused)
+  };
+}
+
+function summarizeTaskPacket(taskPacketRecord) {
+  if (!taskPacketRecord) return null;
+  return {
+    laneId: taskPacketRecord.laneId,
+    cycle: taskPacketRecord.cycle,
+    status: taskPacketRecord.status,
+    objective: {
+      summary: taskPacketRecord.objective?.summary ?? null,
+      source: taskPacketRecord.objective?.source ?? null
+    },
+    branch: {
+      name: taskPacketRecord.branch?.name ?? null,
+      status: taskPacketRecord.branch?.status ?? null
+    },
+    pullRequest: {
+      url: taskPacketRecord.pullRequest?.url ?? null,
+      status: taskPacketRecord.pullRequest?.status ?? null
+    },
+    checks: {
+      status: taskPacketRecord.checks?.status ?? null,
+      blockerClass: taskPacketRecord.checks?.blockerClass ?? null
+    },
+    helperSurface: {
+      preferredCount: Array.isArray(taskPacketRecord.helperSurface?.preferred)
+        ? taskPacketRecord.helperSurface.preferred.length
+        : 0,
+      fallbackCount: Array.isArray(taskPacketRecord.helperSurface?.fallbacks)
+        ? taskPacketRecord.helperSurface.fallbacks.length
+        : 0
+    },
+    generatedAt: taskPacketRecord.generatedAt ?? null,
+    artifacts: taskPacketRecord.artifacts ?? {}
   };
 }
 
@@ -433,6 +470,56 @@ function normalizeWorkerBranchRecord(workerBranch, now) {
   };
 }
 
+function normalizeTaskPacketRecord(taskPacket, now) {
+  if (!taskPacket || typeof taskPacket !== 'object') return null;
+  const objective = taskPacket.objective && typeof taskPacket.objective === 'object' ? taskPacket.objective : {};
+  const branch = taskPacket.branch && typeof taskPacket.branch === 'object' ? taskPacket.branch : {};
+  const pullRequest = taskPacket.pullRequest && typeof taskPacket.pullRequest === 'object' ? taskPacket.pullRequest : {};
+  const checks = taskPacket.checks && typeof taskPacket.checks === 'object' ? taskPacket.checks : {};
+  const helperSurface = taskPacket.helperSurface && typeof taskPacket.helperSurface === 'object' ? taskPacket.helperSurface : {};
+  const recentEvents = Array.isArray(taskPacket.recentEvents) ? taskPacket.recentEvents : [];
+  const evidence = taskPacket.evidence && typeof taskPacket.evidence === 'object' ? taskPacket.evidence : {};
+  const artifacts = taskPacket.artifacts && typeof taskPacket.artifacts === 'object' ? taskPacket.artifacts : {};
+  return {
+    schema: TASK_PACKET_SCHEMA,
+    generatedAt: normalizeText(taskPacket.generatedAt) || toIso(now),
+    cycle: Number.isInteger(taskPacket.cycle) ? taskPacket.cycle : null,
+    laneId: normalizeText(taskPacket.laneId) || null,
+    status: normalizeText(taskPacket.status).toLowerCase() || 'ready',
+    source: normalizeText(taskPacket.source) || null,
+    objective: {
+      summary: normalizeText(objective.summary) || null,
+      source: normalizeText(objective.source) || null
+    },
+    branch: {
+      name: normalizeText(branch.name) || null,
+      forkRemote: normalizeText(branch.forkRemote) || null,
+      status: normalizeText(branch.status) || null,
+      trackingRef: normalizeText(branch.trackingRef) || null,
+      checkoutPath: normalizeText(branch.checkoutPath) || null
+    },
+    pullRequest: {
+      url: normalizeText(pullRequest.url) || null,
+      status: normalizeText(pullRequest.status) || null
+    },
+    checks: {
+      status: normalizeText(checks.status) || null,
+      blockerClass: normalizeText(checks.blockerClass) || null
+    },
+    helperSurface: {
+      preferred: Array.isArray(helperSurface.preferred)
+        ? helperSurface.preferred.map((entry) => String(entry))
+        : [],
+      fallbacks: Array.isArray(helperSurface.fallbacks)
+        ? helperSurface.fallbacks.map((entry) => String(entry))
+        : []
+    },
+    recentEvents,
+    evidence,
+    artifacts
+  };
+}
+
 function buildActiveLaneSummary(laneRecord) {
   if (!laneRecord) return null;
   return {
@@ -446,6 +533,7 @@ function buildActiveLaneSummary(laneRecord) {
     worker: summarizeWorker(laneRecord.worker),
     workerReady: summarizeWorkerReady(laneRecord.workerReady),
     workerBranch: summarizeWorkerBranch(laneRecord.workerBranch),
+    taskPacket: summarizeTaskPacket(laneRecord.taskPacket),
     updatedAt: laneRecord.updatedAt
   };
 }
@@ -534,6 +622,7 @@ function buildLaneRecord(options, now) {
   const worker = normalizeWorkerRecord(options.worker, now);
   const workerReady = normalizeWorkerReadyRecord(options.workerReady, now);
   const workerBranch = normalizeWorkerBranchRecord(options.workerBranch, now);
+  const taskPacket = normalizeTaskPacketRecord(options.taskPacket, now);
   return {
     schema: LANE_SCHEMA,
     laneId,
@@ -554,6 +643,7 @@ function buildLaneRecord(options, now) {
     worker,
     workerReady,
     workerBranch,
+    taskPacket,
     createdAt: toIso(now),
     updatedAt: toIso(now)
   };
@@ -788,6 +878,8 @@ async function runStepAction(context) {
         workerReadyArtifactPath: laneRecord?.workerReady?.artifacts?.lanePath ?? null,
         workerBranchPath: laneRecord?.workerBranch?.artifacts?.latestPath ?? null,
         workerBranchArtifactPath: laneRecord?.workerBranch?.artifacts?.lanePath ?? null,
+        taskPacketPath: laneRecord?.taskPacket?.artifacts?.latestPath ?? null,
+        taskPacketHistoryPath: laneRecord?.taskPacket?.artifacts?.historyPath ?? null,
         statePath: runtimePaths.statePath,
         eventsPath: runtimePaths.eventsPath
       }
@@ -813,6 +905,7 @@ async function runStepAction(context) {
     report.worker = summarizeWorker(laneRecord?.worker);
     report.workerReady = summarizeWorkerReady(laneRecord?.workerReady);
     report.workerBranch = summarizeWorkerBranch(laneRecord?.workerBranch);
+    report.taskPacket = summarizeTaskPacket(laneRecord?.taskPacket);
     report.state = state;
   } finally {
     const leaseId = report.lease?.acquire?.leaseId ?? null;

--- a/packages/runtime-harness/index.mjs
+++ b/packages/runtime-harness/index.mjs
@@ -17,6 +17,7 @@ export const WORKER_CHECKOUT_SCHEMA = 'priority/runtime-worker-checkout@v1';
 export const WORKER_READY_SCHEMA = 'priority/runtime-worker-ready@v1';
 export const WORKER_BRANCH_SCHEMA = 'priority/runtime-worker-branch@v1';
 export const TASK_PACKET_SCHEMA = 'priority/runtime-worker-task-packet@v1';
+export const WORKER_RECEIPT_SCHEMA = 'priority/runtime-worker-receipt@v1';
 export const DEFAULT_RUNTIME_DIR = path.join('tests', 'results', '_agent', 'runtime');
 export const DEFAULT_LEASE_SCOPE = 'workspace';
 export const ACTIONS = new Set(['status', 'step', 'stop', 'resume']);
@@ -286,6 +287,7 @@ export function createRuntimeAdapter(adapter = {}) {
     bootstrapWorker: typeof adapter.bootstrapWorker === 'function' ? adapter.bootstrapWorker : null,
     activateWorker: typeof adapter.activateWorker === 'function' ? adapter.activateWorker : null,
     buildTaskPacket: typeof adapter.buildTaskPacket === 'function' ? adapter.buildTaskPacket : null,
+    executeTaskPacket: typeof adapter.executeTaskPacket === 'function' ? adapter.executeTaskPacket : null,
     resolveRepository:
       typeof adapter.resolveRepository === 'function'
         ? adapter.resolveRepository
@@ -373,6 +375,22 @@ function summarizeTaskPacket(taskPacketRecord) {
     },
     generatedAt: taskPacketRecord.generatedAt ?? null,
     artifacts: taskPacketRecord.artifacts ?? {}
+  };
+}
+
+function summarizeWorkerReceipt(workerReceiptRecord) {
+  if (!workerReceiptRecord) return null;
+  return {
+    laneId: workerReceiptRecord.laneId,
+    cycle: workerReceiptRecord.cycle,
+    status: workerReceiptRecord.status,
+    source: workerReceiptRecord.source ?? null,
+    objective: {
+      summary: workerReceiptRecord.objective?.summary ?? null
+    },
+    result: workerReceiptRecord.result ?? null,
+    executedAt: workerReceiptRecord.executedAt ?? null,
+    artifacts: workerReceiptRecord.artifacts ?? {}
   };
 }
 
@@ -520,6 +538,38 @@ function normalizeTaskPacketRecord(taskPacket, now) {
   };
 }
 
+function normalizeWorkerReceiptRecord(workerReceipt, now) {
+  if (!workerReceipt || typeof workerReceipt !== 'object') return null;
+  const objective = workerReceipt.objective && typeof workerReceipt.objective === 'object' ? workerReceipt.objective : {};
+  const execution = workerReceipt.execution && typeof workerReceipt.execution === 'object' ? workerReceipt.execution : {};
+  const artifacts = workerReceipt.artifacts && typeof workerReceipt.artifacts === 'object' ? workerReceipt.artifacts : {};
+  return {
+    schema: WORKER_RECEIPT_SCHEMA,
+    generatedAt: normalizeText(workerReceipt.generatedAt) || toIso(now),
+    cycle: Number.isInteger(workerReceipt.cycle) ? workerReceipt.cycle : null,
+    laneId: normalizeText(workerReceipt.laneId) || null,
+    status: normalizeText(workerReceipt.status).toLowerCase() || 'noop',
+    source: normalizeText(workerReceipt.source) || null,
+    objective: {
+      summary: normalizeText(objective.summary) || null
+    },
+    result: normalizeText(workerReceipt.result) || null,
+    reason: normalizeText(workerReceipt.reason) || null,
+    execution: {
+      commands: Array.isArray(execution.commands) ? execution.commands.map((entry) => String(entry)) : [],
+      commandCount: Number.isInteger(execution.commandCount)
+        ? execution.commandCount
+        : Array.isArray(execution.commands)
+          ? execution.commands.length
+          : 0,
+      durationMs: Number.isFinite(execution.durationMs) ? Number(execution.durationMs) : null
+    },
+    taskPacketGeneratedAt: normalizeText(workerReceipt.taskPacketGeneratedAt) || null,
+    executedAt: normalizeText(workerReceipt.executedAt) || toIso(now),
+    artifacts
+  };
+}
+
 function buildActiveLaneSummary(laneRecord) {
   if (!laneRecord) return null;
   return {
@@ -534,6 +584,7 @@ function buildActiveLaneSummary(laneRecord) {
     workerReady: summarizeWorkerReady(laneRecord.workerReady),
     workerBranch: summarizeWorkerBranch(laneRecord.workerBranch),
     taskPacket: summarizeTaskPacket(laneRecord.taskPacket),
+    workerReceipt: summarizeWorkerReceipt(laneRecord.workerReceipt),
     updatedAt: laneRecord.updatedAt
   };
 }
@@ -623,6 +674,7 @@ function buildLaneRecord(options, now) {
   const workerReady = normalizeWorkerReadyRecord(options.workerReady, now);
   const workerBranch = normalizeWorkerBranchRecord(options.workerBranch, now);
   const taskPacket = normalizeTaskPacketRecord(options.taskPacket, now);
+  const workerReceipt = normalizeWorkerReceiptRecord(options.workerReceipt, now);
   return {
     schema: LANE_SCHEMA,
     laneId,
@@ -644,6 +696,7 @@ function buildLaneRecord(options, now) {
     workerReady,
     workerBranch,
     taskPacket,
+    workerReceipt,
     createdAt: toIso(now),
     updatedAt: toIso(now)
   };
@@ -880,6 +933,8 @@ async function runStepAction(context) {
         workerBranchArtifactPath: laneRecord?.workerBranch?.artifacts?.lanePath ?? null,
         taskPacketPath: laneRecord?.taskPacket?.artifacts?.latestPath ?? null,
         taskPacketHistoryPath: laneRecord?.taskPacket?.artifacts?.historyPath ?? null,
+        workerReceiptPath: laneRecord?.workerReceipt?.artifacts?.latestPath ?? null,
+        workerReceiptHistoryPath: laneRecord?.workerReceipt?.artifacts?.historyPath ?? null,
         statePath: runtimePaths.statePath,
         eventsPath: runtimePaths.eventsPath
       }
@@ -906,6 +961,7 @@ async function runStepAction(context) {
     report.workerReady = summarizeWorkerReady(laneRecord?.workerReady);
     report.workerBranch = summarizeWorkerBranch(laneRecord?.workerBranch);
     report.taskPacket = summarizeTaskPacket(laneRecord?.taskPacket);
+    report.workerReceipt = summarizeWorkerReceipt(laneRecord?.workerReceipt);
     report.state = state;
   } finally {
     const leaseId = report.lease?.acquire?.leaseId ?? null;

--- a/packages/runtime-harness/observer.mjs
+++ b/packages/runtime-harness/observer.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { mkdir, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import process from 'node:process';
 import {
@@ -8,6 +8,7 @@ import {
   createRuntimeAdapter,
   DEFAULT_RUNTIME_DIR,
   SCHEDULER_DECISION_SCHEMA,
+  TASK_PACKET_SCHEMA,
   WORKER_BRANCH_SCHEMA,
   WORKER_CHECKOUT_SCHEMA,
   WORKER_READY_SCHEMA
@@ -120,6 +121,16 @@ function resolveSchedulerPaths(options, repoRoot) {
   };
 }
 
+function resolveRuntimeArtifactPaths(options, repoRoot) {
+  const runtimeDir = resolvePath(repoRoot, options.runtimeDir || DEFAULT_RUNTIME_DIR);
+  return {
+    runtimeDir,
+    statePath: path.join(runtimeDir, 'runtime-state.json'),
+    eventsPath: path.join(runtimeDir, 'runtime-events.ndjson'),
+    stopRequestPath: path.join(runtimeDir, 'stop-request.json')
+  };
+}
+
 function resolveWorkerPaths(options, repoRoot) {
   const runtimeDir = resolvePath(repoRoot, options.runtimeDir || DEFAULT_RUNTIME_DIR);
   return {
@@ -132,11 +143,34 @@ function resolveWorkerPaths(options, repoRoot) {
   };
 }
 
+function resolveTaskPacketPaths(options, repoRoot) {
+  const runtimeDir = resolvePath(repoRoot, options.runtimeDir || DEFAULT_RUNTIME_DIR);
+  return {
+    latestPath: path.join(runtimeDir, 'task-packet.json'),
+    historyDir: path.join(runtimeDir, 'task-packets')
+  };
+}
+
 async function writeJson(filePath, payload) {
   const resolved = path.resolve(filePath);
   await mkdir(path.dirname(resolved), { recursive: true });
   await writeFile(resolved, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
   return resolved;
+}
+
+async function readRecentEvents(eventsPath, limit = 5) {
+  try {
+    const raw = await readFile(path.resolve(eventsPath), 'utf8');
+    const events = raw
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line) => JSON.parse(line));
+    return events.slice(Math.max(0, events.length - limit));
+  } catch (error) {
+    if (error?.code === 'ENOENT') return [];
+    throw error;
+  }
 }
 
 function normalizeStepOptions(stepOptions = {}) {
@@ -445,6 +479,292 @@ function buildDecisionSummary(decision, artifacts) {
   };
 }
 
+function normalizeHelperCommands(list) {
+  return Array.isArray(list)
+    ? list.map((entry) => normalizeText(entry)).filter(Boolean)
+    : [];
+}
+
+function determineTaskPacketStatus({ schedulerDecision, preparedWorker, workerReady, workerBranch }) {
+  if (
+    preparedWorker?.status === 'blocked' ||
+    workerReady?.status === 'blocked' ||
+    workerBranch?.status === 'blocked' ||
+    schedulerDecision?.outcome === 'blocked'
+  ) {
+    return 'blocked';
+  }
+  if (schedulerDecision?.outcome === 'idle') {
+    return 'idle';
+  }
+  if (workerBranch?.status) {
+    return 'ready';
+  }
+  if (workerReady?.status) {
+    return 'prepared';
+  }
+  if (preparedWorker?.status) {
+    return 'selected';
+  }
+  return normalizeText(schedulerDecision?.outcome) || 'idle';
+}
+
+function buildDefaultTaskObjective(schedulerDecision) {
+  const activeLane = schedulerDecision?.activeLane ?? null;
+  if (Number.isInteger(activeLane?.issue)) {
+    const branch = normalizeText(activeLane.branch);
+    const laneTarget = branch || normalizeText(activeLane.laneId) || `issue-${activeLane.issue}`;
+    return {
+      summary: `Advance issue #${activeLane.issue} on ${laneTarget}`,
+      source: normalizeText(schedulerDecision?.source) || 'runtime-harness'
+    };
+  }
+  return {
+    summary: normalizeText(schedulerDecision?.reason) || 'No active lane selected for this worker cycle.',
+    source: normalizeText(schedulerDecision?.source) || 'runtime-harness'
+  };
+}
+
+function buildObservedActiveLane(schedulerDecision, preparedWorker, workerReady, workerBranch, taskPacket) {
+  if (!schedulerDecision?.activeLane) return null;
+  const activeLane = {
+    ...schedulerDecision.activeLane
+  };
+  if (preparedWorker) {
+    activeLane.worker = preparedWorker;
+  }
+  if (workerReady) {
+    activeLane.workerReady = workerReady;
+  }
+  if (workerBranch) {
+    activeLane.workerBranch = workerBranch;
+  }
+  if (taskPacket) {
+    activeLane.taskPacket = {
+      cycle: taskPacket.cycle,
+      status: taskPacket.status,
+      objective: taskPacket.objective,
+      generatedAt: taskPacket.generatedAt,
+      artifacts: taskPacket.artifacts ?? {}
+    };
+  }
+  return activeLane;
+}
+
+function buildObserverArtifacts({
+  runtimeArtifactPaths,
+  workerArtifacts,
+  workerReadyArtifacts,
+  workerBranchArtifacts,
+  schedulerArtifacts,
+  taskPacketArtifacts,
+  includeRuntimeState = false
+}) {
+  return {
+    statePath: includeRuntimeState ? runtimeArtifactPaths.statePath : null,
+    eventsPath: includeRuntimeState ? runtimeArtifactPaths.eventsPath : null,
+    stopRequestPath: includeRuntimeState ? runtimeArtifactPaths.stopRequestPath : null,
+    workerCheckoutPath: workerArtifacts.latestPath,
+    workerLanePath: workerArtifacts.lanePath,
+    workerReadyPath: workerReadyArtifacts.latestPath,
+    workerReadyLanePath: workerReadyArtifacts.lanePath,
+    workerBranchPath: workerBranchArtifacts.latestPath,
+    workerBranchLanePath: workerBranchArtifacts.lanePath,
+    schedulerDecisionPath: schedulerArtifacts.latestPath,
+    schedulerDecisionHistoryPath: schedulerArtifacts.historyPath,
+    taskPacketPath: taskPacketArtifacts.latestPath,
+    taskPacketHistoryPath: taskPacketArtifacts.historyPath
+  };
+}
+
+async function buildTaskPacket({
+  options,
+  deps,
+  adapter,
+  repoRoot,
+  repository,
+  cycle,
+  heartbeatPath,
+  runtimeArtifactPaths,
+  schedulerArtifacts,
+  taskPacketPaths,
+  schedulerDecision,
+  preparedWorker,
+  workerReady,
+  workerBranch,
+  workerArtifacts,
+  workerReadyArtifacts,
+  workerBranchArtifacts,
+  previousDecision,
+  previousStep,
+  now
+}) {
+  const activeLane = schedulerDecision?.activeLane ?? null;
+  const taskPacketHook =
+    typeof deps.buildTaskPacketFn === 'function'
+      ? deps.buildTaskPacketFn
+      : (typeof adapter.buildTaskPacket === 'function' ? (context) => adapter.buildTaskPacket(context) : null);
+  const recentEvents = await readRecentEvents(runtimeArtifactPaths.eventsPath, 5);
+  const packet = {
+    schema: TASK_PACKET_SCHEMA,
+    generatedAt: toIso(now),
+    cycle,
+    runtimeAdapter: adapter.name,
+    repository,
+    laneId: activeLane?.laneId ?? null,
+    status: determineTaskPacketStatus({
+      schedulerDecision,
+      preparedWorker,
+      workerReady,
+      workerBranch
+    }),
+    source: normalizeText(schedulerDecision?.source) || adapter.name,
+    objective: buildDefaultTaskObjective(schedulerDecision),
+    branch: {
+      name: normalizeText(workerBranch?.branch) || normalizeText(activeLane?.branch) || null,
+      forkRemote: normalizeText(workerBranch?.forkRemote) || normalizeText(activeLane?.forkRemote) || null,
+      status:
+        normalizeText(workerBranch?.status) ||
+        normalizeText(workerReady?.status) ||
+        normalizeText(preparedWorker?.status) ||
+        (activeLane ? 'selected' : 'idle'),
+      trackingRef: normalizeText(workerBranch?.trackingRef) || null,
+      checkoutPath:
+        normalizeText(workerBranch?.checkoutPath) ||
+        normalizeText(workerReady?.checkoutPath) ||
+        normalizeText(preparedWorker?.checkoutPath) ||
+        null
+    },
+    pullRequest: {
+      url: normalizeText(activeLane?.prUrl) || null,
+      status: normalizeText(activeLane?.prUrl) ? 'linked' : 'none'
+    },
+    checks: {
+      status: activeLane?.blockerClass === 'ci' ? 'blocked' : normalizeText(activeLane?.prUrl) ? 'pending-or-unknown' : 'not-linked',
+      blockerClass: normalizeText(activeLane?.blockerClass) || 'none'
+    },
+    helperSurface: {
+      preferred: [],
+      fallbacks: []
+    },
+    recentEvents,
+    evidence: {
+      runtime: {
+        runtimeDir: runtimeArtifactPaths.runtimeDir,
+        heartbeatPath,
+        statePath: runtimeArtifactPaths.statePath,
+        eventsPath: runtimeArtifactPaths.eventsPath,
+        stopRequestPath: runtimeArtifactPaths.stopRequestPath
+      },
+      scheduler: {
+        latestPath: schedulerArtifacts.latestPath,
+        historyPath: schedulerArtifacts.historyPath,
+        sourceArtifacts: schedulerDecision?.artifacts ?? {}
+      },
+      worker: {
+        checkoutPath: workerArtifacts.latestPath,
+        checkoutLanePath: workerArtifacts.lanePath,
+        readyPath: workerReadyArtifacts.latestPath,
+        readyLanePath: workerReadyArtifacts.lanePath,
+        branchPath: workerBranchArtifacts.latestPath,
+        branchLanePath: workerBranchArtifacts.lanePath
+      }
+    },
+    artifacts: {}
+  };
+
+  if (taskPacketHook) {
+    const adapterPacket = await taskPacketHook({
+      options,
+      env: process.env,
+      repoRoot,
+      deps,
+      adapter,
+      repository,
+      cycle,
+      heartbeatPath,
+      runtimeArtifactPaths,
+      schedulerArtifacts,
+      taskPacketPaths,
+      schedulerDecision,
+      preparedWorker,
+      workerReady,
+      workerBranch,
+      workerArtifacts,
+      workerReadyArtifacts,
+      workerBranchArtifacts,
+      previousDecision,
+      previousStep,
+      now,
+      recentEvents
+    });
+    if (adapterPacket && typeof adapterPacket === 'object') {
+      const objective = adapterPacket.objective && typeof adapterPacket.objective === 'object' ? adapterPacket.objective : {};
+      const branch = adapterPacket.branch && typeof adapterPacket.branch === 'object' ? adapterPacket.branch : {};
+      const pullRequest =
+        adapterPacket.pullRequest && typeof adapterPacket.pullRequest === 'object' ? adapterPacket.pullRequest : {};
+      const checks = adapterPacket.checks && typeof adapterPacket.checks === 'object' ? adapterPacket.checks : {};
+      const evidence = adapterPacket.evidence && typeof adapterPacket.evidence === 'object' ? adapterPacket.evidence : {};
+      packet.source = normalizeText(adapterPacket.source) || packet.source;
+      packet.status = normalizeText(adapterPacket.status).toLowerCase() || packet.status;
+      packet.objective = {
+        summary: normalizeText(objective.summary) || packet.objective.summary,
+        source: normalizeText(objective.source) || packet.objective.source
+      };
+      packet.branch = {
+        ...packet.branch,
+        name: normalizeText(branch.name) || packet.branch.name,
+        forkRemote: normalizeText(branch.forkRemote) || packet.branch.forkRemote,
+        status: normalizeText(branch.status) || packet.branch.status,
+        trackingRef: normalizeText(branch.trackingRef) || packet.branch.trackingRef,
+        checkoutPath: normalizeText(branch.checkoutPath) || packet.branch.checkoutPath
+      };
+      packet.pullRequest = {
+        url: normalizeText(pullRequest.url) || packet.pullRequest.url,
+        status: normalizeText(pullRequest.status) || packet.pullRequest.status
+      };
+      packet.checks = {
+        status: normalizeText(checks.status) || packet.checks.status,
+        blockerClass: normalizeText(checks.blockerClass) || packet.checks.blockerClass
+      };
+      packet.helperSurface = {
+        preferred: normalizeHelperCommands(adapterPacket.helperSurface?.preferred),
+        fallbacks: normalizeHelperCommands(adapterPacket.helperSurface?.fallbacks)
+      };
+      packet.recentEvents = Array.isArray(adapterPacket.recentEvents) ? adapterPacket.recentEvents : packet.recentEvents;
+      packet.evidence = {
+        ...packet.evidence,
+        ...evidence
+      };
+    }
+  }
+
+  return packet;
+}
+
+async function writeTaskPacket(taskPacketPaths, taskPacket) {
+  await mkdir(taskPacketPaths.historyDir, { recursive: true });
+  const historyPath = path.join(
+    taskPacketPaths.historyDir,
+    makeDecisionFileName(new Date(taskPacket.generatedAt), taskPacket.cycle ?? 0)
+  );
+  const persistedTaskPacket = {
+    ...taskPacket,
+    artifacts: {
+      ...(taskPacket.artifacts ?? {}),
+      latestPath: taskPacketPaths.latestPath,
+      historyPath
+    }
+  };
+  await writeJson(taskPacketPaths.latestPath, persistedTaskPacket);
+  await writeJson(historyPath, persistedTaskPacket);
+  return {
+    latestPath: taskPacketPaths.latestPath,
+    historyPath,
+    taskPacket: persistedTaskPacket
+  };
+}
+
 export function parseObserverArgs(argv = process.argv) {
   const args = argv.slice(2);
   const options = {
@@ -561,8 +881,10 @@ export async function runRuntimeObserverLoop(options = {}, deps = {}) {
   const adapter = createRuntimeAdapter(deps.adapter ?? {});
   const repoRoot = resolveRepoRoot(options, deps, adapter);
   const heartbeatPath = resolveHeartbeatPath(options, repoRoot);
+  const runtimeArtifactPaths = resolveRuntimeArtifactPaths(options, repoRoot);
   const schedulerPaths = resolveSchedulerPaths(options, repoRoot);
   const workerPaths = resolveWorkerPaths(options, repoRoot);
+  const taskPacketPaths = resolveTaskPacketPaths(options, repoRoot);
   const nowFactory = deps.nowFactory ?? (() => deps.now ?? new Date());
   const sleepFn = deps.sleepFn ?? sleep;
 
@@ -586,6 +908,10 @@ export async function runRuntimeObserverLoop(options = {}, deps = {}) {
       readyDir: workerPaths.readyDir,
       branchLatestPath: workerPaths.branchLatestPath,
       branchDir: workerPaths.branchDir
+    },
+    taskPackets: {
+      latestPath: taskPacketPaths.latestPath,
+      historyDir: taskPacketPaths.historyDir
     },
     status: 'pass',
     outcome: 'idle',
@@ -630,6 +956,51 @@ export async function runRuntimeObserverLoop(options = {}, deps = {}) {
 
     const schedulerArtifacts = await writeSchedulerDecision(schedulerPaths, schedulerDecision);
     report.lastDecision = buildDecisionSummary(schedulerDecision, schedulerArtifacts);
+    let taskPacket = null;
+    let taskPacketArtifacts = {
+      latestPath: null,
+      historyPath: null
+    };
+
+    if (schedulerDecision.outcome !== 'selected') {
+      const taskPacketRecord = await buildTaskPacket({
+        options,
+        deps,
+        adapter,
+        repoRoot,
+        repository: report.repository,
+        cycle,
+        heartbeatPath,
+        runtimeArtifactPaths,
+        schedulerArtifacts,
+        taskPacketPaths,
+        schedulerDecision,
+        preparedWorker: null,
+        workerReady: null,
+        workerBranch: null,
+        workerArtifacts: {
+          latestPath: null,
+          lanePath: null
+        },
+        workerReadyArtifacts: {
+          latestPath: null,
+          lanePath: null
+        },
+        workerBranchArtifacts: {
+          latestPath: null,
+          lanePath: null
+        },
+        previousDecision,
+        previousStep,
+        now: stepNow
+      });
+      const persistedTaskPacket = await writeTaskPacket(taskPacketPaths, taskPacketRecord);
+      taskPacket = persistedTaskPacket.taskPacket;
+      taskPacketArtifacts = {
+        latestPath: persistedTaskPacket.latestPath,
+        historyPath: persistedTaskPacket.historyPath
+      };
+    }
 
     if (schedulerDecision.outcome === 'blocked') {
       const heartbeatNow = nowFactory();
@@ -642,24 +1013,26 @@ export async function runRuntimeObserverLoop(options = {}, deps = {}) {
         cyclesCompleted: report.cyclesCompleted,
         outcome: 'scheduler-blocked',
         stopRequested: false,
-        activeLane: schedulerDecision.activeLane,
+        activeLane: buildObservedActiveLane(schedulerDecision, null, null, null, taskPacket),
         schedulerDecision: report.lastDecision,
-        artifacts: {
-          statePath: null,
-          eventsPath: null,
-          stopRequestPath: null,
-          workerCheckoutPath: null,
-          workerLanePath: null,
-          workerReadyPath: null,
-          workerReadyLanePath: null,
-          workerBranchPath: null,
-          workerBranchLanePath: null,
-          schedulerDecisionPath: schedulerArtifacts.latestPath,
-          schedulerDecisionHistoryPath: schedulerArtifacts.historyPath
-        }
+        artifacts: buildObserverArtifacts({
+          runtimeArtifactPaths,
+          workerArtifacts: { latestPath: null, lanePath: null },
+          workerReadyArtifacts: { latestPath: null, lanePath: null },
+          workerBranchArtifacts: { latestPath: null, lanePath: null },
+          schedulerArtifacts,
+          taskPacketArtifacts
+        })
       });
       report.status = 'blocked';
       report.outcome = 'scheduler-blocked';
+      report.lastStep = {
+        exitCode: 12,
+        outcome: 'scheduler-blocked',
+        statePath: null,
+        turnPath: null,
+        taskPacket
+      };
       return { exitCode: 12, report };
     }
 
@@ -937,26 +1310,16 @@ export async function runRuntimeObserverLoop(options = {}, deps = {}) {
           cyclesCompleted: report.cyclesCompleted,
           outcome: 'worker-branch-blocked',
           stopRequested: false,
-          activeLane: {
-            ...(schedulerDecision.activeLane ?? {}),
-            worker: preparedWorker,
-            workerReady,
-            workerBranch
-          },
+          activeLane: buildObservedActiveLane(schedulerDecision, preparedWorker, workerReady, workerBranch, taskPacket),
           schedulerDecision: report.lastDecision,
-          artifacts: {
-            statePath: null,
-            eventsPath: null,
-            stopRequestPath: null,
-            workerCheckoutPath: workerArtifacts.latestPath,
-            workerLanePath: workerArtifacts.lanePath,
-            workerReadyPath: workerReadyArtifacts.latestPath,
-            workerReadyLanePath: workerReadyArtifacts.lanePath,
-            workerBranchPath: workerBranchArtifacts.latestPath,
-            workerBranchLanePath: workerBranchArtifacts.lanePath,
-            schedulerDecisionPath: schedulerArtifacts.latestPath,
-            schedulerDecisionHistoryPath: schedulerArtifacts.historyPath
-          }
+          artifacts: buildObserverArtifacts({
+            runtimeArtifactPaths,
+            workerArtifacts,
+            workerReadyArtifacts,
+            workerBranchArtifacts,
+            schedulerArtifacts,
+            taskPacketArtifacts
+          })
         });
         report.status = 'blocked';
         report.outcome = 'worker-branch-blocked';
@@ -967,10 +1330,42 @@ export async function runRuntimeObserverLoop(options = {}, deps = {}) {
           turnPath: null,
           worker: preparedWorker,
           workerReady,
-          workerBranch
+          workerBranch,
+          taskPacket
         };
         return { exitCode: 15, report };
       }
+    }
+
+    if (schedulerDecision.outcome === 'selected') {
+      const taskPacketRecord = await buildTaskPacket({
+        options,
+        deps,
+        adapter,
+        repoRoot,
+        repository: report.repository,
+        cycle,
+        heartbeatPath,
+        runtimeArtifactPaths,
+        schedulerArtifacts,
+        taskPacketPaths,
+        schedulerDecision,
+        preparedWorker,
+        workerReady,
+        workerBranch,
+        workerArtifacts,
+        workerReadyArtifacts,
+        workerBranchArtifacts,
+        previousDecision,
+        previousStep,
+        now: stepNow
+      });
+      const persistedTaskPacket = await writeTaskPacket(taskPacketPaths, taskPacketRecord);
+      taskPacket = persistedTaskPacket.taskPacket;
+      taskPacketArtifacts = {
+        latestPath: persistedTaskPacket.latestPath,
+        historyPath: persistedTaskPacket.historyPath
+      };
     }
 
     const stepResult = await runRuntimeWorkerStep(
@@ -978,7 +1373,8 @@ export async function runRuntimeObserverLoop(options = {}, deps = {}) {
         ...buildWorkerStepOptions(options, schedulerDecision),
         worker: preparedWorker,
         workerReady,
-        workerBranch
+        workerBranch,
+        taskPacket
       },
       {
         ...deps,
@@ -996,7 +1392,8 @@ export async function runRuntimeObserverLoop(options = {}, deps = {}) {
       turnPath: stepResult.report.turnPath ?? null,
       worker: stepResult.report.worker ?? preparedWorker,
       workerReady: stepResult.report.workerReady ?? workerReady,
-      workerBranch: stepResult.report.workerBranch ?? workerBranch
+      workerBranch: stepResult.report.workerBranch ?? workerBranch,
+      taskPacket: stepResult.report.taskPacket ?? taskPacket
     };
     previousDecision = schedulerDecision;
     previousStep = report.lastStep;
@@ -1013,19 +1410,15 @@ export async function runRuntimeObserverLoop(options = {}, deps = {}) {
       stopRequested: Boolean(stepResult.report.state?.lifecycle?.stopRequested),
       activeLane: stepResult.report.state?.activeLane ?? null,
       schedulerDecision: report.lastDecision,
-      artifacts: {
-        statePath: stepResult.report.runtime?.statePath ?? null,
-        eventsPath: stepResult.report.runtime?.eventsPath ?? null,
-        stopRequestPath: stepResult.report.runtime?.stopRequestPath ?? null,
-        workerCheckoutPath: workerArtifacts.latestPath,
-        workerLanePath: workerArtifacts.lanePath,
-        workerReadyPath: workerReadyArtifacts.latestPath,
-        workerReadyLanePath: workerReadyArtifacts.lanePath,
-        workerBranchPath: workerBranchArtifacts.latestPath,
-        workerBranchLanePath: workerBranchArtifacts.lanePath,
-        schedulerDecisionPath: schedulerArtifacts.latestPath,
-        schedulerDecisionHistoryPath: schedulerArtifacts.historyPath
-      }
+      artifacts: buildObserverArtifacts({
+        runtimeArtifactPaths,
+        workerArtifacts,
+        workerReadyArtifacts,
+        workerBranchArtifacts,
+        schedulerArtifacts,
+        taskPacketArtifacts,
+        includeRuntimeState: true
+      })
     });
 
     if (stepResult.exitCode !== 0) {

--- a/packages/runtime-harness/observer.mjs
+++ b/packages/runtime-harness/observer.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { mkdir, open, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import process from 'node:process';
 import {
@@ -20,6 +20,8 @@ export const OBSERVER_HEARTBEAT_SCHEMA = 'priority/runtime-observer-heartbeat@v1
 export const DEFAULT_POLL_INTERVAL_SECONDS = 60;
 export const SCHEDULER_DECISION_OUTCOMES = new Set(['selected', 'idle', 'blocked']);
 const SCHEDULER_STEP_OPTION_KEYS = ['lane', 'issue', 'epic', 'forkRemote', 'branch', 'prUrl', 'blockerClass', 'reason'];
+const DEFAULT_RECENT_EVENTS_LIMIT = 5;
+const MAX_RECENT_EVENTS_BYTES = 64 * 1024;
 
 function printUsage() {
   console.log('Usage: node runtime-daemon [options]');
@@ -158,18 +160,42 @@ async function writeJson(filePath, payload) {
   return resolved;
 }
 
-async function readRecentEvents(eventsPath, limit = 5) {
+async function readRecentEvents(eventsPath, limit = DEFAULT_RECENT_EVENTS_LIMIT) {
+  let handle;
   try {
-    const raw = await readFile(path.resolve(eventsPath), 'utf8');
-    const events = raw
-      .split(/\r?\n/)
-      .map((line) => line.trim())
-      .filter(Boolean)
-      .map((line) => JSON.parse(line));
-    return events.slice(Math.max(0, events.length - limit));
+    handle = await open(path.resolve(eventsPath), 'r');
+    const stats = await handle.stat();
+    if (!Number.isFinite(stats.size) || stats.size <= 0) {
+      return [];
+    }
+
+    const bytesToRead = Math.min(stats.size, MAX_RECENT_EVENTS_BYTES);
+    const startOffset = Math.max(0, stats.size - bytesToRead);
+    const buffer = Buffer.alloc(bytesToRead);
+    const { bytesRead } = await handle.read(buffer, 0, bytesToRead, startOffset);
+    const raw = buffer.toString('utf8', 0, bytesRead);
+    const lines = raw.split(/\r?\n/);
+    if (startOffset > 0) {
+      lines.shift();
+    }
+
+    const events = [];
+    for (let index = lines.length - 1; index >= 0 && events.length < limit; index -= 1) {
+      const line = lines[index]?.trim();
+      if (!line) continue;
+      try {
+        events.push(JSON.parse(line));
+      } catch {
+        continue;
+      }
+    }
+
+    return events.reverse();
   } catch (error) {
     if (error?.code === 'ENOENT') return [];
     throw error;
+  } finally {
+    await handle?.close();
   }
 }
 
@@ -1299,42 +1325,6 @@ export async function runRuntimeObserverLoop(options = {}, deps = {}) {
           lanePath: workerBranchArtifacts.lanePath
         };
       }
-      if (workerBranch?.status === 'blocked') {
-        const heartbeatNow = nowFactory();
-        await writeJson(heartbeatPath, {
-          schema: OBSERVER_HEARTBEAT_SCHEMA,
-          generatedAt: toIso(heartbeatNow),
-          runtimeAdapter: adapter.name,
-          repository: report.repository,
-          platform,
-          cyclesCompleted: report.cyclesCompleted,
-          outcome: 'worker-branch-blocked',
-          stopRequested: false,
-          activeLane: buildObservedActiveLane(schedulerDecision, preparedWorker, workerReady, workerBranch, taskPacket),
-          schedulerDecision: report.lastDecision,
-          artifacts: buildObserverArtifacts({
-            runtimeArtifactPaths,
-            workerArtifacts,
-            workerReadyArtifacts,
-            workerBranchArtifacts,
-            schedulerArtifacts,
-            taskPacketArtifacts
-          })
-        });
-        report.status = 'blocked';
-        report.outcome = 'worker-branch-blocked';
-        report.lastStep = {
-          exitCode: 15,
-          outcome: 'worker-branch-blocked',
-          statePath: null,
-          turnPath: null,
-          worker: preparedWorker,
-          workerReady,
-          workerBranch,
-          taskPacket
-        };
-        return { exitCode: 15, report };
-      }
     }
 
     if (schedulerDecision.outcome === 'selected') {
@@ -1366,6 +1356,43 @@ export async function runRuntimeObserverLoop(options = {}, deps = {}) {
         latestPath: persistedTaskPacket.latestPath,
         historyPath: persistedTaskPacket.historyPath
       };
+    }
+
+    if (workerBranch?.status === 'blocked') {
+      const heartbeatNow = nowFactory();
+      await writeJson(heartbeatPath, {
+        schema: OBSERVER_HEARTBEAT_SCHEMA,
+        generatedAt: toIso(heartbeatNow),
+        runtimeAdapter: adapter.name,
+        repository: report.repository,
+        platform,
+        cyclesCompleted: report.cyclesCompleted,
+        outcome: 'worker-branch-blocked',
+        stopRequested: false,
+        activeLane: buildObservedActiveLane(schedulerDecision, preparedWorker, workerReady, workerBranch, taskPacket),
+        schedulerDecision: report.lastDecision,
+        artifacts: buildObserverArtifacts({
+          runtimeArtifactPaths,
+          workerArtifacts,
+          workerReadyArtifacts,
+          workerBranchArtifacts,
+          schedulerArtifacts,
+          taskPacketArtifacts
+        })
+      });
+      report.status = 'blocked';
+      report.outcome = 'worker-branch-blocked';
+      report.lastStep = {
+        exitCode: 15,
+        outcome: 'worker-branch-blocked',
+        statePath: null,
+        turnPath: null,
+        worker: preparedWorker,
+        workerReady,
+        workerBranch,
+        taskPacket
+      };
+      return { exitCode: 15, report };
     }
 
     const stepResult = await runRuntimeWorkerStep(

--- a/packages/runtime-harness/observer.mjs
+++ b/packages/runtime-harness/observer.mjs
@@ -9,6 +9,7 @@ import {
   DEFAULT_RUNTIME_DIR,
   SCHEDULER_DECISION_SCHEMA,
   TASK_PACKET_SCHEMA,
+  WORKER_RECEIPT_SCHEMA,
   WORKER_BRANCH_SCHEMA,
   WORKER_CHECKOUT_SCHEMA,
   WORKER_READY_SCHEMA
@@ -141,7 +142,9 @@ function resolveWorkerPaths(options, repoRoot) {
     readyLatestPath: path.join(runtimeDir, 'worker-ready.json'),
     readyDir: path.join(runtimeDir, 'workers-ready'),
     branchLatestPath: path.join(runtimeDir, 'worker-branch.json'),
-    branchDir: path.join(runtimeDir, 'workers-branch')
+    branchDir: path.join(runtimeDir, 'workers-branch'),
+    receiptLatestPath: path.join(runtimeDir, 'worker-receipt.json'),
+    receiptDir: path.join(runtimeDir, 'worker-receipts')
   };
 }
 
@@ -582,6 +585,7 @@ function buildObserverArtifacts({
   workerArtifacts,
   workerReadyArtifacts,
   workerBranchArtifacts,
+  workerReceiptArtifacts,
   schedulerArtifacts,
   taskPacketArtifacts,
   includeRuntimeState = false
@@ -596,10 +600,59 @@ function buildObserverArtifacts({
     workerReadyLanePath: workerReadyArtifacts.lanePath,
     workerBranchPath: workerBranchArtifacts.latestPath,
     workerBranchLanePath: workerBranchArtifacts.lanePath,
+    workerReceiptPath: workerReceiptArtifacts.latestPath,
+    workerReceiptHistoryPath: workerReceiptArtifacts.historyPath,
     schedulerDecisionPath: schedulerArtifacts.latestPath,
     schedulerDecisionHistoryPath: schedulerArtifacts.historyPath,
     taskPacketPath: taskPacketArtifacts.latestPath,
     taskPacketHistoryPath: taskPacketArtifacts.historyPath
+  };
+}
+
+function normalizeWorkerReceipt(rawWorkerReceipt, taskPacket, now, adapter, repository) {
+  if (!rawWorkerReceipt || typeof rawWorkerReceipt !== 'object') return null;
+  const objective = rawWorkerReceipt.objective && typeof rawWorkerReceipt.objective === 'object' ? rawWorkerReceipt.objective : {};
+  const execution = rawWorkerReceipt.execution && typeof rawWorkerReceipt.execution === 'object' ? rawWorkerReceipt.execution : {};
+  return {
+    schema: WORKER_RECEIPT_SCHEMA,
+    generatedAt: toIso(now),
+    runtimeAdapter: adapter.name,
+    repository,
+    cycle: Number.isInteger(rawWorkerReceipt.cycle) ? rawWorkerReceipt.cycle : taskPacket?.cycle ?? null,
+    laneId: normalizeText(rawWorkerReceipt.laneId) || taskPacket?.laneId || null,
+    status: normalizeText(rawWorkerReceipt.status).toLowerCase() || 'noop',
+    source: normalizeText(rawWorkerReceipt.source) || adapter.name,
+    objective: {
+      summary: normalizeText(objective.summary) || taskPacket?.objective?.summary || null
+    },
+    result: normalizeText(rawWorkerReceipt.result) || null,
+    reason: normalizeText(rawWorkerReceipt.reason) || null,
+    execution: {
+      commands: Array.isArray(execution.commands) ? execution.commands.map((entry) => String(entry)) : [],
+      commandCount: Number.isInteger(execution.commandCount)
+        ? execution.commandCount
+        : Array.isArray(execution.commands)
+          ? execution.commands.length
+          : 0,
+      durationMs: Number.isFinite(execution.durationMs) ? Number(execution.durationMs) : null
+    },
+    taskPacketGeneratedAt: normalizeText(rawWorkerReceipt.taskPacketGeneratedAt) || taskPacket?.generatedAt || null,
+    executedAt: normalizeText(rawWorkerReceipt.executedAt) || toIso(now),
+    artifacts: rawWorkerReceipt.artifacts && typeof rawWorkerReceipt.artifacts === 'object' ? rawWorkerReceipt.artifacts : {}
+  };
+}
+
+async function writeWorkerReceipt(workerPaths, workerReceipt) {
+  await mkdir(workerPaths.receiptDir, { recursive: true });
+  await writeJson(workerPaths.receiptLatestPath, workerReceipt);
+  const historyPath = path.join(
+    workerPaths.receiptDir,
+    makeDecisionFileName(new Date(workerReceipt.executedAt), workerReceipt.cycle ?? 0)
+  );
+  await writeJson(historyPath, workerReceipt);
+  return {
+    latestPath: workerPaths.receiptLatestPath,
+    historyPath
   };
 }
 
@@ -933,7 +986,9 @@ export async function runRuntimeObserverLoop(options = {}, deps = {}) {
       readyLatestPath: workerPaths.readyLatestPath,
       readyDir: workerPaths.readyDir,
       branchLatestPath: workerPaths.branchLatestPath,
-      branchDir: workerPaths.branchDir
+      branchDir: workerPaths.branchDir,
+      receiptLatestPath: workerPaths.receiptLatestPath,
+      receiptDir: workerPaths.receiptDir
     },
     taskPackets: {
       latestPath: taskPacketPaths.latestPath,
@@ -1029,6 +1084,49 @@ export async function runRuntimeObserverLoop(options = {}, deps = {}) {
     }
 
     if (schedulerDecision.outcome === 'blocked') {
+      let workerReceipt = null;
+      let workerReceiptArtifacts = {
+        latestPath: null,
+        historyPath: null
+      };
+      const executeTaskPacketFn =
+        typeof deps.executeTaskPacketFn === 'function'
+          ? deps.executeTaskPacketFn
+          : (typeof adapter.executeTaskPacket === 'function' ? (context) => adapter.executeTaskPacket(context) : null);
+      if (executeTaskPacketFn && taskPacket) {
+        workerReceipt = normalizeWorkerReceipt(
+          await executeTaskPacketFn({
+            options,
+            env: process.env,
+            repoRoot,
+            deps,
+            adapter,
+            repository: report.repository,
+            cycle,
+            heartbeatPath,
+            runtimeArtifactPaths,
+            schedulerPaths,
+            taskPacketPaths,
+            workerPaths,
+            schedulerDecision,
+            taskPacket,
+            previousDecision,
+            previousStep,
+            now: stepNow
+          }),
+          taskPacket,
+          stepNow,
+          adapter,
+          report.repository
+        );
+        if (workerReceipt) {
+          workerReceiptArtifacts = await writeWorkerReceipt(workerPaths, workerReceipt);
+          workerReceipt.artifacts = {
+            latestPath: workerReceiptArtifacts.latestPath,
+            historyPath: workerReceiptArtifacts.historyPath
+          };
+        }
+      }
       const heartbeatNow = nowFactory();
       await writeJson(heartbeatPath, {
         schema: OBSERVER_HEARTBEAT_SCHEMA,
@@ -1039,13 +1137,17 @@ export async function runRuntimeObserverLoop(options = {}, deps = {}) {
         cyclesCompleted: report.cyclesCompleted,
         outcome: 'scheduler-blocked',
         stopRequested: false,
-        activeLane: buildObservedActiveLane(schedulerDecision, null, null, null, taskPacket),
+        activeLane: {
+          ...(buildObservedActiveLane(schedulerDecision, null, null, null, taskPacket) ?? {}),
+          workerReceipt
+        },
         schedulerDecision: report.lastDecision,
         artifacts: buildObserverArtifacts({
           runtimeArtifactPaths,
           workerArtifacts: { latestPath: null, lanePath: null },
           workerReadyArtifacts: { latestPath: null, lanePath: null },
           workerBranchArtifacts: { latestPath: null, lanePath: null },
+          workerReceiptArtifacts,
           schedulerArtifacts,
           taskPacketArtifacts
         })
@@ -1057,7 +1159,8 @@ export async function runRuntimeObserverLoop(options = {}, deps = {}) {
         outcome: 'scheduler-blocked',
         statePath: null,
         turnPath: null,
-        taskPacket
+        taskPacket,
+        workerReceipt
       };
       return { exitCode: 12, report };
     }
@@ -1076,6 +1179,11 @@ export async function runRuntimeObserverLoop(options = {}, deps = {}) {
     let workerBranchArtifacts = {
       latestPath: null,
       lanePath: null
+    };
+    let workerReceipt = null;
+    let workerReceiptArtifacts = {
+      latestPath: null,
+      historyPath: null
     };
     const prepareWorkerFn =
       typeof deps.prepareWorkerFn === 'function'
@@ -1358,6 +1466,55 @@ export async function runRuntimeObserverLoop(options = {}, deps = {}) {
       };
     }
 
+    const executeTaskPacketFn =
+      typeof deps.executeTaskPacketFn === 'function'
+        ? deps.executeTaskPacketFn
+        : (typeof adapter.executeTaskPacket === 'function' ? (context) => adapter.executeTaskPacket(context) : null);
+    if (executeTaskPacketFn && taskPacket) {
+      try {
+        workerReceipt = normalizeWorkerReceipt(
+          await executeTaskPacketFn({
+            options,
+            env: process.env,
+            repoRoot,
+            deps,
+            adapter,
+            repository: report.repository,
+            cycle,
+            heartbeatPath,
+            runtimeArtifactPaths,
+            schedulerPaths,
+            taskPacketPaths,
+            workerPaths,
+            schedulerDecision,
+            preparedWorker,
+            workerReady,
+            workerBranch,
+            taskPacket,
+            previousDecision,
+            previousStep,
+            now: stepNow
+          }),
+          taskPacket,
+          stepNow,
+          adapter,
+          report.repository
+        );
+      } catch (error) {
+        report.status = 'blocked';
+        report.outcome = 'worker-receipt-failed';
+        report.message = error?.message || String(error);
+        return { exitCode: 16, report };
+      }
+      if (workerReceipt) {
+        workerReceiptArtifacts = await writeWorkerReceipt(workerPaths, workerReceipt);
+        workerReceipt.artifacts = {
+          latestPath: workerReceiptArtifacts.latestPath,
+          historyPath: workerReceiptArtifacts.historyPath
+        };
+      }
+    }
+
     if (workerBranch?.status === 'blocked') {
       const heartbeatNow = nowFactory();
       await writeJson(heartbeatPath, {
@@ -1369,13 +1526,17 @@ export async function runRuntimeObserverLoop(options = {}, deps = {}) {
         cyclesCompleted: report.cyclesCompleted,
         outcome: 'worker-branch-blocked',
         stopRequested: false,
-        activeLane: buildObservedActiveLane(schedulerDecision, preparedWorker, workerReady, workerBranch, taskPacket),
+        activeLane: {
+          ...(buildObservedActiveLane(schedulerDecision, preparedWorker, workerReady, workerBranch, taskPacket) ?? {}),
+          ...(workerReceipt ? { workerReceipt } : {})
+        },
         schedulerDecision: report.lastDecision,
         artifacts: buildObserverArtifacts({
           runtimeArtifactPaths,
           workerArtifacts,
           workerReadyArtifacts,
           workerBranchArtifacts,
+          workerReceiptArtifacts,
           schedulerArtifacts,
           taskPacketArtifacts
         })
@@ -1390,9 +1551,52 @@ export async function runRuntimeObserverLoop(options = {}, deps = {}) {
         worker: preparedWorker,
         workerReady,
         workerBranch,
-        taskPacket
+        taskPacket,
+        workerReceipt
       };
       return { exitCode: 15, report };
+    }
+
+    if (workerReceipt?.status === 'blocked') {
+      const heartbeatNow = nowFactory();
+      await writeJson(heartbeatPath, {
+        schema: OBSERVER_HEARTBEAT_SCHEMA,
+        generatedAt: toIso(heartbeatNow),
+        runtimeAdapter: adapter.name,
+        repository: report.repository,
+        platform,
+        cyclesCompleted: report.cyclesCompleted,
+        outcome: 'worker-receipt-blocked',
+        stopRequested: false,
+        activeLane: {
+          ...(buildObservedActiveLane(schedulerDecision, preparedWorker, workerReady, workerBranch, taskPacket) ?? {}),
+          workerReceipt
+        },
+        schedulerDecision: report.lastDecision,
+        artifacts: buildObserverArtifacts({
+          runtimeArtifactPaths,
+          workerArtifacts,
+          workerReadyArtifacts,
+          workerBranchArtifacts,
+          workerReceiptArtifacts,
+          schedulerArtifacts,
+          taskPacketArtifacts
+        })
+      });
+      report.status = 'blocked';
+      report.outcome = 'worker-receipt-blocked';
+      report.lastStep = {
+        exitCode: 16,
+        outcome: 'worker-receipt-blocked',
+        statePath: null,
+        turnPath: null,
+        worker: preparedWorker,
+        workerReady,
+        workerBranch,
+        taskPacket,
+        workerReceipt
+      };
+      return { exitCode: 16, report };
     }
 
     const stepResult = await runRuntimeWorkerStep(
@@ -1401,7 +1605,8 @@ export async function runRuntimeObserverLoop(options = {}, deps = {}) {
         worker: preparedWorker,
         workerReady,
         workerBranch,
-        taskPacket
+        taskPacket,
+        workerReceipt
       },
       {
         ...deps,
@@ -1420,7 +1625,8 @@ export async function runRuntimeObserverLoop(options = {}, deps = {}) {
       worker: stepResult.report.worker ?? preparedWorker,
       workerReady: stepResult.report.workerReady ?? workerReady,
       workerBranch: stepResult.report.workerBranch ?? workerBranch,
-      taskPacket: stepResult.report.taskPacket ?? taskPacket
+      taskPacket: stepResult.report.taskPacket ?? taskPacket,
+      workerReceipt: stepResult.report.workerReceipt ?? workerReceipt
     };
     previousDecision = schedulerDecision;
     previousStep = report.lastStep;
@@ -1442,6 +1648,7 @@ export async function runRuntimeObserverLoop(options = {}, deps = {}) {
         workerArtifacts,
         workerReadyArtifacts,
         workerBranchArtifacts,
+        workerReceiptArtifacts,
         schedulerArtifacts,
         taskPacketArtifacts,
         includeRuntimeState: true

--- a/packages/runtime-harness/test/runtime-harness.test.mjs
+++ b/packages/runtime-harness/test/runtime-harness.test.mjs
@@ -106,6 +106,43 @@ test('runRuntimeSupervisor executes through an injected adapter', async () => {
         status: 'attached',
         trackingRef: 'origin/issue/origin-977-fork-policy-portability'
       },
+      taskPacket: {
+        schema: 'priority/runtime-worker-task-packet@v1',
+        generatedAt: '2026-03-10T15:00:00.000Z',
+        cycle: 1,
+        laneId: 'origin-977',
+        status: 'ready',
+        source: 'test-adapter',
+        objective: {
+          summary: 'Advance issue #977',
+          source: 'test-adapter'
+        },
+        branch: {
+          name: 'issue/origin-977-fork-policy-portability',
+          forkRemote: 'origin',
+          status: 'attached',
+          trackingRef: 'origin/issue/origin-977-fork-policy-portability',
+          checkoutPath: path.join(repoRoot, 'workers', 'origin-977')
+        },
+        pullRequest: {
+          url: 'https://example.test/pr/7',
+          status: 'linked'
+        },
+        checks: {
+          status: 'blocked',
+          blockerClass: 'ci'
+        },
+        helperSurface: {
+          preferred: ['node tools/npm/run-script.mjs priority:pr'],
+          fallbacks: ['gh pr create --body-file <path>']
+        },
+        recentEvents: [],
+        evidence: {},
+        artifacts: {
+          latestPath: path.join(repoRoot, 'tests', 'results', '_agent', 'runtime', 'task-packet.json'),
+          historyPath: path.join(repoRoot, 'tests', 'results', '_agent', 'runtime', 'task-packets', '2026-03-10T15-00-00-000Z-0001.json')
+        }
+      },
       blockerClass: 'ci',
       reason: 'hosted checks are red'
     },
@@ -125,6 +162,8 @@ test('runRuntimeSupervisor executes through an injected adapter', async () => {
   assert.equal(result.report.workerReady.status, 'ready');
   assert.equal(state.activeLane.workerBranch.status, 'attached');
   assert.equal(result.report.workerBranch.branch, 'issue/origin-977-fork-policy-portability');
+  assert.equal(state.activeLane.taskPacket.objective.summary, 'Advance issue #977');
+  assert.equal(result.report.taskPacket.status, 'ready');
   assert.deepEqual(
     adapterCalls.map((entry) => entry.type),
     ['acquire', 'release']

--- a/packages/runtime-harness/test/runtime-harness.test.mjs
+++ b/packages/runtime-harness/test/runtime-harness.test.mjs
@@ -143,6 +143,29 @@ test('runRuntimeSupervisor executes through an injected adapter', async () => {
           historyPath: path.join(repoRoot, 'tests', 'results', '_agent', 'runtime', 'task-packets', '2026-03-10T15-00-00-000Z-0001.json')
         }
       },
+      workerReceipt: {
+        schema: 'priority/runtime-worker-receipt@v1',
+        generatedAt: '2026-03-10T15:00:00.000Z',
+        cycle: 1,
+        laneId: 'origin-977',
+        status: 'completed',
+        source: 'test-adapter',
+        objective: {
+          summary: 'Advance issue #977'
+        },
+        result: 'receipt-completed',
+        execution: {
+          commands: ['node tools/npm/run-script.mjs priority:pr'],
+          commandCount: 1,
+          durationMs: 0
+        },
+        taskPacketGeneratedAt: '2026-03-10T15:00:00.000Z',
+        executedAt: '2026-03-10T15:00:01.000Z',
+        artifacts: {
+          latestPath: path.join(repoRoot, 'tests', 'results', '_agent', 'runtime', 'worker-receipt.json'),
+          historyPath: path.join(repoRoot, 'tests', 'results', '_agent', 'runtime', 'worker-receipts', '2026-03-10T15-00-01-000Z-0001.json')
+        }
+      },
       blockerClass: 'ci',
       reason: 'hosted checks are red'
     },
@@ -164,6 +187,8 @@ test('runRuntimeSupervisor executes through an injected adapter', async () => {
   assert.equal(result.report.workerBranch.branch, 'issue/origin-977-fork-policy-portability');
   assert.equal(state.activeLane.taskPacket.objective.summary, 'Advance issue #977');
   assert.equal(result.report.taskPacket.status, 'ready');
+  assert.equal(state.activeLane.workerReceipt.result, 'receipt-completed');
+  assert.equal(result.report.workerReceipt.status, 'completed');
   assert.deepEqual(
     adapterCalls.map((entry) => entry.type),
     ['acquire', 'release']

--- a/packages/runtime-harness/test/runtime-observer.test.mjs
+++ b/packages/runtime-harness/test/runtime-observer.test.mjs
@@ -2,7 +2,7 @@
 
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { access, mkdtemp, readFile, readdir } from 'node:fs/promises';
+import { access, mkdtemp, readFile, readdir, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { createRuntimeAdapter } from '../index.mjs';
@@ -25,6 +25,7 @@ async function pathExists(filePath) {
 function makeAdapter(repoRoot, calls, options = {}) {
   const bootstrapMode = options.bootstrapMode ?? 'ready';
   const plannerMode = options.plannerMode ?? 'manual';
+  const activateMode = options.activateMode ?? 'attached';
   return createRuntimeAdapter({
     name: 'test-adapter',
     resolveRepoRoot: () => repoRoot,
@@ -86,16 +87,29 @@ function makeAdapter(repoRoot, calls, options = {}) {
         bootstrapCommand: ['pwsh', '-NoLogo', '-NoProfile', '-File', 'tools/priority/bootstrap.ps1']
       };
     },
-    activateWorker: async ({ workerReady, schedulerDecision }) => ({
-      laneId: schedulerDecision.activeLane?.laneId,
-      checkoutPath: workerReady.checkoutPath,
-      branch: schedulerDecision.activeLane?.branch,
-      forkRemote: schedulerDecision.activeLane?.forkRemote,
-      status: 'attached',
-      source: 'test-adapter',
-      trackingRef: `${schedulerDecision.activeLane?.forkRemote}/${schedulerDecision.activeLane?.branch}`,
-      fetchedRemotes: ['upstream', 'origin']
-    }),
+    activateWorker: async ({ workerReady, schedulerDecision }) => {
+      if (activateMode === 'blocked') {
+        return {
+          laneId: schedulerDecision.activeLane?.laneId,
+          checkoutPath: workerReady.checkoutPath,
+          branch: schedulerDecision.activeLane?.branch,
+          forkRemote: schedulerDecision.activeLane?.forkRemote,
+          status: 'blocked',
+          source: 'test-adapter',
+          reason: 'activation blocked'
+        };
+      }
+      return {
+        laneId: schedulerDecision.activeLane?.laneId,
+        checkoutPath: workerReady.checkoutPath,
+        branch: schedulerDecision.activeLane?.branch,
+        forkRemote: schedulerDecision.activeLane?.forkRemote,
+        status: 'attached',
+        source: 'test-adapter',
+        trackingRef: `${schedulerDecision.activeLane?.forkRemote}/${schedulerDecision.activeLane?.branch}`,
+        fetchedRemotes: ['upstream', 'origin']
+      };
+    },
     buildTaskPacket: async ({ schedulerDecision, cycle, recentEvents }) => ({
       source: 'test-adapter',
       objective: {
@@ -432,6 +446,54 @@ test('runRuntimeObserverLoop records worker-ready-blocked when bootstrap returns
   assert.deepEqual(calls, []);
 });
 
+test('runRuntimeObserverLoop still writes a task packet when worker branch activation blocks', async () => {
+  const runtimeDir = await mkdtemp(path.join(os.tmpdir(), 'runtime-observer-branch-blocked-'));
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'runtime-observer-branch-blocked-root-'));
+  const calls = [];
+  let tick = 0;
+
+  const result = await runRuntimeObserverLoop(
+    {
+      repo: 'example/repo',
+      runtimeDir,
+      lane: 'origin-1005',
+      issue: 1005,
+      epic: 958,
+      forkRemote: 'origin',
+      branch: 'issue/origin-1005-runtime-task-packets',
+      owner: 'agent@example',
+      pollIntervalSeconds: 0,
+      maxCycles: 1
+    },
+    {
+      platform: 'linux',
+      adapter: makeAdapter(repoRoot, calls, { activateMode: 'blocked' }),
+      nowFactory: () => new Date(Date.UTC(2026, 2, 10, 16, 35, tick++)),
+      sleepFn: async () => {
+        throw new Error('sleep should not run when worker branch activation is blocked');
+      }
+    }
+  );
+
+  const heartbeat = await readJson(path.join(runtimeDir, 'observer-heartbeat.json'));
+  const workerBranch = await readJson(path.join(runtimeDir, 'worker-branch.json'));
+  const taskPacket = await readJson(path.join(runtimeDir, 'task-packet.json'));
+  const taskPacketHistory = await readdir(path.join(runtimeDir, 'task-packets'));
+
+  assert.equal(result.exitCode, 15);
+  assert.equal(result.report.status, 'blocked');
+  assert.equal(result.report.outcome, 'worker-branch-blocked');
+  assert.equal(result.report.lastStep.workerBranch.status, 'blocked');
+  assert.equal(taskPacket.status, 'blocked');
+  assert.equal(taskPacket.objective.summary, 'Execute issue #1005');
+  assert.equal(taskPacketHistory.length, 1);
+  assert.equal(heartbeat.outcome, 'worker-branch-blocked');
+  assert.equal(heartbeat.activeLane.workerBranch.status, 'blocked');
+  assert.equal(heartbeat.activeLane.taskPacket.objective.summary, 'Execute issue #1005');
+  assert.equal(heartbeat.artifacts.taskPacketPath, path.join(runtimeDir, 'task-packet.json'));
+  assert.equal(workerBranch.status, 'blocked');
+});
+
 test('runRuntimeObserverLoop records worker-bootstrap-failed heartbeat when bootstrap throws', async () => {
   const runtimeDir = await mkdtemp(path.join(os.tmpdir(), 'runtime-observer-bootstrap-failed-'));
   const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'runtime-observer-bootstrap-failed-root-'));
@@ -476,4 +538,56 @@ test('runRuntimeObserverLoop records worker-bootstrap-failed heartbeat when boot
   assert.equal(workerCheckout.status, 'created');
   assert.equal(await pathExists(workerReadyPath), false);
   assert.deepEqual(calls, []);
+});
+
+test('runRuntimeObserverLoop reads only the recent valid event tail', async () => {
+  const runtimeDir = await mkdtemp(path.join(os.tmpdir(), 'runtime-observer-recent-events-'));
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'runtime-observer-recent-events-root-'));
+  const calls = [];
+  let tick = 0;
+  const eventsPath = path.join(runtimeDir, 'runtime-events.ndjson');
+  const largePayload = 'x'.repeat(256);
+  const lines = [];
+  for (let index = 0; index < 300; index += 1) {
+    lines.push(JSON.stringify({
+      sequence: index,
+      kind: 'info',
+      message: `event-${index}`,
+      payload: largePayload
+    }));
+  }
+  lines.splice(10, 0, '{"sequence": "bad"');
+  await writeFile(eventsPath, `${lines.join('\n')}\n`, 'utf8');
+
+  const result = await runRuntimeObserverLoop(
+    {
+      repo: 'example/repo',
+      runtimeDir,
+      lane: 'origin-1006',
+      issue: 1006,
+      epic: 958,
+      forkRemote: 'origin',
+      branch: 'issue/origin-1006-runtime-events-tail',
+      owner: 'agent@example',
+      pollIntervalSeconds: 0,
+      maxCycles: 1
+    },
+    {
+      platform: 'linux',
+      adapter: makeAdapter(repoRoot, calls),
+      nowFactory: () => new Date(Date.UTC(2026, 2, 10, 16, 45, tick++)),
+      sleepFn: async () => {
+        throw new Error('sleep should not run when maxCycles=1');
+      }
+    }
+  );
+
+  const taskPacket = await readJson(path.join(runtimeDir, 'task-packet.json'));
+
+  assert.equal(result.exitCode, 0);
+  assert.deepEqual(
+    taskPacket.recentEvents.map((event) => event.sequence),
+    [295, 296, 297, 298, 299]
+  );
+  assert.equal(taskPacket.evidence.adapter.recentEventCount, 5);
 });

--- a/packages/runtime-harness/test/runtime-observer.test.mjs
+++ b/packages/runtime-harness/test/runtime-observer.test.mjs
@@ -24,11 +24,35 @@ async function pathExists(filePath) {
 
 function makeAdapter(repoRoot, calls, options = {}) {
   const bootstrapMode = options.bootstrapMode ?? 'ready';
+  const plannerMode = options.plannerMode ?? 'manual';
   return createRuntimeAdapter({
     name: 'test-adapter',
     resolveRepoRoot: () => repoRoot,
     resolveOwner: () => 'agent@example',
     resolveRepository: () => 'example/repo',
+    planStep: async ({ explicitStepOptions }) => {
+      if (plannerMode === 'idle') {
+        return {
+          source: 'test-planner',
+          outcome: 'idle',
+          reason: 'queue empty'
+        };
+      }
+      if (plannerMode === 'blocked') {
+        return {
+          source: 'test-planner',
+          outcome: 'blocked',
+          reason: 'review blocked on current lane',
+          stepOptions: explicitStepOptions
+        };
+      }
+      return {
+        source: 'manual',
+        outcome: 'selected',
+        reason: 'using explicit observer lane input',
+        stepOptions: explicitStepOptions
+      };
+    },
     prepareWorker: async ({ schedulerDecision }) => ({
       laneId: schedulerDecision.activeLane?.laneId,
       checkoutRoot: path.join(repoRoot, '.runtime-worktrees', 'example-repo'),
@@ -71,6 +95,25 @@ function makeAdapter(repoRoot, calls, options = {}) {
       source: 'test-adapter',
       trackingRef: `${schedulerDecision.activeLane?.forkRemote}/${schedulerDecision.activeLane?.branch}`,
       fetchedRemotes: ['upstream', 'origin']
+    }),
+    buildTaskPacket: async ({ schedulerDecision, cycle, recentEvents }) => ({
+      source: 'test-adapter',
+      objective: {
+        summary: schedulerDecision.activeLane?.issue
+          ? `Execute issue #${schedulerDecision.activeLane.issue}`
+          : 'Observe idle runtime state',
+        source: 'test-adapter'
+      },
+      helperSurface: {
+        preferred: ['node tools/npm/run-script.mjs priority:pr'],
+        fallbacks: ['gh pr create --body-file <path>']
+      },
+      evidence: {
+        adapter: {
+          cycle,
+          recentEventCount: recentEvents.length
+        }
+      }
     }),
     acquireLease: async (leaseOptions) => {
       calls.push({ type: 'acquire', leaseOptions });
@@ -215,6 +258,8 @@ test('runRuntimeObserverLoop writes heartbeat and state across bounded linux cyc
   const workerReadyHistory = await readdir(path.join(runtimeDir, 'workers-ready'));
   const workerBranch = await readJson(path.join(runtimeDir, 'worker-branch.json'));
   const workerBranchHistory = await readdir(path.join(runtimeDir, 'workers-branch'));
+  const taskPacket = await readJson(path.join(runtimeDir, 'task-packet.json'));
+  const taskPacketHistory = await readdir(path.join(runtimeDir, 'task-packets'));
   const state = await readJson(path.join(runtimeDir, 'runtime-state.json'));
 
   assert.equal(result.exitCode, 0);
@@ -242,23 +287,108 @@ test('runRuntimeObserverLoop writes heartbeat and state across bounded linux cyc
   assert.equal(workerBranch.status, 'attached');
   assert.equal(workerBranch.branch, 'issue/origin-977-fork-policy-portability');
   assert.equal(workerBranchHistory.length, 1);
+  assert.equal(taskPacket.schema, 'priority/runtime-worker-task-packet@v1');
+  assert.equal(taskPacket.objective.summary, 'Execute issue #977');
+  assert.equal(taskPacket.helperSurface.preferred[0], 'node tools/npm/run-script.mjs priority:pr');
+  assert.equal(taskPacket.recentEvents.length, 1);
+  assert.equal(taskPacketHistory.length, 2);
   assert.equal(heartbeat.activeLane.issue, 977);
   assert.equal(heartbeat.activeLane.worker.status, 'created');
   assert.equal(heartbeat.activeLane.workerReady.status, 'ready');
   assert.equal(heartbeat.activeLane.workerBranch.status, 'attached');
+  assert.equal(heartbeat.activeLane.taskPacket.objective.summary, 'Execute issue #977');
+  assert.equal(heartbeat.artifacts.taskPacketPath, path.join(runtimeDir, 'task-packet.json'));
   assert.equal(state.lifecycle.cycle, 2);
   assert.equal(state.activeLane.issue, 977);
   assert.equal(state.activeLane.worker.status, 'created');
   assert.equal(state.activeLane.workerReady.status, 'ready');
   assert.equal(state.activeLane.workerBranch.status, 'attached');
+  assert.equal(state.activeLane.taskPacket.objective.summary, 'Execute issue #977');
   assert.equal(result.report.lastStep.worker.status, 'created');
   assert.equal(result.report.lastStep.workerReady.status, 'ready');
   assert.equal(result.report.lastStep.workerBranch.status, 'attached');
+  assert.equal(result.report.lastStep.taskPacket.objective.summary, 'Execute issue #977');
   assert.equal(sleepCalls, 1);
   assert.deepEqual(
     calls.map((entry) => entry.type),
     ['acquire', 'release', 'acquire', 'release']
   );
+});
+
+test('runRuntimeObserverLoop emits an idle task packet when the planner returns idle', async () => {
+  const runtimeDir = await mkdtemp(path.join(os.tmpdir(), 'runtime-observer-idle-'));
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'runtime-observer-idle-root-'));
+  const calls = [];
+  let tick = 0;
+
+  const result = await runRuntimeObserverLoop(
+    {
+      repo: 'example/repo',
+      runtimeDir,
+      owner: 'agent@example',
+      pollIntervalSeconds: 0,
+      maxCycles: 1
+    },
+    {
+      platform: 'linux',
+      adapter: makeAdapter(repoRoot, calls, { plannerMode: 'idle' }),
+      nowFactory: () => new Date(Date.UTC(2026, 2, 10, 16, 15, tick++)),
+      sleepFn: async () => {
+        throw new Error('sleep should not run when maxCycles=1');
+      }
+    }
+  );
+
+  const taskPacket = await readJson(path.join(runtimeDir, 'task-packet.json'));
+
+  assert.equal(result.exitCode, 0);
+  assert.equal(result.report.lastDecision.outcome, 'idle');
+  assert.equal(result.report.lastStep.outcome, 'idle');
+  assert.equal(taskPacket.status, 'idle');
+  assert.equal(taskPacket.objective.summary, 'Observe idle runtime state');
+  assert.equal(taskPacket.laneId, null);
+  assert.equal(taskPacket.evidence.adapter.cycle, 1);
+});
+
+test('runRuntimeObserverLoop emits a blocked task packet when the planner blocks the lane', async () => {
+  const runtimeDir = await mkdtemp(path.join(os.tmpdir(), 'runtime-observer-task-blocked-'));
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'runtime-observer-task-blocked-root-'));
+  const calls = [];
+  let tick = 0;
+
+  const result = await runRuntimeObserverLoop(
+    {
+      repo: 'example/repo',
+      runtimeDir,
+      lane: 'origin-1002',
+      issue: 1002,
+      epic: 958,
+      forkRemote: 'personal',
+      branch: 'issue/personal-1002-runtime-daemon-task-packets',
+      owner: 'agent@example',
+      pollIntervalSeconds: 0,
+      maxCycles: 1
+    },
+    {
+      platform: 'linux',
+      adapter: makeAdapter(repoRoot, calls, { plannerMode: 'blocked' }),
+      nowFactory: () => new Date(Date.UTC(2026, 2, 10, 16, 20, tick++)),
+      sleepFn: async () => {
+        throw new Error('sleep should not run when planner blocks');
+      }
+    }
+  );
+
+  const taskPacket = await readJson(path.join(runtimeDir, 'task-packet.json'));
+  const heartbeat = await readJson(path.join(runtimeDir, 'observer-heartbeat.json'));
+
+  assert.equal(result.exitCode, 12);
+  assert.equal(result.report.outcome, 'scheduler-blocked');
+  assert.equal(taskPacket.status, 'blocked');
+  assert.equal(taskPacket.laneId, 'origin-1002');
+  assert.equal(taskPacket.objective.summary, 'Execute issue #1002');
+  assert.equal(heartbeat.artifacts.taskPacketPath, path.join(runtimeDir, 'task-packet.json'));
+  assert.equal(heartbeat.activeLane.taskPacket.objective.summary, 'Execute issue #1002');
 });
 
 test('runRuntimeObserverLoop records worker-ready-blocked when bootstrap returns a blocked result', async () => {

--- a/packages/runtime-harness/test/runtime-observer.test.mjs
+++ b/packages/runtime-harness/test/runtime-observer.test.mjs
@@ -129,6 +129,24 @@ function makeAdapter(repoRoot, calls, options = {}) {
         }
       }
     }),
+    executeTaskPacket: async ({ taskPacket }) => ({
+      source: 'test-adapter',
+      status: taskPacket?.status === 'blocked' ? 'blocked' : taskPacket?.status === 'idle' ? 'noop' : 'completed',
+      objective: {
+        summary: taskPacket?.objective?.summary ?? 'No task packet'
+      },
+      result:
+        taskPacket?.status === 'blocked'
+          ? 'receipt-blocked'
+          : taskPacket?.status === 'idle'
+            ? 'receipt-idle'
+            : 'receipt-completed',
+      execution: {
+        commands: taskPacket?.status === 'ready' ? ['node tools/npm/run-script.mjs priority:pr'] : [],
+        durationMs: 0
+      },
+      taskPacketGeneratedAt: taskPacket?.generatedAt ?? null
+    }),
     acquireLease: async (leaseOptions) => {
       calls.push({ type: 'acquire', leaseOptions });
       return {
@@ -274,6 +292,8 @@ test('runRuntimeObserverLoop writes heartbeat and state across bounded linux cyc
   const workerBranchHistory = await readdir(path.join(runtimeDir, 'workers-branch'));
   const taskPacket = await readJson(path.join(runtimeDir, 'task-packet.json'));
   const taskPacketHistory = await readdir(path.join(runtimeDir, 'task-packets'));
+  const workerReceipt = await readJson(path.join(runtimeDir, 'worker-receipt.json'));
+  const workerReceiptHistory = await readdir(path.join(runtimeDir, 'worker-receipts'));
   const state = await readJson(path.join(runtimeDir, 'runtime-state.json'));
 
   assert.equal(result.exitCode, 0);
@@ -306,11 +326,17 @@ test('runRuntimeObserverLoop writes heartbeat and state across bounded linux cyc
   assert.equal(taskPacket.helperSurface.preferred[0], 'node tools/npm/run-script.mjs priority:pr');
   assert.equal(taskPacket.recentEvents.length, 1);
   assert.equal(taskPacketHistory.length, 2);
+  assert.equal(workerReceipt.schema, 'priority/runtime-worker-receipt@v1');
+  assert.equal(workerReceipt.status, 'completed');
+  assert.equal(workerReceipt.result, 'receipt-completed');
+  assert.equal(workerReceipt.execution.commands[0], 'node tools/npm/run-script.mjs priority:pr');
+  assert.equal(workerReceiptHistory.length, 2);
   assert.equal(heartbeat.activeLane.issue, 977);
   assert.equal(heartbeat.activeLane.worker.status, 'created');
   assert.equal(heartbeat.activeLane.workerReady.status, 'ready');
   assert.equal(heartbeat.activeLane.workerBranch.status, 'attached');
   assert.equal(heartbeat.activeLane.taskPacket.objective.summary, 'Execute issue #977');
+  assert.equal(heartbeat.artifacts.workerReceiptPath, path.join(runtimeDir, 'worker-receipt.json'));
   assert.equal(heartbeat.artifacts.taskPacketPath, path.join(runtimeDir, 'task-packet.json'));
   assert.equal(state.lifecycle.cycle, 2);
   assert.equal(state.activeLane.issue, 977);
@@ -318,10 +344,12 @@ test('runRuntimeObserverLoop writes heartbeat and state across bounded linux cyc
   assert.equal(state.activeLane.workerReady.status, 'ready');
   assert.equal(state.activeLane.workerBranch.status, 'attached');
   assert.equal(state.activeLane.taskPacket.objective.summary, 'Execute issue #977');
+  assert.equal(state.activeLane.workerReceipt.result, 'receipt-completed');
   assert.equal(result.report.lastStep.worker.status, 'created');
   assert.equal(result.report.lastStep.workerReady.status, 'ready');
   assert.equal(result.report.lastStep.workerBranch.status, 'attached');
   assert.equal(result.report.lastStep.taskPacket.objective.summary, 'Execute issue #977');
+  assert.equal(result.report.lastStep.workerReceipt.result, 'receipt-completed');
   assert.equal(sleepCalls, 1);
   assert.deepEqual(
     calls.map((entry) => entry.type),
@@ -354,6 +382,7 @@ test('runRuntimeObserverLoop emits an idle task packet when the planner returns 
   );
 
   const taskPacket = await readJson(path.join(runtimeDir, 'task-packet.json'));
+  const workerReceipt = await readJson(path.join(runtimeDir, 'worker-receipt.json'));
 
   assert.equal(result.exitCode, 0);
   assert.equal(result.report.lastDecision.outcome, 'idle');
@@ -362,6 +391,8 @@ test('runRuntimeObserverLoop emits an idle task packet when the planner returns 
   assert.equal(taskPacket.objective.summary, 'Observe idle runtime state');
   assert.equal(taskPacket.laneId, null);
   assert.equal(taskPacket.evidence.adapter.cycle, 1);
+  assert.equal(workerReceipt.status, 'noop');
+  assert.equal(workerReceipt.result, 'receipt-idle');
 });
 
 test('runRuntimeObserverLoop emits a blocked task packet when the planner blocks the lane', async () => {
@@ -395,13 +426,17 @@ test('runRuntimeObserverLoop emits a blocked task packet when the planner blocks
 
   const taskPacket = await readJson(path.join(runtimeDir, 'task-packet.json'));
   const heartbeat = await readJson(path.join(runtimeDir, 'observer-heartbeat.json'));
+  const workerReceipt = await readJson(path.join(runtimeDir, 'worker-receipt.json'));
 
   assert.equal(result.exitCode, 12);
   assert.equal(result.report.outcome, 'scheduler-blocked');
   assert.equal(taskPacket.status, 'blocked');
   assert.equal(taskPacket.laneId, 'origin-1002');
   assert.equal(taskPacket.objective.summary, 'Execute issue #1002');
+  assert.equal(workerReceipt.status, 'blocked');
+  assert.equal(workerReceipt.result, 'receipt-blocked');
   assert.equal(heartbeat.artifacts.taskPacketPath, path.join(runtimeDir, 'task-packet.json'));
+  assert.equal(heartbeat.artifacts.workerReceiptPath, path.join(runtimeDir, 'worker-receipt.json'));
   assert.equal(heartbeat.activeLane.taskPacket.objective.summary, 'Execute issue #1002');
 });
 

--- a/tools/priority/__tests__/runtime-daemon.test.mjs
+++ b/tools/priority/__tests__/runtime-daemon.test.mjs
@@ -117,6 +117,7 @@ test('runtime-daemon wrapper defaults to the comparevi adapter', async () => {
   );
 
   const heartbeat = await readJson(path.join(runtimeDir, 'observer-heartbeat.json'));
+  const taskPacket = await readJson(path.join(runtimeDir, 'task-packet.json'));
 
   assert.equal(result.exitCode, 0);
   assert.equal(result.report.runtimeAdapter, 'comparevi');
@@ -127,6 +128,8 @@ test('runtime-daemon wrapper defaults to the comparevi adapter', async () => {
   assert.equal(heartbeat.activeLane.workerReady.status, 'ready');
   assert.equal(heartbeat.activeLane.workerBranch.status, 'attached');
   assert.equal(heartbeat.activeLane.workerBranch.branch, 'issue/origin-977-fork-policy-portability');
+  assert.equal(taskPacket.objective.summary, 'Advance issue #977 on issue/origin-977-fork-policy-portability');
+  assert.equal(taskPacket.helperSurface.preferred[0], 'pwsh -NoLogo -NoProfile -File tools/priority/bootstrap.ps1');
   assert.ok(execDeps.calls.some((entry) => entry.command === 'pwsh'));
   assert.ok(execDeps.calls.some((entry) => entry.command === 'git' && entry.args[0] === 'checkout'));
   assert.deepEqual(
@@ -184,6 +187,7 @@ test('runtime-daemon wrapper schedules from the comparevi standing-priority cach
   );
 
   const heartbeat = await readJson(path.join(repoRoot, runtimeDir, 'observer-heartbeat.json'));
+  const taskPacket = await readJson(path.join(repoRoot, runtimeDir, 'task-packet.json'));
 
   assert.equal(result.exitCode, 0);
   assert.equal(result.report.outcome, 'max-cycles-reached');
@@ -197,6 +201,8 @@ test('runtime-daemon wrapper schedules from the comparevi standing-priority cach
   assert.equal(heartbeat.activeLane.worker.status, 'created');
   assert.equal(heartbeat.activeLane.workerReady.status, 'ready');
   assert.equal(heartbeat.activeLane.workerBranch.status, 'attached');
+  assert.equal(taskPacket.objective.summary, 'Advance issue #982: Human go/no-go workflow on issue/origin-982-human-go-no-go-workflow');
+  assert.equal(taskPacket.evidence.priority.cachePath, path.join(repoRoot, '.agent_priority_cache.json'));
   assert.ok(execDeps.calls.some((entry) => entry.command === 'git' && entry.args[0] === 'checkout'));
   assert.deepEqual(
     deps.calls.map((entry) => entry.type),

--- a/tools/priority/__tests__/runtime-daemon.test.mjs
+++ b/tools/priority/__tests__/runtime-daemon.test.mjs
@@ -118,6 +118,7 @@ test('runtime-daemon wrapper defaults to the comparevi adapter', async () => {
 
   const heartbeat = await readJson(path.join(runtimeDir, 'observer-heartbeat.json'));
   const taskPacket = await readJson(path.join(runtimeDir, 'task-packet.json'));
+  const workerReceipt = await readJson(path.join(runtimeDir, 'worker-receipt.json'));
 
   assert.equal(result.exitCode, 0);
   assert.equal(result.report.runtimeAdapter, 'comparevi');
@@ -130,6 +131,8 @@ test('runtime-daemon wrapper defaults to the comparevi adapter', async () => {
   assert.equal(heartbeat.activeLane.workerBranch.branch, 'issue/origin-977-fork-policy-portability');
   assert.equal(taskPacket.objective.summary, 'Advance issue #977 on issue/origin-977-fork-policy-portability');
   assert.equal(taskPacket.helperSurface.preferred[0], 'pwsh -NoLogo -NoProfile -File tools/priority/bootstrap.ps1');
+  assert.equal(workerReceipt.status, 'completed');
+  assert.equal(workerReceipt.result, 'task-packet-consumed');
   assert.ok(execDeps.calls.some((entry) => entry.command === 'pwsh'));
   assert.ok(execDeps.calls.some((entry) => entry.command === 'git' && entry.args[0] === 'checkout'));
   assert.deepEqual(
@@ -188,6 +191,7 @@ test('runtime-daemon wrapper schedules from the comparevi standing-priority cach
 
   const heartbeat = await readJson(path.join(repoRoot, runtimeDir, 'observer-heartbeat.json'));
   const taskPacket = await readJson(path.join(repoRoot, runtimeDir, 'task-packet.json'));
+  const workerReceipt = await readJson(path.join(repoRoot, runtimeDir, 'worker-receipt.json'));
 
   assert.equal(result.exitCode, 0);
   assert.equal(result.report.outcome, 'max-cycles-reached');
@@ -203,6 +207,8 @@ test('runtime-daemon wrapper schedules from the comparevi standing-priority cach
   assert.equal(heartbeat.activeLane.workerBranch.status, 'attached');
   assert.equal(taskPacket.objective.summary, 'Advance issue #982: Human go/no-go workflow on issue/origin-982-human-go-no-go-workflow');
   assert.equal(taskPacket.evidence.priority.cachePath, path.join(repoRoot, '.agent_priority_cache.json'));
+  assert.equal(workerReceipt.status, 'completed');
+  assert.equal(workerReceipt.result, 'task-packet-consumed');
   assert.ok(execDeps.calls.some((entry) => entry.command === 'git' && entry.args[0] === 'checkout'));
   assert.deepEqual(
     deps.calls.map((entry) => entry.type),

--- a/tools/priority/__tests__/runtime-supervisor.test.mjs
+++ b/tools/priority/__tests__/runtime-supervisor.test.mjs
@@ -115,6 +115,22 @@ test('comparevi branch resolver matches the repo issue branch naming contract', 
   assert.equal(branch, 'issue/personal-998-attach-ready-worker-checkouts-onto-deterministic-lane-branches');
 });
 
+test('comparevi worker receipt builder consumes a ready task packet deterministically', async () => {
+  const receipt = await compareviRuntimeTest.buildCompareviWorkerReceipt({
+    taskPacket: {
+      generatedAt: '2026-03-10T12:00:00.000Z',
+      status: 'ready',
+      objective: {
+        summary: 'Advance issue #1004'
+      }
+    }
+  });
+
+  assert.equal(receipt.status, 'completed');
+  assert.equal(receipt.result, 'task-packet-consumed');
+  assert.equal(receipt.objective.summary, 'Advance issue #1004');
+});
+
 test('runRuntimeSupervisor step writes runtime state, lane, turn, event, and blocker artifacts', async () => {
   const repoRoot = await mkdtemp(path.join(os.tmpdir(), 'runtime-supervisor-'));
   const runtimeDir = 'tests/results/_agent/runtime';

--- a/tools/priority/runtime-supervisor.mjs
+++ b/tools/priority/runtime-supervisor.mjs
@@ -16,6 +16,7 @@ import {
   REPORT_SCHEMA,
   STATE_SCHEMA,
   STOP_REQUEST_SCHEMA,
+  TASK_PACKET_SCHEMA,
   TURN_SCHEMA,
   WORKER_CHECKOUT_SCHEMA,
   __test,
@@ -44,6 +45,7 @@ export {
   REPORT_SCHEMA,
   STATE_SCHEMA,
   STOP_REQUEST_SCHEMA,
+  TASK_PACKET_SCHEMA,
   TURN_SCHEMA,
   WORKER_CHECKOUT_SCHEMA,
   WORKER_READY_SCHEMA,
@@ -55,6 +57,18 @@ export {
 const COMPAREVI_UPSTREAM_REPOSITORY = 'LabVIEW-Community-CI-CD/compare-vi-cli-action';
 const PRIORITY_CACHE_FILENAME = '.agent_priority_cache.json';
 const PRIORITY_ISSUE_DIR = path.join('tests', 'results', '_agent', 'issue');
+const COMPAREVI_PREFERRED_HELPERS = [
+  'pwsh -NoLogo -NoProfile -File tools/priority/bootstrap.ps1',
+  'node tools/npm/run-script.mjs priority:develop:sync',
+  'node tools/npm/run-script.mjs priority:github:metadata:apply',
+  'node tools/npm/run-script.mjs priority:project:portfolio:apply',
+  'node tools/npm/run-script.mjs priority:pr'
+];
+const COMPAREVI_FALLBACK_HELPERS = [
+  'gh issue create --body-file <path>',
+  'gh pr create --body-file <path>',
+  'gh pr merge --match-head-commit <sha>'
+];
 
 function normalizeText(value) {
   if (value == null) return '';
@@ -220,6 +234,71 @@ async function planCompareviRuntimeStep({ repoRoot, env, explicitStepOptions }) 
   });
 }
 
+async function resolveCompareviTaskPacketSnapshot({ repoRoot, schedulerDecision }) {
+  const artifactPaths = schedulerDecision?.artifacts ?? {};
+  for (const candidate of [artifactPaths.issuePath, artifactPaths.cachePath]) {
+    const resolved = normalizeText(candidate);
+    if (!resolved) {
+      continue;
+    }
+    const snapshot = await readJsonIfPresent(resolved);
+    if (snapshot) {
+      return snapshot;
+    }
+  }
+
+  const issueNumber = schedulerDecision?.activeLane?.issue;
+  if (!Number.isInteger(issueNumber)) {
+    return null;
+  }
+  return readJsonIfPresent(path.join(repoRoot, PRIORITY_ISSUE_DIR, `${issueNumber}.json`));
+}
+
+async function buildCompareviTaskPacket({ repoRoot, schedulerDecision, preparedWorker, workerReady, workerBranch }) {
+  const activeLane = schedulerDecision?.activeLane ?? null;
+  const snapshot = await resolveCompareviTaskPacketSnapshot({ repoRoot, schedulerDecision });
+  const issueNumber = activeLane?.issue;
+  const issueTitle = normalizeText(snapshot?.title);
+  const branchName = normalizeText(workerBranch?.branch) || normalizeText(activeLane?.branch);
+  const objectiveSummary = Number.isInteger(issueNumber)
+    ? `Advance issue #${issueNumber}${issueTitle ? `: ${issueTitle}` : ''}${branchName ? ` on ${branchName}` : ''}`
+    : normalizeText(schedulerDecision?.reason) || 'No compare-vi lane selected.';
+
+  return {
+    source: 'comparevi-runtime',
+    objective: {
+      summary: objectiveSummary,
+      source: issueTitle ? 'comparevi-issue-snapshot' : 'comparevi-runtime'
+    },
+    pullRequest: {
+      url: normalizeText(activeLane?.prUrl) || null,
+      status: normalizeText(activeLane?.prUrl) ? 'linked' : 'none'
+    },
+    checks: {
+      status: activeLane?.blockerClass === 'ci' ? 'blocked' : normalizeText(activeLane?.prUrl) ? 'pending-or-unknown' : 'not-linked',
+      blockerClass: normalizeText(activeLane?.blockerClass) || 'none'
+    },
+    helperSurface: {
+      preferred: COMPAREVI_PREFERRED_HELPERS,
+      fallbacks: COMPAREVI_FALLBACK_HELPERS
+    },
+    evidence: {
+      priority: {
+        cachePath: normalizeText(schedulerDecision?.artifacts?.cachePath) || null,
+        routerPath: normalizeText(schedulerDecision?.artifacts?.routerPath) || null,
+        issuePath: normalizeText(schedulerDecision?.artifacts?.issuePath) || null
+      },
+      lane: {
+        workerCheckoutPath:
+          normalizeText(workerBranch?.checkoutPath) ||
+          normalizeText(workerReady?.checkoutPath) ||
+          normalizeText(preparedWorker?.checkoutPath) ||
+          null
+      }
+    }
+  };
+}
+
 export const compareviRuntimeAdapter = createRuntimeAdapter({
   name: 'comparevi',
   resolveRepoRoot: () => getRepoRoot(),
@@ -230,12 +309,14 @@ export const compareviRuntimeAdapter = createRuntimeAdapter({
   planStep: (context) => planCompareviRuntimeStep(context),
   prepareWorker: (context) => prepareCompareviWorkerCheckout(context),
   bootstrapWorker: (context) => bootstrapCompareviWorkerCheckout(context),
-  activateWorker: (context) => activateCompareviWorkerLane(context)
+  activateWorker: (context) => activateCompareviWorkerLane(context),
+  buildTaskPacket: (context) => buildCompareviTaskPacket(context)
 });
 
 export const compareviRuntimeTest = {
   activateCompareviWorkerLane,
   buildSchedulerDecisionFromSnapshot,
+  buildCompareviTaskPacket,
   bootstrapCompareviWorkerCheckout,
   planCompareviRuntimeStep,
   prepareCompareviWorkerCheckout,

--- a/tools/priority/runtime-supervisor.mjs
+++ b/tools/priority/runtime-supervisor.mjs
@@ -19,6 +19,7 @@ import {
   TASK_PACKET_SCHEMA,
   TURN_SCHEMA,
   WORKER_CHECKOUT_SCHEMA,
+  WORKER_RECEIPT_SCHEMA,
   __test,
   createRuntimeAdapter,
   parseArgs,
@@ -48,6 +49,7 @@ export {
   TASK_PACKET_SCHEMA,
   TURN_SCHEMA,
   WORKER_CHECKOUT_SCHEMA,
+  WORKER_RECEIPT_SCHEMA,
   WORKER_READY_SCHEMA,
   __test,
   createRuntimeAdapter,
@@ -299,6 +301,31 @@ async function buildCompareviTaskPacket({ repoRoot, schedulerDecision, preparedW
   };
 }
 
+async function buildCompareviWorkerReceipt({ taskPacket }) {
+  const taskStatus = normalizeText(taskPacket?.status).toLowerCase();
+  const status = taskStatus === 'blocked' ? 'blocked' : taskStatus === 'idle' ? 'noop' : 'completed';
+  return {
+    source: 'comparevi-runtime',
+    status,
+    objective: {
+      summary: normalizeText(taskPacket?.objective?.summary) || 'No compare-vi task packet was available.'
+    },
+    result:
+      status === 'blocked'
+        ? 'task-packet-blocked'
+        : status === 'noop'
+          ? 'task-packet-idle'
+          : 'task-packet-consumed',
+    reason: status === 'blocked' ? 'task packet reached the execution seam in a blocked state' : null,
+    execution: {
+      commands: [],
+      commandCount: 0,
+      durationMs: 0
+    },
+    taskPacketGeneratedAt: normalizeText(taskPacket?.generatedAt) || null
+  };
+}
+
 export const compareviRuntimeAdapter = createRuntimeAdapter({
   name: 'comparevi',
   resolveRepoRoot: () => getRepoRoot(),
@@ -310,13 +337,15 @@ export const compareviRuntimeAdapter = createRuntimeAdapter({
   prepareWorker: (context) => prepareCompareviWorkerCheckout(context),
   bootstrapWorker: (context) => bootstrapCompareviWorkerCheckout(context),
   activateWorker: (context) => activateCompareviWorkerLane(context),
-  buildTaskPacket: (context) => buildCompareviTaskPacket(context)
+  buildTaskPacket: (context) => buildCompareviTaskPacket(context),
+  executeTaskPacket: (context) => buildCompareviWorkerReceipt(context)
 });
 
 export const compareviRuntimeTest = {
   activateCompareviWorkerLane,
   buildSchedulerDecisionFromSnapshot,
   buildCompareviTaskPacket,
+  buildCompareviWorkerReceipt,
   bootstrapCompareviWorkerCheckout,
   planCompareviRuntimeStep,
   prepareCompareviWorkerCheckout,


### PR DESCRIPTION
## Summary
- consume bounded runtime task packets through a worker receipt seam before repo-native worker execution resumes
- persist `worker-receipt.json` plus `worker-receipts/*.json` and thread receipt state through observer heartbeat/report surfaces
- extend daemon tests to cover the receipt seam on top of the hardened observer task-packet flow

## Testing
- `node tools/npm/run-script.mjs runtime-harness:test`
- `node --test tools/priority/__tests__/runtime-daemon.test.mjs tools/priority/__tests__/runtime-supervisor.test.mjs`

## Notes
- stacked on the current `#1005` task-packet lane while that upstream PR drains through merge

## Agent Metadata
- Agent ID: Codex GPT-5
- Issue: #1004
- Branch: `issue/personal-1004-runtime-worker-turn-receipt`
- Repo: `svelderrainruiz/compare-vi-cli-action`
